### PR TITLE
chore: validate schema generation in CI

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -90,4 +90,5 @@ vulnz
 worktree
 yaml
 yml
+EDITMSG
 keyid

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,8 @@ on:
       - main
     paths:
       - ".github/workflows/docs.yml"
-      - "requirements-docs.txt"
+      - "pyproject.toml"
+      - "uv.lock"
       - "mkdocs.yml"
       - "main.py"
       - "hooks.py"
@@ -52,18 +53,20 @@ jobs:
       - name: Configure Git Credentials
         run: |
           git config --global user.name github-actions[bot]
-          git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config --global user.email \
+            41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
+          sudo apt-get install -y libcairo2-dev libfreetype6-dev libffi-dev \
+            libjpeg-dev libpng-dev libz-dev
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v7
 
       - name: Install documentation dependencies
-        run: uv sync
+        run: uv sync --all-groups
 
       - name: Lint YAML files
         run: uv run yamllint -c .github/linters/.yamllint.yml .
@@ -73,6 +76,14 @@ jobs:
         uses: tj-actions/changed-files@v46
         with:
           files: source/**
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
 
       - name: Install ucp-schema for runtime resolution
         run: |
@@ -95,11 +106,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Fetch the Pages URL. Fails safely if not enabled.
-          PAGES_URL=$(gh api "repos/${{ github.repository }}/pages" --jq '.html_url' 2>/dev/null || true)
+          PAGES_URL=$(gh api "repos/${{ github.repository }}/pages" \
+            --jq '.html_url' 2>/dev/null || true)
 
           if [ -z "$PAGES_URL" ]; then
             echo "Pages URL not detected. Falling back to default structure."
-            PAGES_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
+            OWNER="${{ github.repository_owner }}"
+            REPO="${{ github.event.repository.name }}"
+            PAGES_URL="https://${OWNER}.github.io/${REPO}"
           fi
 
           # Ensure trailing slash
@@ -146,8 +160,9 @@ jobs:
           # Extract the date (e.g., release/2026-01-11 -> 2026-01-11)
           VERSION_NAME=${GITHUB_REF#refs/heads/release/}
 
-          # Deploy this version, tag it as 'latest', and set it as the default site root
-          uv run mike deploy --push --update-aliases $VERSION_NAME latest
+          # Deploy this version, tag as 'latest', set as default site root
+          uv run mike deploy --push --update-aliases \
+            $VERSION_NAME latest
 
       - name: Create GitHub Release and Tag
         if: startsWith(github.ref, 'refs/heads/release/')

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -19,6 +19,19 @@ on:
     branches:
       - main
       - 'release/**'
+    paths:
+      - ".github/workflows/linter.yaml"
+      - ".github/workflows/schema-validation.yml"
+      - ".github/linters/**"
+      - ".pre-commit-config.yaml"
+      - "pyproject.toml"
+      - "package.json"
+      - "package-lock.json"
+      - "biome.json"
+      - "scripts/**"
+      - "source/**"
+      - "docs/**"
+      - "*.py"
 
 permissions:
   contents: read      # Required to checkout the code
@@ -49,7 +62,8 @@ jobs:
           LOG_LEVEL: INFO
           SHELLCHECK_OPTS: -e SC1091 -e 2086
           VALIDATE_ALL_CODEBASE: false
-          FILTER_REGEX_EXCLUDE: "^(\\.github/|\\.vscode/).*|CODE_OF_CONDUCT.md|CHANGELOG.md"
+          FILTER_REGEX_EXCLUDE: >-
+            ^(\\.github/|\\.vscode/).*|CODE_OF_CONDUCT.md|CHANGELOG.md
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_PYTHON_BLACK: false
           VALIDATE_PYTHON_FLAKE8: false
@@ -58,6 +72,7 @@ jobs:
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_CHECKOV: false
           VALIDATE_GITLEAKS: false
+          VALIDATE_TRIVY: false
           VALIDATE_NATURAL_LANGUAGE: false
           VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_JAVASCRIPT_PRETTIER: false

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -1,0 +1,75 @@
+---
+#   Copyright 2026 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+name: Schema Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+    paths:
+      - ".github/workflows/schema-validation.yml"
+      - "generate_ts_schema_types.js"
+      - "generated/schema-types.ts"
+      - "package.json"
+      - "package-lock.json"
+      - "source/**"
+  push:
+    branches:
+      - main
+      - 'release/**'
+    paths:
+      - ".github/workflows/schema-validation.yml"
+      - "generate_ts_schema_types.js"
+      - "generated/schema-types.ts"
+      - "package.json"
+      - "package-lock.json"
+      - "source/**"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-schemas:
+    name: Generate and Validate Schemas
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install ucp-schema
+        run: |
+          cargo install ucp-schema
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Lint source schemas
+        run: ucp-schema lint source/
+
+      - name: Generate TypeScript schema types
+        run: node generate_ts_schema_types.js
+
+      - name: Verify generated files are in sync
+        run: git diff --exit-code -- generated/schema-types.ts

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,9 @@ repos:
     hooks:
       - id: validate-generated-schema-types
         name: validate generated schema types
-        entry: bash -c 'node generate_ts_schema_types.js && git diff --exit-code -- generated/schema-types.ts'
+        entry: >-
+          bash -c 'node generate_ts_schema_types.js && git diff --exit-code
+          -- generated/schema-types.ts'
         language: system
         pass_filenames: false
   - repo: https://github.com/streetsidesoftware/cspell-cli
@@ -62,5 +64,6 @@ repos:
     hooks:
       - id: prettier
         name: prettier-css
-        types: [css]  # Only run on CSS files
-        # If you want it to run on EVERYTHING (JS, JSON, MD), remove the 'types' line.
+        # Only run on CSS files
+        types: [css]
+        # To run on everything (JS, JSON, MD), remove the 'types' line.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,13 @@
 exclude: '^(\.github/|\.vscode/).*|CODE_OF_CONDUCT\.md|CHANGELOG\.md'
 
 repos:
+  - repo: local
+    hooks:
+      - id: validate-generated-schema-types
+        name: validate generated schema types
+        entry: bash -c 'node generate_ts_schema_types.js && git diff --exit-code -- generated/schema-types.ts'
+        language: system
+        pass_filenames: false
   - repo: https://github.com/streetsidesoftware/cspell-cli
     rev: v9.3.3
     hooks:

--- a/generate_ts_schema_types.js
+++ b/generate_ts_schema_types.js
@@ -2,7 +2,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { compile } = require('json-schema-to-typescript');
 
-const SOURCE_ROOT = path.resolve(__dirname, 'spec');
+const SOURCE_ROOT = path.resolve(__dirname, 'source');
 const OUTPUT_FILE = path.resolve(__dirname, './generated/schema-types.ts');
 const WRAPPER_NAME = 'SCHEMA_WRAPPER';
 

--- a/generated/schema-types.ts
+++ b/generated/schema-types.ts
@@ -10,185 +10,105 @@
 /**
  * JWS Detached Content signature (RFC 7515 Appendix F) over the checkout response body (excluding ap2 field). Format: `<base64url-header>..<base64url-signature>`. The header MUST contain 'alg' (ES256/ES384/ES512) and 'kid' claims. The signature covers both the header and JCS-canonicalized checkout payload.
  *
- * This interface was referenced by `AP2MandateExtensionCompleteRequest`'s JSON-Schema
+ * This interface was referenced by `AP2MandateExtension`'s JSON-Schema
  * via the `definition` "merchant_authorization".
  */
-export type MerchantAuthorizationCompleteRequest = string;
+export type MerchantAuthorization = string;
 /**
  * SD-JWT+kb credential in `ap2.checkout_mandate`. Proving user authorization for the checkout. Contains the full checkout including `ap2.merchant_authorization`.
  *
- * This interface was referenced by `AP2MandateExtensionCompleteRequest`'s JSON-Schema
+ * This interface was referenced by `AP2MandateExtension`'s JSON-Schema
  * via the `definition` "checkout_mandate".
  */
-export type CheckoutMandateCompleteRequest = string;
+export type CheckoutMandate = string;
+/**
+ * JWS Detached Content signature (RFC 7515 Appendix F) over the checkout response body (excluding ap2 field). Format: `<base64url-header>..<base64url-signature>`. The header MUST contain 'alg' (ES256/ES384/ES512) and 'kid' claims. The signature covers both the header and JCS-canonicalized checkout payload.
+ */
+export type MerchantAuthorization1 = string;
+/**
+ * SD-JWT+kb credential in `ap2.checkout_mandate`. Proving user authorization for the checkout. Contains the full checkout including `ap2.merchant_authorization`.
+ */
+export type CheckoutMandate1 = string;
 /**
  * Checkout extended with AP2 mandate support.
  *
- * This interface was referenced by `AP2MandateExtensionCompleteRequest`'s JSON-Schema
- * via the `definition` "checkout".
+ * This interface was referenced by `AP2MandateExtension`'s JSON-Schema
+ * via the `definition` "dev.ucp.shopping.checkout".
  */
