### PR TITLE
docs: Add Services section to Reference

### DIFF
--- a/docs/specification/reference.md
+++ b/docs/specification/reference.md
@@ -39,6 +39,16 @@ The top-level structure of a discovery document (`/.well-known/ucp`).
 
 {{ extension_schema_fields('ucp.json#/$defs/discovery_profile', 'reference') }}
 
+### Services
+Services define the API surface for a vertical (shopping, common, etc.) with
+transport bindings. Each service is keyed by its reverse-domain name
+(e.g., `dev.ucp.shopping`) in the discovery profile's `services` object.
+
+{{ extension_schema_fields('ucp.json#/$defs/services', 'reference') }}
+
+#### Service Schema
+{{ schema_fields('service_schema', 'reference') }}
+
 ### Checkout Response Metadata
 The `ucp` object included in checkout responses.
 

--- a/main.py
+++ b/main.py
@@ -49,6 +49,7 @@ def define_env(env):
     "spec/schemas/",
     "spec/schemas/shopping/",
     "spec/schemas/shopping/types/",
+    "spec/services/",
   ]
 
   def _load_json_file(entity_name):

--- a/source/schemas/ucp.json
+++ b/source/schemas/ucp.json
@@ -14,6 +14,11 @@
     "services": {
       "type": "object",
       "description": "Service definitions keyed by reverse-domain service name.",
+      "properties": {
+        "com.example.service": {
+          "$ref": "../services/service_schema.json"
+        }
+      },
       "additionalProperties": {"$ref": "../services/service_schema.json"}
     },
 

--- a/spec/schemas/ucp.json
+++ b/spec/schemas/ucp.json
@@ -12,6 +12,11 @@
     "services": {
       "type": "object",
       "description": "Service definitions keyed by reverse-domain service name.",
+      "properties": {
+        "com.example.service": {
+          "$ref": "../services/service_schema.json"
+        }
+      },
       "additionalProperties": {
         "$ref": "../services/service_schema.json"
       }


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

`Services` object schema was missing from the Reference page, making the link from `Discovery Profile` broken.
This PR adds it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [x] Documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
