### PR TITLE
Windows (PowerShell) setup instructions to the "Using a virtual environment (Recommended)" section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,3 +157,19 @@ $ source .ucp/bin/activate
 (.ucp) $ mkdocs serve --watch spec
 (.ucp) $ deactivate # when done
 ```
+
+**Windows (PowerShell):**
+
+```powershell
+$ python -m venv .ucp
+$ .\.ucp\Scripts\Activate.ps1
+(.ucp) $ pip install -r requirements-docs.txt
+(.ucp) $ mkdocs serve --watch spec
+(.ucp) $ deactivate # when done
+```
+
+**Note:** If you encounter execution policy errors when activating, you may need to run:
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+


### PR DESCRIPTION
## What Changed
Added Windows (PowerShell) setup instructions to the "Using a virtual environment (Recommended)" section in CONTRIBUTING.md.

## Why
The contributing guide previously only included Linux/macOS commands for setting up a virtual environment. This made it difficult for Windows users to get started with local development.

## Changes
- Added PowerShell commands for creating and activating virtual environments on Windows
- Included a helpful note about execution policy settings that may be needed for PowerShell activation
- Maintained consistency with the existing Linux example format

## Testing
- Verified PowerShell commands work on Windows 10/11
- Confirmed the execution policy note addresses common activation issues