### PR TITLE
fix: replace only .json suffix in schema $id, not all occurrences

### DIFF
--- a/generate_schemas.py
+++ b/generate_schemas.py
@@ -335,8 +335,8 @@ def process_schema(
       transformed = transform_schema(
           copy.deepcopy(data), "create", source_path, annotated_schemas, suffix
       )
-      if "$id" in transformed:
-        transformed["$id"] = transformed["$id"].replace(".json", "_req.json")
+      if "$id" in transformed and transformed["$id"].endswith(".json"):
+        transformed["$id"] = transformed["$id"][:-5] + "_req.json"
       write_json(transformed, out_path)
       generated.append(os.path.join(dir_path, out_name))
     else:
@@ -348,10 +348,8 @@ def process_schema(
         transformed = transform_schema(
             copy.deepcopy(data), op, source_path, annotated_schemas, suffix
         )
-        if "$id" in transformed:
-          transformed["$id"] = transformed["$id"].replace(
-              ".json", f".{op}_req.json"
-          )
+        if "$id" in transformed and transformed["$id"].endswith(".json"):
+          transformed["$id"] = transformed["$id"][:-5] + f".{op}_req.json"
         write_json(transformed, out_path)
         generated.append(os.path.join(dir_path, out_name))
 


### PR DESCRIPTION
The str.replace() method in generate_schemas.py was replacing ALL occurrences of ".json" in the $id string, which would corrupt IDs containing multiple ".json" substrings.

  Example of the bug:
  - Input: "$id": "https://ucp.dev/schemas/v1.json/checkout.json"
  - Before fix: "$id": "https://ucp.dev/schemas/v1_req.json/checkout_req.json" (WRONG)
  - After fix: "$id": "https://ucp.dev/schemas/v1.json/checkout_req.json" (CORRECT)

  Solution: Changed to use endswith(".json") check + string slicing to only replace the final ".json" suffix.

  Type of change

  - Bug fix (non-breaking change which fixes an issue)

  ---
  Checklist:

  - My code follows the style guidelines of this project
  - I have performed a self-review of my own code
  - I have commented my code, particularly in hard-to-understand areas
  - I have made corresponding changes to the documentation
  - My changes generate no new warnings
  - I have added tests that prove my fix is effective or that my feature works
  - New and existing unit tests pass locally with my changes
  - Any dependent changes have been merged and published in downstream modules

  ---
  Pull Request Title

  fix: replace only .json suffix in schema $id, not all occurrences