### PR TITLE
fix: update ECP card instrument example objects

### DIFF
--- a/docs/specification/embedded-checkout.md
+++ b/docs/specification/embedded-checkout.md
@@ -25,7 +25,7 @@ buyer interacts with the checkout, and delegate key user actions such as address
 and payment selection. ECP is a transport binding (like REST)—it defines **how**
 to communicate, not **what** data exists.
 
-#### W3C Payment Request Conceptual Alignment
+### W3C Payment Request Conceptual Alignment
 
 ECP draws inspiration from the
 **[W3C Payment Request API](https://www.w3.org/TR/payment-request/){ target="_blank" }**,
@@ -506,24 +506,19 @@ information:**
     "result": {
         "checkout": {
             "payment": {
+                "selected_instrument_id": "payment_instrument_123",
+                // The instrument structure is defined by the handler's instrument schema
                 "instruments": [
                     {
-                        "type": "card",
-                        "status": "created",
-                        "handler_id": "merchant_psp_handler",
                         "id": "payment_instrument_123",
-                        "account_info": {
-                            "payment_account_reference": "V0010010000000000000000000000",
-                            "fingerprint": "xyz_123"
-                        },
-                        "display_data": {
-                            "summary": "Visa •••• 1111",
-                            "brand": "visa",
-                            "last_digits": "1111",
-                            "expiry_month": 12,
-                            "expiry_year": 2025,
-                            "card_art_url": "https://host.com/cards/visa-gold.png"
-                        }
+                        "handler_id": "merchant_psp_handler_123",
+                        "type": "card",
+                        "brand": "visa",
+                        "expiry_month": 12,
+                        "expiry_year": 2026,
+                        "last_digits": "1111",
+                        "rich_text_description": "Visa •••• 1111",
+                        "rich_card_art": "https://host.com/cards/visa-gold.png"
                     }
                 ]
             }
@@ -836,17 +831,18 @@ existing state.
         "checkout": {
             "payment": {
                 "selected_instrument_id": "payment_instrument_123",
+                // The instrument structure is defined by the handler's instrument schema
                 "instruments": [
                     {
                         "id": "payment_instrument_123",
-                        "handler_id": "merchant_psp_handler",
+                        "handler_id": "merchant_psp_handler_123",
                         "type": "card",
                         "brand": "visa",
-                        "last_digits": "1111",
                         "expiry_month": 12,
-                        "expiry_year": 2025,
-                        "summary": "Visa •••• 1111",
-                        "card_art_url": "https://host.com/cards/visa-gold.png"
+                        "expiry_year": 2026,
+                        "last_digits": "1111",
+                        "rich_text_description": "Visa •••• 1111",
+                        "rich_card_art": "https://host.com/cards/visa-gold.png"
                         // No `credential` yet; it will be attached in the `ec.payment.credential_request` response
                     }
                 ]
@@ -927,20 +923,22 @@ to merge the new data with existing state.
     "result": {
         "checkout": {
             "payment": {
+                "selected_instrument_id": "payment_instrument_123",
                 "instruments": [
-                    // Instrument schema is determined by the payment handler's instrument_schemas
                     {
                         "id": "payment_instrument_123",
-                        "handler_id": "gpay",
+                        "handler_id": "merchant_psp_handler_123",
                         "type": "card",
                         "brand": "visa",
-                        "last_digits": "1234",
                         "expiry_month": 12,
                         "expiry_year": 2026,
+                        "last_digits": "1111",
+                        "rich_text_description": "Visa •••• 1111",
+                        "rich_card_art": "https://host.com/cards/visa-gold.png",
                         // The credential structure is defined by the handler's instrument schema
                         "credential": {
-                            "type": "PAYMENT_GATEWAY",
-                            "token": "{\"id\": \"tok_123\", \"object\": \"token\"...}"
+                            "type": "token",
+                            "token": "tok_123"
                         }
                     }
                 ]


### PR DESCRIPTION
# Description

This PR matches a few card payment instrument examples in the ECP docs to the standard instrument shapes defined in https://ucp.dev/schemas/shopping/types/card_payment_instrument.json. While an instrument may have any schema — not just what we have defined as the "standard" shape — and many of the fields are optional, I felt it was nicer to show a more complete example of the spec'ed shape for a card instrument.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [x] Documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