-export type CheckoutWithAP2MandateCompleteRequest = CheckoutCompleteRequest & {
+export type CheckoutWithAP2Mandate = Checkout & {
   ap2?: Ap2WithMerchantAuthorization & Ap2WithCheckoutMandate;
   [k: string]: unknown;
 };
 /**
- * Matches a specific instrument type based on validation logic.
+ * UCP metadata for checkout responses.
  */
-export type PaymentInstrument = CardPaymentInstrument;
-/**
- * A basic card payment instrument with visible card details. Can be inherited by a handler's instrument schema to define handler-specific display details or more complex credential structures.
- */
-export type CardPaymentInstrument = PaymentInstrumentBase & {
-  /**
-   * Indicates this is a card payment instrument.
-   */
-  type: 'card';
-  /**
-   * The card brand/network (e.g., visa, mastercard, amex).
-   */
-  brand: string;
-  /**
-   * Last 4 digits of the card number.
-   */
-  last_digits: string;
-  /**
-   * The month of the card's expiration date (1-12).
-   */
-  expiry_month?: number;
-  /**
-   * The year of the card's expiration date.
-   */
-  expiry_year?: number;
-  /**
-   * An optional rich text description of the card to display to the user (e.g., 'Visa ending in 1234, expires 12/2025').
-   */
-  rich_text_description?: string;
-  /**
-   * An optional URI to a rich image representing the card (e.g., card art provided by the issuer).
-   */
-  rich_card_art?: string;
+export type UCPCheckoutResponseSchema = Base & {
+  services?: {
+    [k: string]: ServiceResponseSchema[];
+  };
+  capabilities?: {
+    [k: string]: CapabilityResponseSchema[];
+  };
+  payment_handlers: {
+    [k: string]: PaymentHandlerResponseSchema[];
+  };
   [k: string]: unknown;
 };
 /**
- * Container for sensitive payment data. Use the specific schema matching the 'type' field.
+ * Service binding in API responses. Includes per-resource transport configuration via typed config.
  */
-export type PaymentCredential = TokenCredentialResponse | CardCredential;
-/**
- * Error codes specific to AP2 mandate verification.
- *
- * This interface was referenced by `AP2MandateExtensionCompleteRequest`'s JSON-Schema
- * via the `definition` "error_code".
- */
-export type AP2ErrorCodeCompleteRequest =
-  | 'mandate_required'
-  | 'agent_missing_key'
-  | 'mandate_invalid_signature'
-  | 'mandate_expired'
-  | 'mandate_scope_mismatch'
-  | 'merchant_authorization_invalid'
-  | 'merchant_authorization_missing';
-/**
- * JWS Detached Content signature (RFC 7515 Appendix F) over the checkout response body (excluding ap2 field). Format: `<base64url-header>..<base64url-signature>`. The header MUST contain 'alg' (ES256/ES384/ES512) and 'kid' claims. The signature covers both the header and JCS-canonicalized checkout payload.
- *
- * This interface was referenced by `AP2MandateExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "merchant_authorization".
- */
-export type MerchantAuthorizationCreateRequest = string;
-/**
- * SD-JWT+kb credential in `ap2.checkout_mandate`. Proving user authorization for the checkout. Contains the full checkout including `ap2.merchant_authorization`.
- *
- * This interface was referenced by `AP2MandateExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "checkout_mandate".
- */
-export type CheckoutMandateCreateRequest = string;
-/**
- * Checkout extended with AP2 mandate support.
- *
- * This interface was referenced by `AP2MandateExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "checkout".
- */
-export type CheckoutWithAP2MandateCreateRequest = CheckoutCreateRequest & {
+export type ServiceResponseSchema = (Entity & {
+  /**
+   * Transport protocol for this service binding.
+   */
+  transport: 'rest' | 'mcp' | 'a2a' | 'embedded';
+  /**
+   * Endpoint URL for this transport binding.
+   */
+  endpoint?: string;
   [k: string]: unknown;
-};
-/**
- * Error codes specific to AP2 mandate verification.
- *
- * This interface was referenced by `AP2MandateExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "error_code".
- */
-export type AP2ErrorCodeCreateRequest =
-  | 'mandate_required'
-  | 'agent_missing_key'
-  | 'mandate_invalid_signature'
-  | 'mandate_expired'
-  | 'mandate_scope_mismatch'
-  | 'merchant_authorization_invalid'
-  | 'merchant_authorization_missing';
-/**
- * JWS Detached Content signature (RFC 7515 Appendix F) over the checkout response body (excluding ap2 field). Format: `<base64url-header>..<base64url-signature>`. The header MUST contain 'alg' (ES256/ES384/ES512) and 'kid' claims. The signature covers both the header and JCS-canonicalized checkout payload.
- *
- * This interface was referenced by `AP2MandateExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "merchant_authorization".
- */
-export type MerchantAuthorizationUpdateRequest = string;
-/**
- * SD-JWT+kb credential in `ap2.checkout_mandate`. Proving user authorization for the checkout. Contains the full checkout including `ap2.merchant_authorization`.
- *
- * This interface was referenced by `AP2MandateExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "checkout_mandate".
- */
-export type CheckoutMandateUpdateRequest = string;
-/**
- * Checkout extended with AP2 mandate support.
- *
- * This interface was referenced by `AP2MandateExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "checkout".
- */
-export type CheckoutWithAP2MandateUpdateRequest = CheckoutUpdateRequest & {
-  [k: string]: unknown;
-};
-/**
- * Error codes specific to AP2 mandate verification.
- *
- * This interface was referenced by `AP2MandateExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "error_code".
- */
-export type AP2ErrorCodeUpdateRequest =
-  | 'mandate_required'
-  | 'agent_missing_key'
-  | 'mandate_invalid_signature'
-  | 'mandate_expired'
-  | 'mandate_scope_mismatch'
-  | 'merchant_authorization_invalid'
-  | 'merchant_authorization_missing';
-/**
- * JWS Detached Content signature (RFC 7515 Appendix F) over the checkout response body (excluding ap2 field). Format: `<base64url-header>..<base64url-signature>`. The header MUST contain 'alg' (ES256/ES384/ES512) and 'kid' claims. The signature covers both the header and JCS-canonicalized checkout payload.
- *
- * This interface was referenced by `AP2MandateExtensionResponse`'s JSON-Schema
- * via the `definition` "merchant_authorization".
- */
-export type MerchantAuthorizationResponse = string;
-/**
- * SD-JWT+kb credential in `ap2.checkout_mandate`. Proving user authorization for the checkout. Contains the full checkout including `ap2.merchant_authorization`.
- *
- * This interface was referenced by `AP2MandateExtensionResponse`'s JSON-Schema
- * via the `definition` "checkout_mandate".
- */
-export type CheckoutMandateResponse = string;
-/**
- * Checkout extended with AP2 mandate support.
- *
- * This interface was referenced by `AP2MandateExtensionResponse`'s JSON-Schema
- * via the `definition` "checkout".
- */
-export type CheckoutWithAP2MandateResponse = CheckoutResponse & {
-  ap2?: Ap2WithMerchantAuthorization1 & Ap2WithCheckoutMandate1;
-  [k: string]: unknown;
-};
+}) &
+  (
+    | {
+        transport?: 'rest';
+        [k: string]: unknown;
+      }
+    | {
+        transport?: 'mcp';
+        [k: string]: unknown;
+      }
+    | {
+        transport?: 'a2a';
+        [k: string]: unknown;
+      }
+    | {
+        transport?: 'embedded';
+        config?: EmbeddedTransportConfig;
+        [k: string]: unknown;
+      }
+  );
 /**
  * Capability reference in responses. Only name/version required to confirm active capabilities.
  */
-export type CapabilityResponse = Base & {
+export type CapabilityResponseSchema = Entity & {
+  /**
+   * Parent capability(s) this extends. Present for extensions, absent for root capabilities. Use array for multi-parent extensions.
+   */
+  extends?: string | [string, ...string[]];
+  [k: string]: unknown;
+};
+/**
+ * Handler reference in responses. May include full config state for runtime usage of the handler.
+ */
+export type PaymentHandlerResponseSchema = Entity & {
+  [k: string]: unknown;
+} & {
+  /**
+   * Instrument types this handler supports, with optional constraints. When absent, every instrument should be considered available.
+   *
+   * @minItems 1
+   */
+  available_instruments?: [AvailablePaymentInstrument, ...AvailablePaymentInstrument[]];
   [k: string]: unknown;
 };
 /**
@@ -196,12 +116,26 @@ export type CapabilityResponse = Base & {
  */
 export type Message = MessageError | MessageWarning | MessageInfo;
 /**
+ * Error code identifying the type of error. Standard errors are defined in specification (see examples), and have standardized semantics; freeform codes are permitted.
+ */
+export type ErrorCode = string;
+/**
+ * A payment instrument with selection state.
+ */
+export type SelectedPaymentInstrument = PaymentInstrument & {
+  /**
+   * Whether this instrument is selected by the user.
+   */
+  selected?: boolean;
+  [k: string]: unknown;
+};
+/**
  * Error codes specific to AP2 mandate verification.
  *
- * This interface was referenced by `AP2MandateExtensionResponse`'s JSON-Schema
+ * This interface was referenced by `AP2MandateExtension`'s JSON-Schema
  * via the `definition` "error_code".
  */
-export type AP2ErrorCodeResponse =
+export type AP2ErrorCode =
   | 'mandate_required'
   | 'agent_missing_key'
   | 'mandate_invalid_signature'
@@ -212,172 +146,70 @@ export type AP2ErrorCodeResponse =
 /**
  * Buyer object extended with consent tracking.
  *
- * This interface was referenced by `BuyerConsentExtensionCompleteRequest`'s JSON-Schema
+ * This interface was referenced by `BuyerConsentExtension`'s JSON-Schema
  * via the `definition` "buyer".
  */
-export type BuyerWithConsentCompleteRequest = Buyer & {
+export type BuyerWithConsent = Buyer1 & {
   consent?: Consent;
   [k: string]: unknown;
 };
 /**
  * Checkout extended with consent tracking via buyer object.
  *
- * This interface was referenced by `BuyerConsentExtensionCompleteRequest`'s JSON-Schema
- * via the `definition` "checkout".
+ * This interface was referenced by `BuyerConsentExtension`'s JSON-Schema
+ * via the `definition` "dev.ucp.shopping.checkout".
  */
-export type CheckoutWithBuyerConsentCompleteRequest = CheckoutCompleteRequest & {
+export type CheckoutWithBuyerConsent = Checkout & {
+  buyer?: BuyerWithConsent1;
   [k: string]: unknown;
 };
 /**
  * Buyer object extended with consent tracking.
- *
- * This interface was referenced by `BuyerConsentExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "buyer".
  */
-export type BuyerWithConsentCreateRequest = Buyer & {
-  consent?: Consent1;
+export type BuyerWithConsent1 = Buyer1 & {
+  consent?: Consent;
   [k: string]: unknown;
 };
 /**
- * Checkout extended with consent tracking via buyer object.
+ * UCP metadata for cart responses. No payment handlers needed pre-checkout.
+ */
+export type UCPCartResponseSchema = Base & {
+  capabilities?: {
+    [k: string]: CapabilityResponseSchema[];
+  };
+  [k: string]: unknown;
+};
+/**
+ * Checkout extended with cart capability. Adds cart_id to create_checkout for cart-to-checkout conversion.
  *
- * This interface was referenced by `BuyerConsentExtensionCreateRequest`'s JSON-Schema
+ * This interface was referenced by `Cart`'s JSON-Schema
  * via the `definition` "checkout".
  */
-export type CheckoutWithBuyerConsentCreateRequest = CheckoutCreateRequest & {
-  buyer?: BuyerWithConsentCreateRequest;
-  [k: string]: unknown;
-};
-/**
- * Buyer object extended with consent tracking.
- *
- * This interface was referenced by `BuyerConsentExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "buyer".
- */
-export type BuyerWithConsentUpdateRequest = Buyer & {
-  consent?: Consent2;
-  [k: string]: unknown;
-};
-/**
- * Checkout extended with consent tracking via buyer object.
- *
- * This interface was referenced by `BuyerConsentExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "checkout".
- */
-export type CheckoutWithBuyerConsentUpdateRequest = CheckoutUpdateRequest & {
-  buyer?: BuyerWithConsentUpdateRequest;
-  [k: string]: unknown;
-};
-/**
- * Buyer object extended with consent tracking.
- *
- * This interface was referenced by `BuyerConsentExtensionResponse`'s JSON-Schema
- * via the `definition` "buyer".
- */
-export type BuyerWithConsentResponse = Buyer & {
-  consent?: Consent3;
-  [k: string]: unknown;
-};
-/**
- * Checkout extended with consent tracking via buyer object.
- *
- * This interface was referenced by `BuyerConsentExtensionResponse`'s JSON-Schema
- * via the `definition` "checkout".
- */
-export type CheckoutWithBuyerConsentResponse = CheckoutResponse & {
-  buyer?: BuyerWithConsentResponse;
+export type CheckoutWithCart = Checkout & {
+  /**
+   * Cart ID to convert to checkout. Business MUST use cart contents (line_items, context, buyer) and MUST ignore overlapping fields in checkout payload.
+   */
+  cart_id?: string;
   [k: string]: unknown;
 };
 /**
  * Checkout extended with discount capability.
  *
- * This interface was referenced by `DiscountExtensionCompleteRequest`'s JSON-Schema
- * via the `definition` "checkout".
+ * This interface was referenced by `DiscountExtension`'s JSON-Schema
+ * via the `definition` "dev.ucp.shopping.checkout".
  */
-export type CheckoutWithDiscountCompleteRequest = CheckoutCompleteRequest & {
-  [k: string]: unknown;
-};
-/**
- * Checkout extended with discount capability.
- *
- * This interface was referenced by `DiscountExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "checkout".
- */
-export type CheckoutWithDiscountCreateRequest = CheckoutCreateRequest & {
+export type CheckoutWithDiscount = Checkout & {
   discounts?: DiscountsObject;
   [k: string]: unknown;
 };
 /**
- * Checkout extended with discount capability.
- *
- * This interface was referenced by `DiscountExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "checkout".
- */
-export type CheckoutWithDiscountUpdateRequest = CheckoutUpdateRequest & {
-  discounts?: DiscountsObject1;
-  [k: string]: unknown;
-};
-/**
- * Checkout extended with discount capability.
- *
- * This interface was referenced by `DiscountExtensionResponse`'s JSON-Schema
- * via the `definition` "checkout".
- */
-export type CheckoutWithDiscountResponse = CheckoutResponse & {
-  discounts?: DiscountsObject2;
-  [k: string]: unknown;
-};
-/**
  * A destination for fulfillment.
  */
-export type FulfillmentDestinationRequest = ShippingDestinationRequest | RetailLocationRequest;
+export type FulfillmentDestination = ShippingDestination | RetailLocation;
 /**
  * Shipping destination.
  */
-export type ShippingDestinationRequest = PostalAddress & {
-  /**
-   * ID specific to this shipping destination.
-   */
-  id?: string;
-  [k: string]: unknown;
-};
-/**
- * Checkout extended with hierarchical fulfillment.
- *
- * This interface was referenced by `FulfillmentExtensionCompleteRequest`'s JSON-Schema
- * via the `definition` "checkout".
- */
-export type CheckoutWithFulfillmentCompleteRequest = CheckoutCompleteRequest & {
-  [k: string]: unknown;
-};
-/**
- * Checkout extended with hierarchical fulfillment.
- *
- * This interface was referenced by `FulfillmentExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "checkout".
- */
-export type CheckoutWithFulfillmentCreateRequest = CheckoutCreateRequest & {
-  fulfillment?: FulfillmentRequest;
-  [k: string]: unknown;
-};
-/**
- * Checkout extended with hierarchical fulfillment.
- *
- * This interface was referenced by `FulfillmentExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "checkout".
- */
-export type CheckoutWithFulfillmentUpdateRequest = CheckoutUpdateRequest & {
-  fulfillment?: FulfillmentRequest;
-  [k: string]: unknown;
-};
-/**
- * A destination for fulfillment.
- */
-export type FulfillmentDestinationResponse = ShippingDestinationResponse | RetailLocationResponse;
-/**
- * Shipping destination.
- */
-export type ShippingDestinationResponse = PostalAddress & {
+export type ShippingDestination = PostalAddress & {
   /**
    * ID specific to this shipping destination.
    */
@@ -387,209 +219,266 @@ export type ShippingDestinationResponse = PostalAddress & {
 /**
  * Checkout extended with hierarchical fulfillment.
  *
- * This interface was referenced by `FulfillmentExtensionResponse`'s JSON-Schema
- * via the `definition` "checkout".
+ * This interface was referenced by `FulfillmentExtension`'s JSON-Schema
+ * via the `definition` "dev.ucp.shopping.checkout".
  */
-export type CheckoutWithFulfillmentResponse = CheckoutResponse & {
-  fulfillment?: FulfillmentResponse;
+export type CheckoutWithFulfillment = Checkout & {
+  fulfillment?: Fulfillment1;
+  [k: string]: unknown;
+};
+/**
+ * UCP metadata for order responses. No payment handlers needed post-purchase.
+ */
+export type UCPOrderResponseSchema = Base & {
+  capabilities?: {
+    [k: string]: CapabilityResponseSchema[];
+  };
   [k: string]: unknown;
 };
 
 /**
  * Extends Checkout with cryptographic mandate support for non-repudiable authorization per the AP2 protocol. Uses embedded signature model with ap2 namespace.
  */
-export declare interface AP2MandateExtensionCompleteRequest {
+export declare interface AP2MandateExtension {
   [k: string]: unknown;
 }
 /**
  * AP2 extension data including merchant authorization.
  *
- * This interface was referenced by `AP2MandateExtensionCompleteRequest`'s JSON-Schema
+ * This interface was referenced by `AP2MandateExtension`'s JSON-Schema
  * via the `definition` "ap2_with_merchant_authorization".
  */
 export declare interface Ap2WithMerchantAuthorization {
+  merchant_authorization?: MerchantAuthorization1;
   [k: string]: unknown;
 }
 /**
  * AP2 extension data including checkout mandate.
  *
- * This interface was referenced by `AP2MandateExtensionCompleteRequest`'s JSON-Schema
+ * This interface was referenced by `AP2MandateExtension`'s JSON-Schema
  * via the `definition` "ap2_with_checkout_mandate".
  */
 export declare interface Ap2WithCheckoutMandate {
-  checkout_mandate?: CheckoutMandateCompleteRequest;
+  checkout_mandate?: CheckoutMandate1;
   [k: string]: unknown;
 }
 /**
  * Base checkout schema. Extensions compose onto this using allOf.
  */
-export declare interface CheckoutCompleteRequest {
-  payment: PaymentCompleteRequest;
-  [k: string]: unknown;
-}
-/**
- * Payment configuration containing handlers.
- */
-export declare interface PaymentCompleteRequest {
+export declare interface Checkout {
+  ucp: UCPCheckoutResponseSchema;
   /**
-   * The id of the currently selected payment instrument from the instruments array. Set by the agent when submitting payment, and echoed back by the merchant in finalized state.
-   */
-  selected_instrument_id?: string;
-  /**
-   * The payment instruments available for this payment. Each instrument is associated with a specific handler via the handler_id field. Handlers can extend the base payment_instrument schema to add handler-specific fields.
-   */
-  instruments?: PaymentInstrument[];
-  [k: string]: unknown;
-}
-/**
- * The base definition for any payment instrument. It links the instrument to a specific Merchant configuration (handler_id) and defines common fields like billing address.
- */
-export declare interface PaymentInstrumentBase {
-  /**
-   * A unique identifier for this instrument instance, assigned by the Agent. Used to reference this specific instrument in the 'payment.selected_instrument_id' field.
+   * Unique identifier of the checkout session.
    */
   id: string;
   /**
-   * The unique identifier for the handler instance that produced this instrument. This corresponds to the 'id' field in the Payment Handler definition.
-   */
-  handler_id: string;
-  /**
-   * The broad category of the instrument (e.g., 'card', 'tokenized_card'). Specific schemas will constrain this to a constant value.
-   */
-  type: string;
-  billing_address?: PostalAddress;
-  credential?: PaymentCredential;
-  [k: string]: unknown;
-}
-export declare interface PostalAddress {
-  /**
-   * An address extension such as an apartment number, C/O or alternative name.
-   */
-  extended_address?: string;
-  /**
-   * The street address.
-   */
-  street_address?: string;
-  /**
-   * The locality in which the street address is, and which is in the region. For example, Mountain View.
-   */
-  address_locality?: string;
-  /**
-   * The region in which the locality is, and which is in the country. Required for applicable countries (i.e. state in US, province in CA). For example, California or another appropriate first-level Administrative division.
-   */
-  address_region?: string;
-  /**
-   * The country. Recommended to be in 2-letter ISO 3166-1 alpha-2 format, for example "US". For backward compatibility, a 3-letter ISO 3166-1 alpha-3 country code such as "SGP" or a full country name such as "Singapore" can also be used.
-   */
-  address_country?: string;
-  /**
-   * The postal code. For example, 94043.
-   */
-  postal_code?: string;
-  /**
-   * Optional. First name of the contact associated with the address.
-   */
-  first_name?: string;
-  /**
-   * Optional. Last name of the contact associated with the address.
-   */
-  last_name?: string;
-  /**
-   * Optional. Phone number of the contact associated with the address.
-   */
-  phone_number?: string;
-  [k: string]: unknown;
-}
-/**
- * Base token credential schema. Concrete payment handlers may extend this schema with additional fields and define their own constraints.
- */
-export declare interface TokenCredentialResponse {
-  /**
-   * The specific type of token produced by the handler (e.g., 'stripe_token').
-   */
-  type: string;
-  [k: string]: unknown;
-}
-/**
- * A card credential containing sensitive payment card details including raw Primary Account Numbers (PANs). This credential type MUST NOT be used for checkout, only with payment handlers that tokenize or encrypt credentials. CRITICAL: Both parties handling CardCredential (sender and receiver) MUST be PCI DSS compliant. Transmission MUST use HTTPS/TLS with strong cipher suites.
- */
-export declare interface CardCredential {
-  /**
-   * The credential type identifier for card credentials.
-   */
-  type: 'card';
-  /**
-   * The type of card number. Network tokens are preferred with fallback to FPAN. See PCI Scope for more details.
-   */
-  card_number_type: 'fpan' | 'network_token' | 'dpan';
-  /**
-   * Card number.
-   */
-  number?: string;
-  /**
-   * The month of the card's expiration date (1-12).
-   */
-  expiry_month?: number;
-  /**
-   * The year of the card's expiration date.
-   */
-  expiry_year?: number;
-  /**
-   * Cardholder name.
-   */
-  name?: string;
-  /**
-   * Card CVC number.
-   */
-  cvc?: string;
-  /**
-   * Cryptogram provided with network tokens.
-   */
-  cryptogram?: string;
-  /**
-   * Electronic Commerce Indicator / Security Level Indicator provided with network tokens.
-   */
-  eci_value?: string;
-  [k: string]: unknown;
-}
-/**
- * Extends Checkout with cryptographic mandate support for non-repudiable authorization per the AP2 protocol. Uses embedded signature model with ap2 namespace.
- */
-export declare interface AP2MandateExtensionCreateRequest {
-  [k: string]: unknown;
-}
-/**
- * Base checkout schema. Extensions compose onto this using allOf.
- */
-export declare interface CheckoutCreateRequest {
-  /**
    * List of line items being checked out.
    */
-  line_items: LineItemCreateRequest[];
+  line_items: LineItem[];
   buyer?: Buyer;
+  context?: Context;
   /**
-   * ISO 4217 currency code.
+   * Checkout state indicating the current phase and required action. See Checkout Status lifecycle documentation for state transition details.
+   */
+  status:
+    | 'incomplete'
+    | 'requires_escalation'
+    | 'ready_for_complete'
+    | 'complete_in_progress'
+    | 'completed'
+    | 'canceled';
+  /**
+   * ISO 4217 currency code reflecting the merchant's market determination. Derived from address, context, and geo IP—buyers provide signals, merchants determine currency.
    */
   currency: string;
-  payment?: PaymentCreateRequest;
+  /**
+   * Different cart totals.
+   */
+  totals: Total[];
+  /**
+   * List of messages with error and info about the checkout session state.
+   */
+  messages?: Message[];
+  /**
+   * Links to be displayed by the platform (Privacy Policy, TOS). Mandatory for legal compliance.
+   */
+  links: Link[];
+  /**
+   * RFC 3339 expiry timestamp. Default TTL is 6 hours from creation if not sent.
+   */
+  expires_at?: string;
+  /**
+   * URL for checkout handoff and session recovery. MUST be provided when status is requires_escalation. See specification for format and availability requirements.
+   */
+  continue_url?: string;
+  payment?: Payment;
+  order?: OrderConfirmation;
+  [k: string]: unknown;
+}
+/**
+ * Base UCP metadata with shared properties for all schema types.
+ */
+export declare interface Base {
+  /**
+   * UCP version in YYYY-MM-DD format.
+   */
+  version: string;
+  /**
+   * Service registry keyed by reverse-domain name.
+   */
+  services?: {
+    [k: string]: Array<Entity & {
+      /**
+       * Transport protocol for this service binding.
+       */
+      transport: 'rest' | 'mcp' | 'a2a' | 'embedded';
+      /**
+       * Endpoint URL for this transport binding.
+       */
+      endpoint?: string;
+      [k: string]: unknown;
+    }>;
+  };
+  /**
+   * Capability registry keyed by reverse-domain name.
+   */
+  capabilities?: {
+    [k: string]: (Entity & {
+      /**
+       * Parent capability(s) this extends. Present for extensions, absent for root capabilities. Use array for multi-parent extensions.
+       */
+      extends?: string | [string, ...string[]];
+      [k: string]: unknown;
+    })[];
+  };
+  /**
+   * Payment handler registry keyed by reverse-domain name.
+   */
+  payment_handlers?: {
+    [k: string]: Array<Entity & {
+      [k: string]: unknown;
+    } & {
+      /**
+       * Instrument types this handler supports, with optional constraints. When absent, every instrument should be considered available.
+       *
+       * @minItems 1
+       */
+      available_instruments?: [AvailablePaymentInstrument, ...AvailablePaymentInstrument[]];
+      [k: string]: unknown;
+    }>;
+  };
+  [k: string]: unknown;
+}
+/**
+ * Shared foundation for all UCP entities.
+ */
+export declare interface Entity {
+  /**
+   * UCP version in YYYY-MM-DD format.
+   */
+  version: string;
+  /**
+   * URL to human-readable specification document.
+   */
+  spec?: string;
+  /**
+   * URL to JSON Schema defining this entity's structure and payloads.
+   */
+  schema?: string;
+  /**
+   * Unique identifier for this entity instance. Used to disambiguate when multiple instances exist.
+   */
+  id?: string;
+  /**
+   * Entity-specific configuration. Structure defined by each entity's schema.
+   */
+  config?: {
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+/**
+ * An instrument type available from a payment handler with optional constraints.
+ */
+export declare interface AvailablePaymentInstrument {
+  /**
+   * The instrument type identifier (e.g., 'card', 'gift_card'). References an instrument schema's type constant.
+   */
+  type: string;
+  /**
+   * Constraints on this instrument type. Structure depends on instrument type and active capabilities.
+   */
+  constraints?: {
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+/**
+ * Per-checkout configuration for embedded transport binding. Allows businesses to vary ECP availability and delegations based on cart contents, agent authorization, or policy.
+ */
+export declare interface EmbeddedTransportConfig {
+  /**
+   * Delegations the business allows. At service-level, declares available delegations. In checkout responses, confirms accepted delegations for this session.
+   */
+  delegate?: string[];
+  /**
+   * Color schemes the business supports. Hosts use ec_color_scheme query parameter to request a scheme from this list.
+   */
+  color_scheme?: Array<'light' | 'dark'>;
   [k: string]: unknown;
 }
 /**
  * Line item object. Expected to use the currency of the parent object.
  */
-export declare interface LineItemCreateRequest {
-  item: ItemCreateRequest;
+export declare interface LineItem {
+  id: string;
+  item: Item;
   /**
    * Quantity of the item being purchased.
    */
   quantity: number;
+  /**
+   * Line item totals breakdown.
+   */
+  totals: Total[];
+  /**
+   * Parent line item identifier for any nested structures.
+   */
+  parent_id?: string;
   [k: string]: unknown;
 }
-export declare interface ItemCreateRequest {
+export declare interface Item {
   /**
-   * Should be recognized by both the Platform, and the Business. For Google it should match the id provided in the "id" field in the product feed.
+   * The product identifier, often the SKU, required to resolve the product details associated with this line item. Should be recognized by both the Platform, and the Business.
    */
   id: string;
+  /**
+   * Product title.
+   */
+  title: string;
+  /**
+   * Unit price in minor (cents) currency units.
+   */
+  price: number;
+  /**
+   * Product image URI.
+   */
+  image_url?: string;
+  [k: string]: unknown;
+}
+export declare interface Total {
+  /**
+   * Type of total categorization.
+   */
+  type: 'items_discount' | 'subtotal' | 'discount' | 'fulfillment' | 'tax' | 'fee' | 'total';
+  /**
+   * Text to display against the amount. Should reflect appropriate method (e.g., 'Shipping', 'Delivery').
+   */
+  display_text?: string;
+  /**
+   * If type == total, sums subtotal - discount + fulfillment + tax + fee. Should be >= 0. Amount in minor (cents) currency units.
+   */
+  amount: number;
   [k: string]: unknown;
 }
 export declare interface Buyer {
@@ -612,255 +501,25 @@ export declare interface Buyer {
   [k: string]: unknown;
 }
 /**
- * Payment configuration containing handlers.
+ * Provisional buyer signals for relevance and localization: product availability, pricing, currency, tax, shipping, payment methods, and eligibility (e.g., student or affiliation discounts). Businesses SHOULD use these values when authoritative data (e.g., address) is absent, and MAY ignore unsupported values without returning errors. Context SHOULD be non-identifying and can be disclosed progressively—coarse signals early, finer resolution as the session progresses. Higher-resolution data (shipping address, billing address) supersedes context. Platforms SHOULD progressively enhance context throughout the buyer journey.
  */
-export declare interface PaymentCreateRequest {
+export declare interface Context {
   /**
-   * The id of the currently selected payment instrument from the instruments array. Set by the agent when submitting payment, and echoed back by the merchant in finalized state.
+   * The country. Recommended to be in 2-letter ISO 3166-1 alpha-2 format, for example "US". For backward compatibility, a 3-letter ISO 3166-1 alpha-3 country code such as "SGP" or a full country name such as "Singapore" can also be used. Optional hint for market context (currency, availability, pricing)—higher-resolution data (e.g., shipping address) supersedes this value.
    */
-  selected_instrument_id?: string;
+  address_country?: string;
   /**
-   * The payment instruments available for this payment. Each instrument is associated with a specific handler via the handler_id field. Handlers can extend the base payment_instrument schema to add handler-specific fields.
+   * The region in which the locality is, and which is in the country. For example, California or another appropriate first-level Administrative division. Optional hint for progressive localization—higher-resolution data (e.g., shipping address) supersedes this value.
    */
-  instruments?: PaymentInstrument[];
-  [k: string]: unknown;
-}
-/**
- * Extends Checkout with cryptographic mandate support for non-repudiable authorization per the AP2 protocol. Uses embedded signature model with ap2 namespace.
- */
-export declare interface AP2MandateExtensionUpdateRequest {
-  [k: string]: unknown;
-}
-/**
- * Base checkout schema. Extensions compose onto this using allOf.
- */
-export declare interface CheckoutUpdateRequest {
+  address_region?: string;
   /**
-   * Unique identifier of the checkout session.
+   * The postal code. For example, 94043. Optional hint for regional refinement—higher-resolution data (e.g., shipping address) supersedes this value.
    */
-  id: string;
+  postal_code?: string;
   /**
-   * List of line items being checked out.
+   * Background context describing buyer's intent (e.g., 'looking for a gift under $50', 'need something durable for outdoor use'). Informs relevance, recommendations, and personalization.
    */
-  line_items: LineItemUpdateRequest[];
-  buyer?: Buyer;
-  /**
-   * ISO 4217 currency code.
-   */
-  currency: string;
-  payment?: PaymentUpdateRequest;
-  [k: string]: unknown;
-}
-/**
- * Line item object. Expected to use the currency of the parent object.
- */
-export declare interface LineItemUpdateRequest {
-  id?: string;
-  item: ItemUpdateRequest;
-  /**
-   * Quantity of the item being purchased.
-   */
-  quantity: number;
-  /**
-   * Parent line item identifier for any nested structures.
-   */
-  parent_id?: string;
-  [k: string]: unknown;
-}
-export declare interface ItemUpdateRequest {
-  /**
-   * Should be recognized by both the Platform, and the Business. For Google it should match the id provided in the "id" field in the product feed.
-   */
-  id: string;
-  [k: string]: unknown;
-}
-/**
- * Payment configuration containing handlers.
- */
-export declare interface PaymentUpdateRequest {
-  /**
-   * The id of the currently selected payment instrument from the instruments array. Set by the agent when submitting payment, and echoed back by the merchant in finalized state.
-   */
-  selected_instrument_id?: string;
-  /**
-   * The payment instruments available for this payment. Each instrument is associated with a specific handler via the handler_id field. Handlers can extend the base payment_instrument schema to add handler-specific fields.
-   */
-  instruments?: PaymentInstrument[];
-  [k: string]: unknown;
-}
-/**
- * Extends Checkout with cryptographic mandate support for non-repudiable authorization per the AP2 protocol. Uses embedded signature model with ap2 namespace.
- */
-export declare interface AP2MandateExtensionResponse {
-  [k: string]: unknown;
-}
-/**
- * AP2 extension data including merchant authorization.
- *
- * This interface was referenced by `AP2MandateExtensionResponse`'s JSON-Schema
- * via the `definition` "ap2_with_merchant_authorization".
- */
-export declare interface Ap2WithMerchantAuthorization1 {
-  merchant_authorization?: MerchantAuthorizationResponse;
-  [k: string]: unknown;
-}
-/**
- * AP2 extension data including checkout mandate.
- *
- * This interface was referenced by `AP2MandateExtensionResponse`'s JSON-Schema
- * via the `definition` "ap2_with_checkout_mandate".
- */
-export declare interface Ap2WithCheckoutMandate1 {
-  checkout_mandate?: CheckoutMandateResponse;
-  [k: string]: unknown;
-}
-/**
- * Base checkout schema. Extensions compose onto this using allOf.
- */
-export declare interface CheckoutResponse {
-  ucp: UCPCheckoutResponse;
-  /**
-   * Unique identifier of the checkout session.
-   */
-  id: string;
-  /**
-   * List of line items being checked out.
-   */
-  line_items: LineItemResponse[];
-  buyer?: Buyer;
-  /**
-   * Checkout state indicating the current phase and required action. See Checkout Status lifecycle documentation for state transition details.
-   */
-  status:
-    | 'incomplete'
-    | 'requires_escalation'
-    | 'ready_for_complete'
-    | 'complete_in_progress'
-    | 'completed'
-    | 'canceled';
-  /**
-   * ISO 4217 currency code.
-   */
-  currency: string;
-  /**
-   * Different cart totals.
-   */
-  totals: TotalResponse[];
-  /**
-   * List of messages with error and info about the checkout session state.
-   */
-  messages?: Message[];
-  /**
-   * Links to be displayed by the platform (Privacy Policy, TOS). Mandatory for legal compliance.
-   */
-  links: Link[];
-  /**
-   * RFC 3339 expiry timestamp. Default TTL is 6 hours from creation if not sent.
-   */
-  expires_at?: string;
-  /**
-   * URL for checkout handoff and session recovery. MUST be provided when status is requires_escalation. See specification for format and availability requirements.
-   */
-  continue_url?: string;
-  payment: PaymentResponse;
-  order?: OrderConfirmation;
-  [k: string]: unknown;
-}
-/**
- * UCP metadata for checkout responses.
- */
-export declare interface UCPCheckoutResponse {
-  /**
-   * UCP protocol version in YYYY-MM-DD format.
-   */
-  version: string;
-  /**
-   * Active capabilities for this response.
-   */
-  capabilities: CapabilityResponse[];
-  [k: string]: unknown;
-}
-export declare interface Base {
-  /**
-   * Stable capability identifier in reverse-domain notation (e.g., dev.ucp.shopping.checkout). Used in capability negotiation.
-   */
-  name?: string;
-  /**
-   * UCP protocol version in YYYY-MM-DD format.
-   */
-  version?: string;
-  /**
-   * URL to human-readable specification document.
-   */
-  spec?: string;
-  /**
-   * URL to JSON Schema for this capability's payload.
-   */
-  schema?: string;
-  /**
-   * Parent capability this extends. Present for extensions, absent for root capabilities.
-   */
-  extends?: string;
-  /**
-   * Capability-specific configuration (structure defined by each capability).
-   */
-  config?: {
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-/**
- * Line item object. Expected to use the currency of the parent object.
- */
-export declare interface LineItemResponse {
-  id: string;
-  item: ItemResponse;
-  /**
-   * Quantity of the item being purchased.
-   */
-  quantity: number;
-  /**
-   * Line item totals breakdown.
-   */
-  totals: TotalResponse[];
-  /**
-   * Parent line item identifier for any nested structures.
-   */
-  parent_id?: string;
-  [k: string]: unknown;
-}
-export declare interface ItemResponse {
-  /**
-   * Should be recognized by both the Platform, and the Business. For Google it should match the id provided in the "id" field in the product feed.
-   */
-  id: string;
-  /**
-   * Product title.
-   */
-  title: string;
-  /**
-   * Unit price in minor (cents) currency units.
-   */
-  price: number;
-  /**
-   * Product image URI.
-   */
-  image_url?: string;
-  [k: string]: unknown;
-}
-export declare interface TotalResponse {
-  /**
-   * Type of total categorization.
-   */
-  type: 'items_discount' | 'subtotal' | 'discount' | 'fulfillment' | 'tax' | 'fee' | 'total';
-  /**
-   * Text to display against the amount. Should reflect appropriate method (e.g., 'Shipping', 'Delivery').
-   */
-  display_text?: string;
-  /**
-   * If type == total, sums subtotal - discount + fulfillment + tax + fee. Should be >= 0. Amount in minor (cents) currency units.
-   */
-  amount: number;
+  intent?: string;
   [k: string]: unknown;
 }
 export declare interface MessageError {
@@ -868,10 +527,7 @@ export declare interface MessageError {
    * Message type discriminator.
    */
   type: 'error';
-  /**
-   * Error code. Possible values include: missing, invalid, out_of_stock, payment_declined, requires_sign_in, requires_3ds, requires_identity_linking. Freeform codes also allowed.
-   */
-  code: string;
+  code: ErrorCode;
   /**
    * RFC 9535 JSONPath to the component the message refers to (e.g., $.items[1]).
    */
@@ -954,49 +610,86 @@ export declare interface Link {
 /**
  * Payment configuration containing handlers.
  */
-export declare interface PaymentResponse {
-  /**
-   * Processing configurations that define how payment instruments can be collected. Each handler specifies a tokenization or payment collection strategy.
-   */
-  handlers: PaymentHandlerResponse[];
-  /**
-   * The id of the currently selected payment instrument from the instruments array. Set by the agent when submitting payment, and echoed back by the merchant in finalized state.
-   */
-  selected_instrument_id?: string;
+export declare interface Payment {
   /**
    * The payment instruments available for this payment. Each instrument is associated with a specific handler via the handler_id field. Handlers can extend the base payment_instrument schema to add handler-specific fields.
    */
-  instruments?: PaymentInstrument[];
+  instruments?: SelectedPaymentInstrument[];
   [k: string]: unknown;
 }
-export declare interface PaymentHandlerResponse {
+/**
+ * The base definition for any payment instrument. It links the instrument to a specific payment handler.
+ */
+export declare interface PaymentInstrument {
   /**
-   * The unique identifier for this handler instance within the payment.handlers. Used by payment instruments to reference which handler produced them.
+   * A unique identifier for this instrument instance, assigned by the platform.
    */
   id: string;
   /**
-   * The specification name using reverse-DNS format. For example, dev.ucp.delegate_payment.
+   * The unique identifier for the handler instance that produced this instrument. This corresponds to the 'id' field in the Payment Handler definition.
    */
-  name: string;
+  handler_id: string;
   /**
-   * UCP protocol version in YYYY-MM-DD format.
+   * The broad category of the instrument (e.g., 'card', 'tokenized_card'). Specific schemas will constrain this to a constant value.
    */
-  version: string;
+  type: string;
+  billing_address?: PostalAddress;
+  credential?: PaymentCredential;
   /**
-   * A URI pointing to the technical specification or schema that defines how this handler operates.
+   * Display information for this payment instrument. Each payment instrument schema defines its specific display properties, as outlined by the payment handler.
    */
-  spec: string;
-  /**
-   * A URI pointing to a JSON Schema used to validate the structure of the config object.
-   */
-  config_schema: string;
-  instrument_schemas: string[];
-  /**
-   * A dictionary containing provider-specific configuration details, such as merchant IDs, supported networks, or gateway credentials.
-   */
-  config: {
+  display?: {
     [k: string]: unknown;
   };
+  [k: string]: unknown;
+}
+export declare interface PostalAddress {
+  /**
+   * An address extension such as an apartment number, C/O or alternative name.
+   */
+  extended_address?: string;
+  /**
+   * The street address.
+   */
+  street_address?: string;
+  /**
+   * The locality in which the street address is, and which is in the region. For example, Mountain View.
+   */
+  address_locality?: string;
+  /**
+   * The region in which the locality is, and which is in the country. Required for applicable countries (i.e. state in US, province in CA). For example, California or another appropriate first-level Administrative division.
+   */
+  address_region?: string;
+  /**
+   * The country. Recommended to be in 2-letter ISO 3166-1 alpha-2 format, for example "US". For backward compatibility, a 3-letter ISO 3166-1 alpha-3 country code such as "SGP" or a full country name such as "Singapore" can also be used.
+   */
+  address_country?: string;
+  /**
+   * The postal code. For example, 94043.
+   */
+  postal_code?: string;
+  /**
+   * Optional. First name of the contact associated with the address.
+   */
+  first_name?: string;
+  /**
+   * Optional. Last name of the contact associated with the address.
+   */
+  last_name?: string;
+  /**
+   * Optional. Phone number of the contact associated with the address.
+   */
+  phone_number?: string;
+  [k: string]: unknown;
+}
+/**
+ * The base definition for any payment credential. Handlers define specific credential types.
+ */
+export declare interface PaymentCredential {
+  /**
+   * The credential type discriminator. Specific schemas will constrain this to a constant value.
+   */
+  type: string;
   [k: string]: unknown;
 }
 /**
@@ -1016,13 +709,13 @@ export declare interface OrderConfirmation {
 /**
  * Extends Checkout with buyer consent tracking for privacy compliance via the buyer object.
  */
-export declare interface BuyerConsentExtensionCompleteRequest {
+export declare interface BuyerConsentExtension {
   [k: string]: unknown;
 }
 /**
  * User consent states for data processing
  *
- * This interface was referenced by `BuyerConsentExtensionCompleteRequest`'s JSON-Schema
+ * This interface was referenced by `BuyerConsentExtension`'s JSON-Schema
  * via the `definition` "consent".
  */
 export declare interface Consent {
@@ -1044,109 +737,117 @@ export declare interface Consent {
   sale_of_data?: boolean;
   [k: string]: unknown;
 }
-/**
- * Extends Checkout with buyer consent tracking for privacy compliance via the buyer object.
- */
-export declare interface BuyerConsentExtensionCreateRequest {
+export declare interface Buyer1 {
+  /**
+   * First name of the buyer.
+   */
+  first_name?: string;
+  /**
+   * Last name of the buyer.
+   */
+  last_name?: string;
+  /**
+   * Email of the buyer.
+   */
+  email?: string;
+  /**
+   * E.164 standard.
+   */
+  phone_number?: string;
   [k: string]: unknown;
 }
 /**
- * User consent states for data processing
- *
- * This interface was referenced by `BuyerConsentExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "consent".
+ * Shopping cart with estimated pricing before checkout. Lightweight pre-purchase exploration with no payment info or complex status states. Cart exists (200) or doesn't (404).
  */
-export declare interface Consent1 {
+export declare interface Cart {
+  ucp: UCPCartResponseSchema;
   /**
-   * Consent for analytics and performance tracking.
+   * Unique cart identifier.
    */
-  analytics?: boolean;
+  id: string;
   /**
-   * Consent for storing user preferences.
+   * Cart line items. Same structure as checkout. Full replacement on update.
    */
-  preferences?: boolean;
+  line_items: LineItem[];
+  context?: Context1;
+  buyer?: Buyer2;
   /**
-   * Consent for marketing communications.
+   * ISO 4217 currency code. Determined by merchant based on context or geo-IP.
    */
-  marketing?: boolean;
+  currency: string;
   /**
-   * Consent for selling data to third parties (CCPA).
+   * Estimated cost breakdown. May be partial if shipping/tax not yet calculable.
    */
-  sale_of_data?: boolean;
+  totals: Total[];
+  /**
+   * Validation messages, warnings, or informational notices.
+   */
+  messages?: Message[];
+  /**
+   * Optional merchant links (policies, FAQs).
+   */
+  links?: Link[];
+  /**
+   * URL for cart handoff and session recovery. Enables sharing and human-in-the-loop flows.
+   */
+  continue_url?: string;
+  /**
+   * Cart expiry timestamp (RFC 3339). Optional.
+   */
+  expires_at?: string;
   [k: string]: unknown;
 }
 /**
- * Extends Checkout with buyer consent tracking for privacy compliance via the buyer object.
+ * Provisional buyer signals for relevance and localization: product availability, pricing, currency, tax, shipping, payment methods, and eligibility (e.g., student or affiliation discounts). Businesses SHOULD use these values when authoritative data (e.g., address) is absent, and MAY ignore unsupported values without returning errors. Context SHOULD be non-identifying and can be disclosed progressively—coarse signals early, finer resolution as the session progresses. Higher-resolution data (shipping address, billing address) supersedes context. Platforms SHOULD progressively enhance context throughout the buyer journey.
  */
-export declare interface BuyerConsentExtensionUpdateRequest {
+export declare interface Context1 {
+  /**
+   * The country. Recommended to be in 2-letter ISO 3166-1 alpha-2 format, for example "US". For backward compatibility, a 3-letter ISO 3166-1 alpha-3 country code such as "SGP" or a full country name such as "Singapore" can also be used. Optional hint for market context (currency, availability, pricing)—higher-resolution data (e.g., shipping address) supersedes this value.
+   */
+  address_country?: string;
+  /**
+   * The region in which the locality is, and which is in the country. For example, California or another appropriate first-level Administrative division. Optional hint for progressive localization—higher-resolution data (e.g., shipping address) supersedes this value.
+   */
+  address_region?: string;
+  /**
+   * The postal code. For example, 94043. Optional hint for regional refinement—higher-resolution data (e.g., shipping address) supersedes this value.
+   */
+  postal_code?: string;
+  /**
+   * Background context describing buyer's intent (e.g., 'looking for a gift under $50', 'need something durable for outdoor use'). Informs relevance, recommendations, and personalization.
+   */
+  intent?: string;
   [k: string]: unknown;
 }
-/**
- * User consent states for data processing
- *
- * This interface was referenced by `BuyerConsentExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "consent".
- */
-export declare interface Consent2 {
+export declare interface Buyer2 {
   /**
-   * Consent for analytics and performance tracking.
+   * First name of the buyer.
    */
-  analytics?: boolean;
+  first_name?: string;
   /**
-   * Consent for storing user preferences.
+   * Last name of the buyer.
    */
-  preferences?: boolean;
+  last_name?: string;
   /**
-   * Consent for marketing communications.
+   * Email of the buyer.
    */
-  marketing?: boolean;
+  email?: string;
   /**
-   * Consent for selling data to third parties (CCPA).
+   * E.164 standard.
    */
-  sale_of_data?: boolean;
-  [k: string]: unknown;
-}
-/**
- * Extends Checkout with buyer consent tracking for privacy compliance via the buyer object.
- */
-export declare interface BuyerConsentExtensionResponse {
-  [k: string]: unknown;
-}
-/**
- * User consent states for data processing
- *
- * This interface was referenced by `BuyerConsentExtensionResponse`'s JSON-Schema
- * via the `definition` "consent".
- */
-export declare interface Consent3 {
-  /**
-   * Consent for analytics and performance tracking.
-   */
-  analytics?: boolean;
-  /**
-   * Consent for storing user preferences.
-   */
-  preferences?: boolean;
-  /**
-   * Consent for marketing communications.
-   */
-  marketing?: boolean;
-  /**
-   * Consent for selling data to third parties (CCPA).
-   */
-  sale_of_data?: boolean;
+  phone_number?: string;
   [k: string]: unknown;
 }
 /**
  * Extends Checkout with discount code support, enabling agents to apply promotional, loyalty, referral, and other discount codes.
  */
-export declare interface DiscountExtensionCompleteRequest {
+export declare interface DiscountExtension {
   [k: string]: unknown;
 }
 /**
  * Breakdown of how a discount amount was allocated to a specific target.
  *
- * This interface was referenced by `DiscountExtensionCompleteRequest`'s JSON-Schema
+ * This interface was referenced by `DiscountExtension`'s JSON-Schema
  * via the `definition` "allocation".
  */
 export declare interface Allocation {
@@ -1163,7 +864,7 @@ export declare interface Allocation {
 /**
  * A discount that was successfully applied.
  *
- * This interface was referenced by `DiscountExtensionCompleteRequest`'s JSON-Schema
+ * This interface was referenced by `DiscountExtension`'s JSON-Schema
  * via the `definition` "applied_discount".
  */
 export declare interface AppliedDiscount {
@@ -1198,70 +899,7 @@ export declare interface AppliedDiscount {
   [k: string]: unknown;
 }
 /**
- * Extends Checkout with discount code support, enabling agents to apply promotional, loyalty, referral, and other discount codes.
- */
-export declare interface DiscountExtensionCreateRequest {
-  [k: string]: unknown;
-}
-/**
- * Breakdown of how a discount amount was allocated to a specific target.
- *
- * This interface was referenced by `DiscountExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "allocation".
- */
-export declare interface Allocation1 {
-  /**
-   * JSONPath to the allocation target (e.g., '$.line_items[0]', '$.totals.shipping').
-   */
-  path: string;
-  /**
-   * Amount allocated to this target in minor (cents) currency units.
-   */
-  amount: number;
-  [k: string]: unknown;
-}
-/**
- * A discount that was successfully applied.
- *
- * This interface was referenced by `DiscountExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "applied_discount".
- */
-export declare interface AppliedDiscount1 {
-  /**
-   * The discount code. Omitted for automatic discounts.
-   */
-  code?: string;
-  /**
-   * Human-readable discount name (e.g., 'Summer Sale 20% Off').
-   */
-  title: string;
-  /**
-   * Total discount amount in minor (cents) currency units.
-   */
-  amount: number;
-  /**
-   * True if applied automatically by merchant rules (no code required).
-   */
-  automatic?: boolean;
-  /**
-   * Allocation method. 'each' = applied independently per item. 'across' = split proportionally by value.
-   */
-  method?: 'each' | 'across';
-  /**
-   * Stacking order for discount calculation. Lower numbers applied first (1 = first).
-   */
-  priority?: number;
-  /**
-   * Breakdown of where this discount was allocated. Sum of allocation amounts equals total amount.
-   */
-  allocations?: Allocation1[];
-  [k: string]: unknown;
-}
-/**
  * Discount codes input and applied discounts output.
- *
- * This interface was referenced by `DiscountExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "discounts_object".
  */
 export declare interface DiscountsObject {
   /**
@@ -1271,392 +909,22 @@ export declare interface DiscountsObject {
   /**
    * Discounts successfully applied (code-based and automatic).
    */
-  applied?: AppliedDiscount1[];
-  [k: string]: unknown;
-}
-/**
- * Extends Checkout with discount code support, enabling agents to apply promotional, loyalty, referral, and other discount codes.
- */
-export declare interface DiscountExtensionUpdateRequest {
-  [k: string]: unknown;
-}
-/**
- * Breakdown of how a discount amount was allocated to a specific target.
- *
- * This interface was referenced by `DiscountExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "allocation".
- */
-export declare interface Allocation2 {
-  /**
-   * JSONPath to the allocation target (e.g., '$.line_items[0]', '$.totals.shipping').
-   */
-  path: string;
-  /**
-   * Amount allocated to this target in minor (cents) currency units.
-   */
-  amount: number;
-  [k: string]: unknown;
-}
-/**
- * A discount that was successfully applied.
- *
- * This interface was referenced by `DiscountExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "applied_discount".
- */
-export declare interface AppliedDiscount2 {
-  /**
-   * The discount code. Omitted for automatic discounts.
-   */
-  code?: string;
-  /**
-   * Human-readable discount name (e.g., 'Summer Sale 20% Off').
-   */
-  title: string;
-  /**
-   * Total discount amount in minor (cents) currency units.
-   */
-  amount: number;
-  /**
-   * True if applied automatically by merchant rules (no code required).
-   */
-  automatic?: boolean;
-  /**
-   * Allocation method. 'each' = applied independently per item. 'across' = split proportionally by value.
-   */
-  method?: 'each' | 'across';
-  /**
-   * Stacking order for discount calculation. Lower numbers applied first (1 = first).
-   */
-  priority?: number;
-  /**
-   * Breakdown of where this discount was allocated. Sum of allocation amounts equals total amount.
-   */
-  allocations?: Allocation2[];
-  [k: string]: unknown;
-}
-/**
- * Discount codes input and applied discounts output.
- *
- * This interface was referenced by `DiscountExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "discounts_object".
- */
-export declare interface DiscountsObject1 {
-  /**
-   * Discount codes to apply. Case-insensitive. Replaces previously submitted codes. Send empty array to clear.
-   */
-  codes?: string[];
-  /**
-   * Discounts successfully applied (code-based and automatic).
-   */
-  applied?: AppliedDiscount2[];
-  [k: string]: unknown;
-}
-/**
- * Extends Checkout with discount code support, enabling agents to apply promotional, loyalty, referral, and other discount codes.
- */
-export declare interface DiscountExtensionResponse {
-  [k: string]: unknown;
-}
-/**
- * Breakdown of how a discount amount was allocated to a specific target.
- *
- * This interface was referenced by `DiscountExtensionResponse`'s JSON-Schema
- * via the `definition` "allocation".
- */
-export declare interface Allocation3 {
-  /**
-   * JSONPath to the allocation target (e.g., '$.line_items[0]', '$.totals.shipping').
-   */
-  path: string;
-  /**
-   * Amount allocated to this target in minor (cents) currency units.
-   */
-  amount: number;
-  [k: string]: unknown;
-}
-/**
- * A discount that was successfully applied.
- *
- * This interface was referenced by `DiscountExtensionResponse`'s JSON-Schema
- * via the `definition` "applied_discount".
- */
-export declare interface AppliedDiscount3 {
-  /**
-   * The discount code. Omitted for automatic discounts.
-   */
-  code?: string;
-  /**
-   * Human-readable discount name (e.g., 'Summer Sale 20% Off').
-   */
-  title: string;
-  /**
-   * Total discount amount in minor (cents) currency units.
-   */
-  amount: number;
-  /**
-   * True if applied automatically by merchant rules (no code required).
-   */
-  automatic?: boolean;
-  /**
-   * Allocation method. 'each' = applied independently per item. 'across' = split proportionally by value.
-   */
-  method?: 'each' | 'across';
-  /**
-   * Stacking order for discount calculation. Lower numbers applied first (1 = first).
-   */
-  priority?: number;
-  /**
-   * Breakdown of where this discount was allocated. Sum of allocation amounts equals total amount.
-   */
-  allocations?: Allocation3[];
-  [k: string]: unknown;
-}
-/**
- * Discount codes input and applied discounts output.
- *
- * This interface was referenced by `DiscountExtensionResponse`'s JSON-Schema
- * via the `definition` "discounts_object".
- */
-export declare interface DiscountsObject2 {
-  /**
-   * Discount codes to apply. Case-insensitive. Replaces previously submitted codes. Send empty array to clear.
-   */
-  codes?: string[];
-  /**
-   * Discounts successfully applied (code-based and automatic).
-   */
-  applied?: AppliedDiscount3[];
+  applied?: AppliedDiscount[];
   [k: string]: unknown;
 }
 /**
  * Extends Checkout with fulfillment support using methods, destinations, and groups.
  */
-export declare interface FulfillmentExtensionCompleteRequest {
+export declare interface FulfillmentExtension {
   [k: string]: unknown;
 }
 /**
  * A fulfillment option within a group (e.g., Standard Shipping $5, Express $15).
  *
- * This interface was referenced by `FulfillmentExtensionCompleteRequest`'s JSON-Schema
- * via the `definition` "fulfillment_option".
- *
- * This interface was referenced by `FulfillmentExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "fulfillment_option".
- *
- * This interface was referenced by `FulfillmentExtensionUpdateRequest`'s JSON-Schema
+ * This interface was referenced by `FulfillmentExtension`'s JSON-Schema
  * via the `definition` "fulfillment_option".
  */
-export declare interface FulfillmentOptionRequest {
-  [k: string]: unknown;
-}
-/**
- * A merchant-generated package/group of line items with fulfillment options.
- *
- * This interface was referenced by `FulfillmentExtensionCompleteRequest`'s JSON-Schema
- * via the `definition` "fulfillment_group".
- */
-export declare interface FulfillmentGroupCompleteRequest {
-  /**
-   * Group identifier for referencing merchant-generated groups in updates.
-   */
-  id: string;
-  /**
-   * ID of the selected fulfillment option for this group.
-   */
-  selected_option_id?: string | null;
-  [k: string]: unknown;
-}
-/**
- * A fulfillment method (shipping or pickup) with destinations and groups.
- *
- * This interface was referenced by `FulfillmentExtensionCompleteRequest`'s JSON-Schema
- * via the `definition` "fulfillment_method".
- */
-export declare interface FulfillmentMethodCompleteRequest {
-  /**
-   * Unique fulfillment method identifier.
-   */
-  id: string;
-  /**
-   * Fulfillment method type.
-   */
-  type: 'shipping' | 'pickup';
-  /**
-   * Line item IDs fulfilled via this method.
-   */
-  line_item_ids: string[];
-  /**
-   * Available destinations. For shipping: addresses. For pickup: retail locations.
-   */
-  destinations?: FulfillmentDestinationRequest[];
-  /**
-   * ID of the selected destination.
-   */
-  selected_destination_id?: string | null;
-  /**
-   * Fulfillment groups for selecting options. Agent sets selected_option_id on groups to choose shipping method.
-   */
-  groups?: FulfillmentGroupCompleteRequest[];
-  [k: string]: unknown;
-}
-/**
- * A pickup location (retail store, locker, etc.).
- */
-export declare interface RetailLocationRequest {
-  /**
-   * Location name (e.g., store name).
-   */
-  name: string;
-  address?: PostalAddress;
-  [k: string]: unknown;
-}
-/**
- * Inventory availability hint for a fulfillment method type.
- *
- * This interface was referenced by `FulfillmentExtensionCompleteRequest`'s JSON-Schema
- * via the `definition` "fulfillment_available_method".
- *
- * This interface was referenced by `FulfillmentExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "fulfillment_available_method".
- *
- * This interface was referenced by `FulfillmentExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "fulfillment_available_method".
- */
-export declare interface FulfillmentAvailableMethodRequest {
-  [k: string]: unknown;
-}
-/**
- * Container for fulfillment methods and availability.
- *
- * This interface was referenced by `FulfillmentExtensionCompleteRequest`'s JSON-Schema
- * via the `definition` "fulfillment".
- *
- * This interface was referenced by `FulfillmentExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "fulfillment".
- *
- * This interface was referenced by `FulfillmentExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "fulfillment".
- */
-export declare interface FulfillmentRequest {
-  /**
-   * Fulfillment methods for cart items.
-   */
-  methods?: FulfillmentMethodCreateRequest[];
-  [k: string]: unknown;
-}
-/**
- * A fulfillment method (shipping or pickup) with destinations and groups.
- *
- * This interface was referenced by `FulfillmentExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "fulfillment_method".
- */
-export declare interface FulfillmentMethodCreateRequest {
-  /**
-   * Fulfillment method type.
-   */
-  type: 'shipping' | 'pickup';
-  /**
-   * Line item IDs fulfilled via this method.
-   */
-  line_item_ids?: string[];
-  /**
-   * Available destinations. For shipping: addresses. For pickup: retail locations.
-   */
-  destinations?: FulfillmentDestinationRequest[];
-  /**
-   * ID of the selected destination.
-   */
-  selected_destination_id?: string | null;
-  /**
-   * Fulfillment groups for selecting options. Agent sets selected_option_id on groups to choose shipping method.
-   */
-  groups?: FulfillmentGroupCreateRequest[];
-  [k: string]: unknown;
-}
-/**
- * A merchant-generated package/group of line items with fulfillment options.
- *
- * This interface was referenced by `FulfillmentExtensionCreateRequest`'s JSON-Schema
- * via the `definition` "fulfillment_group".
- */
-export declare interface FulfillmentGroupCreateRequest {
-  /**
-   * ID of the selected fulfillment option for this group.
-   */
-  selected_option_id?: string | null;
-  [k: string]: unknown;
-}
-/**
- * Extends Checkout with fulfillment support using methods, destinations, and groups.
- */
-export declare interface FulfillmentExtensionCreateRequest {
-  [k: string]: unknown;
-}
-/**
- * Extends Checkout with fulfillment support using methods, destinations, and groups.
- */
-export declare interface FulfillmentExtensionUpdateRequest {
-  [k: string]: unknown;
-}
-/**
- * A merchant-generated package/group of line items with fulfillment options.
- *
- * This interface was referenced by `FulfillmentExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "fulfillment_group".
- */
-export declare interface FulfillmentGroupUpdateRequest {
-  /**
-   * Group identifier for referencing merchant-generated groups in updates.
-   */
-  id: string;
-  /**
-   * ID of the selected fulfillment option for this group.
-   */
-  selected_option_id?: string | null;
-  [k: string]: unknown;
-}
-/**
- * A fulfillment method (shipping or pickup) with destinations and groups.
- *
- * This interface was referenced by `FulfillmentExtensionUpdateRequest`'s JSON-Schema
- * via the `definition` "fulfillment_method".
- */
-export declare interface FulfillmentMethodUpdateRequest {
-  /**
-   * Unique fulfillment method identifier.
-   */
-  id: string;
-  /**
-   * Line item IDs fulfilled via this method.
-   */
-  line_item_ids: string[];
-  /**
-   * Available destinations. For shipping: addresses. For pickup: retail locations.
-   */
-  destinations?: FulfillmentDestinationRequest[];
-  /**
-   * ID of the selected destination.
-   */
-  selected_destination_id?: string | null;
-  /**
-   * Fulfillment groups for selecting options. Agent sets selected_option_id on groups to choose shipping method.
-   */
-  groups?: FulfillmentGroupUpdateRequest[];
-  [k: string]: unknown;
-}
-/**
- * Extends Checkout with fulfillment support using methods, destinations, and groups.
- */
-export declare interface FulfillmentExtensionResponse {
-  [k: string]: unknown;
-}
-/**
- * A fulfillment option within a group (e.g., Standard Shipping $5, Express $15).
- *
- * This interface was referenced by `FulfillmentExtensionResponse`'s JSON-Schema
- * via the `definition` "fulfillment_option".
- */
-export declare interface FulfillmentOptionResponse {
+export declare interface FulfillmentOption {
   /**
    * Unique fulfillment option identifier.
    */
@@ -1684,16 +952,16 @@ export declare interface FulfillmentOptionResponse {
   /**
    * Fulfillment option totals breakdown.
    */
-  totals: TotalResponse[];
+  totals: Total[];
   [k: string]: unknown;
 }
 /**
  * A merchant-generated package/group of line items with fulfillment options.
  *
- * This interface was referenced by `FulfillmentExtensionResponse`'s JSON-Schema
+ * This interface was referenced by `FulfillmentExtension`'s JSON-Schema
  * via the `definition` "fulfillment_group".
  */
-export declare interface FulfillmentGroupResponse {
+export declare interface FulfillmentGroup {
   /**
    * Group identifier for referencing merchant-generated groups in updates.
    */
@@ -1705,7 +973,7 @@ export declare interface FulfillmentGroupResponse {
   /**
    * Available fulfillment options for this group.
    */
-  options?: FulfillmentOptionResponse[];
+  options?: FulfillmentOption[];
   /**
    * ID of the selected fulfillment option for this group.
    */
@@ -1715,10 +983,10 @@ export declare interface FulfillmentGroupResponse {
 /**
  * A fulfillment method (shipping or pickup) with destinations and groups.
  *
- * This interface was referenced by `FulfillmentExtensionResponse`'s JSON-Schema
+ * This interface was referenced by `FulfillmentExtension`'s JSON-Schema
  * via the `definition` "fulfillment_method".
  */
-export declare interface FulfillmentMethodResponse {
+export declare interface FulfillmentMethod {
   /**
    * Unique fulfillment method identifier.
    */
@@ -1734,7 +1002,7 @@ export declare interface FulfillmentMethodResponse {
   /**
    * Available destinations. For shipping: addresses. For pickup: retail locations.
    */
-  destinations?: FulfillmentDestinationResponse[];
+  destinations?: FulfillmentDestination[];
   /**
    * ID of the selected destination.
    */
@@ -1742,13 +1010,13 @@ export declare interface FulfillmentMethodResponse {
   /**
    * Fulfillment groups for selecting options. Agent sets selected_option_id on groups to choose shipping method.
    */
-  groups?: FulfillmentGroupResponse[];
+  groups?: FulfillmentGroup[];
   [k: string]: unknown;
 }
 /**
  * A pickup location (retail store, locker, etc.).
  */
-export declare interface RetailLocationResponse {
+export declare interface RetailLocation {
   /**
    * Unique location identifier.
    */
@@ -1763,10 +1031,10 @@ export declare interface RetailLocationResponse {
 /**
  * Inventory availability hint for a fulfillment method type.
  *
- * This interface was referenced by `FulfillmentExtensionResponse`'s JSON-Schema
+ * This interface was referenced by `FulfillmentExtension`'s JSON-Schema
  * via the `definition` "fulfillment_available_method".
  */
-export declare interface FulfillmentAvailableMethodResponse {
+export declare interface FulfillmentAvailableMethod {
   /**
    * Fulfillment method type this availability applies to.
    */
@@ -1788,25 +1056,39 @@ export declare interface FulfillmentAvailableMethodResponse {
 /**
  * Container for fulfillment methods and availability.
  *
- * This interface was referenced by `FulfillmentExtensionResponse`'s JSON-Schema
+ * This interface was referenced by `FulfillmentExtension`'s JSON-Schema
  * via the `definition` "fulfillment".
  */
-export declare interface FulfillmentResponse {
+export declare interface Fulfillment {
   /**
    * Fulfillment methods for cart items.
    */
-  methods?: FulfillmentMethodResponse[];
+  methods?: FulfillmentMethod[];
   /**
    * Inventory availability hints.
    */
-  available_methods?: FulfillmentAvailableMethodResponse[];
+  available_methods?: FulfillmentAvailableMethod[];
+  [k: string]: unknown;
+}
+/**
+ * Container for fulfillment methods and availability.
+ */
+export declare interface Fulfillment1 {
+  /**
+   * Fulfillment methods for cart items.
+   */
+  methods?: FulfillmentMethod[];
+  /**
+   * Inventory availability hints.
+   */
+  available_methods?: FulfillmentAvailableMethod[];
   [k: string]: unknown;
 }
 /**
  * Order schema with immutable line items, buyer-facing fulfillment expectations, and append-only event logs.
  */
 export declare interface Order {
-  ucp: UCPOrderResponse;
+  ucp: UCPOrderResponseSchema;
   /**
    * Unique order identifier.
    */
@@ -1844,21 +1126,7 @@ export declare interface Order {
   /**
    * Different totals for the order.
    */
-  totals: TotalResponse[];
-  [k: string]: unknown;
-}
-/**
- * UCP metadata for order responses. No payment handlers needed post-purchase.
- */
-export declare interface UCPOrderResponse {
-  /**
-   * UCP protocol version in YYYY-MM-DD format.
-   */
-  version: string;
-  /**
-   * Active capabilities for this response.
-   */
-  capabilities: CapabilityResponse[];
+  totals: Total[];
   [k: string]: unknown;
 }
 export declare interface OrderLineItem {
@@ -1866,7 +1134,7 @@ export declare interface OrderLineItem {
    * Line item identifier.
    */
   id: string;
-  item: ItemResponse;
+  item: Item;
   /**
    * Quantity tracking. Both total and fulfilled are derived from events.
    */
@@ -1884,7 +1152,7 @@ export declare interface OrderLineItem {
   /**
    * Line item totals breakdown.
    */
-  totals: TotalResponse[];
+  totals: Total[];
   /**
    * Derived status: fulfilled if quantity.fulfilled == quantity.total, partial if quantity.fulfilled > 0, otherwise processing.
    */
@@ -2028,12 +1296,22 @@ export declare interface Adjustment {
  * Platform's order capability configuration.
  *
  * This interface was referenced by `Order`'s JSON-Schema
- * via the `definition` "platform_config".
+ * via the `definition` "platform_schema".
  */
-export declare interface PlatformOrderConfig {
+export declare interface PlatformOrderSchema {
   /**
    * URL where merchant sends order lifecycle events (webhooks).
    */
   webhook_url: string;
+  [k: string]: unknown;
+}
+/**
+ * Payment configuration containing handlers.
+ */
+export declare interface Payment1 {
+  /**
+   * The payment instruments available for this payment. Each instrument is associated with a specific handler via the handler_id field. Handlers can extend the base payment_instrument schema to add handler-specific fields.
+   */
+  instruments?: SelectedPaymentInstrument[];
   [k: string]: unknown;
 }


### PR DESCRIPTION
# Description

Adds a pre-commit hook to catch schema sync issues before commit, plus keeps CI validation as a safety net.

Right now you can edit source schemas, forget to run generate_schemas.py, and CI will pass. Then downstream tools break because spec/ is out of sync.

The pre-commit hook gives instant feedback (seconds instead of waiting for CI). But kept the CI check too in case someone bypasses pre-commit or doesn't have it installed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected, **including removal of schema files or fields**)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules