### PR TITLE
Docs/fix spec links and guides

### DIFF
--- a/docs/documentation/core-concepts.md
+++ b/docs/documentation/core-concepts.md
@@ -123,6 +123,13 @@ interact.
     *   *Examples:* REST API (primary), MCP (Model Context Protocol), A2A
         (Agent2Agent).
 
+## Related guides
+
+*   [Agent Checkout Quickstart](agent-checkout-quickstart.md)
+*   [Cart and Basket Building](cart-and-basket-building.md)
+*   [Loyalty and Member Benefits](loyalty-and-member-benefits.md)
+*   [Post-Order Management](post-order-management.md)
+
 ## Samples and SDKs for checkout integrations
 
 If you are building an agent or assistant that can checkout across any

--- a/docs/documentation/roadmap.md
+++ b/docs/documentation/roadmap.md
@@ -48,6 +48,14 @@ shopping experiences. Key upcoming initiatives include:
 *   **Native cross-sell and upsell modules:** Capabilities for businesses to
     provide personalized recommendations and upsells based on user context.
 
+If you want to explore these areas or contribute documentation, start with the
+guide stubs below:
+
+*   [Agent Checkout Quickstart](agent-checkout-quickstart.md)
+*   [Cart and Basket Building](cart-and-basket-building.md)
+*   [Loyalty and Member Benefits](loyalty-and-member-benefits.md)
+*   [Post-Order Management](post-order-management.md)
+
 ### Support for global markets
 
 We are building a scalable ecosystem that is inclusive of all business sizes and

--- a/docs/specification/ap2-mandates.md
+++ b/docs/specification/ap2-mandates.md
@@ -38,7 +38,7 @@ checkout session into a cryptographically bound agreement:
 intersection, the session is **Security Locked**. Neither party may revert to
 a standard (unprotected) checkout flow.
 
-![High-level AP2 flow sequence diagram](site:specification/images/ucp-ap2-checkout-flow.png)
+![High-level AP2 flow sequence diagram](images/ucp-ap2-checkout-flow.png)
 
 ### Design
 

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -30,7 +30,7 @@ PCI DSS compliant to support this Capability.
 
 **Flow overview**
 
-![High-level checkout flow sequence diagram](site:specification/images/ucp-checkout-flow.png)
+![High-level checkout flow sequence diagram](images/ucp-checkout-flow.png)
 
 **Payments**
 

--- a/docs/specification/embedded-checkout.md
+++ b/docs/specification/embedded-checkout.md
@@ -1141,7 +1141,7 @@ rather than attempting to merge the new data with existing state.
 ### Address Format
 
 The address object uses the UCP
-[PostalAddress](site:specification/checkout/#postal-address) format:
+[PostalAddress](checkout.md#postal-address) format:
 
 {{ schema_fields('postal_address', 'embedded-checkout') }}
 

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -576,7 +576,7 @@ splits responsibilities as follows:
 The payment process follows a standard 3-step lifecycle within UCP:
 **Negotiation**, **Acquisition**, and **Completion**.
 
-![High-level payment flow sequence diagram](site:specification/images/ucp-payment-flow.png)
+![High-level payment flow sequence diagram](images/ucp-payment-flow.png)
 
 1.  **Negotiation (Business → Platform):** The business analyzes the cart and advertises available `handlers`. This tells the platform *how* to pay (e.g., "Use this specific payment credential provider endpoint with this public key").
 2.  **Acquisition (Platform ↔ Payment Credential Provider):** The platform executes the handler's logic. This happens client-side or agent-side, directly with the payment credential provider (e.g., exchanging credentials for a network token). The business is not involved, ensuring raw data never touches the business's frontend API.
@@ -1064,7 +1064,7 @@ Both businesses and platforms declare a single version in their profiles:
 
 ### Version Negotiation
 
-![High-level resolution flow sequence diagram](site:specification/images/ucp-discovery-negotiation.png)
+![High-level resolution flow sequence diagram](images/ucp-discovery-negotiation.png)
 
 Businesses **MUST** validate the platform's version and determine compatibility:
 


### PR DESCRIPTION
## Summary
- Fix `site:` image links so spec diagrams render in GitHub previews.
- Fix the embedded checkout PostalAddress link to a local anchor.
- Add “Related guides” links in Core Concepts and Roadmap.

## Testing
- Not run (docs-only change)

## Additional Notes
- Focused on link correctness and discoverability; no spec changes.
