### PR TITLE
chore: validate schema generation in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,10 @@ on:
       - "mkdocs.yml"
       - "main.py"
       - "docs/**"
+      - "source/**"
       - "spec/**"
+      - "generate_schemas.py"
+      - "validate_specs.py"
   pull_request:
     branches:
       - main
@@ -34,7 +37,10 @@ on:
       - "mkdocs.yml"
       - "main.py"
       - "docs/**"
+      - "source/**"
       - "spec/**"
+      - "generate_schemas.py"
+      - "validate_specs.py"
 
 jobs:
   build_and_deploy:
@@ -78,6 +84,27 @@ jobs:
 
       - name: Lint YAML files
         run: yamllint -c .github/linters/.yamllint.yml .
+
+      - name: Generate schemas from source
+        run: python generate_schemas.py
+
+      - name: Validate generated schemas
+        run: python validate_specs.py
+
+      - name: Check for uncommitted spec changes
+        run: |
+          if ! git diff --exit-code spec/; then
+            echo "Error: Generated schemas in spec/ don't match source/"
+            echo ""
+            echo "The following files have uncommitted changes:"
+            git diff --name-only spec/
+            echo ""
+            echo "Please regenerate schemas locally and commit the changes:"
+            echo "  python generate_schemas.py  # or python3 if needed"
+            echo ""
+            echo "Then commit the updated spec/ files."
+            exit 1
+          fi
 
       - name: Install uv
         run: |

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -19,5 +19,6 @@ mkdocs-site-urls==0.3.1
 mkdocs-llmstxt==0.5.0
 mkdocs-material[imaging]>=9.0.0
 datamodel-code-generator[http]>=0.50.0
+PyYAML>=6.0
 uv==0.2.23
 yamllint==1.35.1


### PR DESCRIPTION
Currently CI validates that Pydantic models can be generated from spec/, but nothing checks whether spec/ actually stays in sync with source/. If someone modifies a source schema and forgets to regenerate, the drift goes unnoticed.

This adds generate_schemas.py and validate_specs.py to the docs workflow, followed by a git diff check on spec/. If the regenerated output doesn't match what's committed, the build fails with a clear error showing which files diverged and how to fix it.

Also added PyYAML>=6.0 to requirements-docs.txt since validate_specs.py imports yaml and the dependency was missing. Moved the validation steps to run right after pip install since they don't need uv.

Tested locally. Both scripts run correctly and the diff check catches stale spec/ files as expected.