### PR TITLE
fix!: introduce config_schema to define config shapes for capabilities

### DIFF
--- a/docs/specification/examples/business-tokenizer-payment-handler.md
+++ b/docs/specification/examples/business-tokenizer-payment-handler.md
@@ -100,6 +100,7 @@ The configuration determines whether the Platform acts in "PSP Mode"
         "id": "processor_tokenizer",
         "name": "com.example.processor_tokenizer",
         "spec": "https://example.com/ucp/processor-tokenizer.json",
+        "config_schema": "https://example.com/ucp/processor-tokenizer/config.json",
         "instrument_schemas": [
            "https://ucp.dev/schemas/shopping/types/card_payment_instrument.json"
         ],
@@ -146,6 +147,7 @@ configuration.
   "id": "processor_tokenizer",
   "name": "com.example.processor_tokenizer",
   "spec": "https://example.com/ucp/processor-tokenizer.json",
+  "config_schema": "https://example.com/ucp/processor-tokenizer/config.json",
   "config": {
     "endpoint": "https://api.processor.com/v1/tokenize",
     "identity": {

--- a/docs/specification/fulfillment.md
+++ b/docs/specification/fulfillment.md
@@ -287,7 +287,12 @@ within each method.
 { "name": "dev.ucp.shopping.fulfillment", "version": "2026-01-11" }
 
 // Opt-in: business MAY return multiple groups per method
-{ "name": "dev.ucp.shopping.fulfillment", "version": "2026-01-11", "config": { "supports_multi_group": true } }
+{
+  "name": "dev.ucp.shopping.fulfillment",
+  "version": "2026-01-11",
+  "config_schema": "https://ucp.dev/schemas/shopping/types/platform_fulfillment_config.json",
+  "config": { "supports_multi_group": true }
+}
 ```
 
 ### Business Profile
@@ -302,6 +307,7 @@ Businesses declare what fulfillment configurations they support using
   "capabilities": [{
     "name": "dev.ucp.shopping.fulfillment",
     "version": "2026-01-11",
+    "config_schema": "https://ucp.dev/schemas/shopping/types/merchant_fulfillment_config.json",
     "config": {
       "allows_multi_destination": {
         "shipping": true

--- a/docs/specification/order.md
+++ b/docs/specification/order.md
@@ -281,6 +281,7 @@ platform's profile and uses it to send order lifecycle events.
 {
   "name": "dev.ucp.shopping.order",
   "version": "2026-01-11",
+  "config_schema": "https://ucp.dev/schemas/shopping/order.json#/$defs/platform_config",
   "config": {
     "webhook_url": "https://platform.example.com/webhooks/ucp/orders"
   }

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -360,6 +360,7 @@ example:
         "version": "2026-01-11",
         "spec": "https://ucp.dev/specification/order",
         "schema": "https://ucp.dev/schemas/shopping/order.json",
+        "config_schema": "https://ucp.dev/schemas/shopping/order.json#/$defs/platform_config",
         "config": {
           "webhook_url": "https://platform.example.com/webhooks/ucp/orders"
         }
@@ -730,7 +731,8 @@ request a challenge.
     "handlers": [{
       "id": "merchant_tokenizer",
       "name": "com.example.tokenizer",
-      // ... more handler required field
+      // ... more handler required fields
+      "config_schema": "https://example.com/ucp/tokenizer/config.json",
       "config": {
         "token_url": "https://api.psp.com/tokens",
         "public_key": "pk_123"

--- a/docs/specification/payment-handler-template.md
+++ b/docs/specification/payment-handler-template.md
@@ -182,6 +182,7 @@ array.
 {
   "id": "{handler_id}",
   "name": "{handler_name}",
+  "config_schema": "{config_schema_url}",
   "config": {
     // Business's configuration
   }

--- a/source/schemas/capability.json
+++ b/source/schemas/capability.json
@@ -25,16 +25,21 @@
         "schema": {
           "type": "string",
           "format": "uri",
-          "description": "URL to JSON Schema for this capability's payload."
+          "description": "URL to JSON Schema for types this capability defines or extends."
         },
         "extends": {
           "type": "string",
           "pattern": "^[a-z][a-z0-9]*(?:\\.[a-z][a-z0-9_]*)+$",
           "description": "Parent capability this extends. Present for extensions, absent for root capabilities."
         },
+        "config_schema": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to JSON Schema that validates the config object."
+        },
         "config": {
           "type": "object",
-          "description": "Capability-specific configuration (structure defined by each capability)."
+          "description": "Capability-specific configuration (structure defined by config_schema)."
         }
       }
     },
@@ -44,7 +49,12 @@
       "description": "Full capability declaration for discovery profiles. Includes spec/schema URLs for agent fetching.",
       "allOf": [
         {"$ref": "#/$defs/base"},
-        {"required": ["name", "version", "spec", "schema"]}
+        {
+          "required": ["name", "version", "spec", "schema"],
+          "dependentRequired": {
+            "config": ["config_schema"]
+          }
+        }
       ]
     },
 


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Adds `config_schema` field to capability declarations, allowing capabilities to expose the JSON Schema URL that validates their `config` object. Previously, capabilities could include a `config` object but there was no mechanism to expose or discover the schema for that config—unlike payment handlers which already had `config_schema`.

This change:
- Adds `config_schema` field to the capability base schema
- Adds `dependentRequired` constraint: if `config` is present, `config_schema` is required
- Updates all documentation examples to include `config_schema` where `config` is used
- Clarifies the `schema` field description to "URL to JSON Schema for types this capability defines or extends"

**Motivation:** The original capability schema had no way to expose config schemas, making it impossible for platforms to validate or understand capability-specific configuration with just schemas; they would have to crawl the spec. This mirrors the pattern already established in payment handlers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [ ] Documentation update

---
### Is this a Breaking Change or Removal?

- [x] **I have added `!` to my PR title** (e.g., `feat!: remove field`).
- [x] **I have added justification below.**
