### PR TITLE
style: Remove conflicting python lint rules and format with ruff

### DIFF
--- a/generate_schemas.py
+++ b/generate_schemas.py
@@ -130,9 +130,9 @@ def collect_annotated_schemas(source_dir: str) -> dict[str, bool]:
       data = schema_utils.load_json(filepath)
       if data and has_ucp_annotations(data):
         is_shared = (
-            data.get("ucp_shared_request", False)
-            if isinstance(data, dict)
-            else False
+          data.get("ucp_shared_request", False)
+          if isinstance(data, dict)
+          else False
         )
         annotated[os.path.normpath(filepath)] = is_shared
   return annotated
@@ -142,10 +142,10 @@ def collect_annotated_schemas(source_dir: str) -> dict[str, bool]:
 
 
 def rewrite_ref(
-    ref: str,
-    current_file: str,
-    annotated_schemas: dict[str, bool],
-    operation: Optional[str],
+  ref: str,
+  current_file: str,
+  annotated_schemas: dict[str, bool],
+  operation: Optional[str],
 ) -> str:
   """Rewrites $ref if target is an annotated schema.
 
@@ -188,11 +188,11 @@ def rewrite_ref(
 
 
 def transform_schema(
-    data: Any,
-    operation: Optional[str],
-    current_file: str,
-    annotated_schemas: dict[str, bool],
-    title_suffix: str = "",
+  data: Any,
+  operation: Optional[str],
+  current_file: str,
+  annotated_schemas: dict[str, bool],
+  title_suffix: str = "",
 ) -> Any:
   """Transforms schema for a specific operation (or response if None).
 
@@ -216,7 +216,7 @@ def transform_schema(
     # Handle $ref rewriting
     if "$ref" in data:
       new_ref = rewrite_ref(
-          data["$ref"], current_file, annotated_schemas, operation
+        data["$ref"], current_file, annotated_schemas, operation
       )
       result = {}
       for k, v in data.items():
@@ -224,17 +224,17 @@ def transform_schema(
           result[k] = new_ref
         elif k not in UCP_ANNOTATIONS:
           result[k] = transform_schema(
-              v, operation, current_file, annotated_schemas, title_suffix
+            v, operation, current_file, annotated_schemas, title_suffix
           )
       return result
 
     if "properties" not in data:
       result = {
-          k: transform_schema(
-              v, operation, current_file, annotated_schemas, title_suffix
-          )
-          for k, v in data.items()
-          if k not in UCP_ANNOTATIONS
+        k: transform_schema(
+          v, operation, current_file, annotated_schemas, title_suffix
+        )
+        for k, v in data.items()
+        if k not in UCP_ANNOTATIONS
       }
       # Update title if we are in a definition context (heuristic: has title and
       # type/properties or is inside $defs) Actually, we just update any title
@@ -255,7 +255,7 @@ def transform_schema(
         continue
 
       new_props[name] = transform_schema(
-          field, operation, current_file, annotated_schemas, title_suffix
+        field, operation, current_file, annotated_schemas, title_suffix
       )
 
       if visibility == "required":
@@ -276,7 +276,7 @@ def transform_schema(
           result["required"] = new_required
       else:
         result[k] = transform_schema(
-            v, operation, current_file, annotated_schemas, title_suffix
+          v, operation, current_file, annotated_schemas, title_suffix
         )
 
     if "title" in result and title_suffix:
@@ -286,10 +286,10 @@ def transform_schema(
 
   if isinstance(data, list):
     return [
-        transform_schema(
-            item, operation, current_file, annotated_schemas, title_suffix
-        )
-        for item in data
+      transform_schema(
+        item, operation, current_file, annotated_schemas, title_suffix
+      )
+      for item in data
     ]
 
   return data
@@ -303,10 +303,10 @@ def write_json(data: dict[str, Any], path: str) -> None:
 
 
 def process_schema(
-    source_path: str,
-    dest_dir: str,
-    rel_path: str,
-    annotated_schemas: dict[str, bool],
+  source_path: str,
+  dest_dir: str,
+  rel_path: str,
+  annotated_schemas: dict[str, bool],
 ) -> tuple[list[str], list[str]]:
   """Processes schema file. Returns (generated_paths, validation_errors)."""
   data = schema_utils.load_json(source_path)
@@ -333,7 +333,7 @@ def process_schema(
       # Use 'create' as representative operation for shared request
       suffix = " Request"
       transformed = transform_schema(
-          copy.deepcopy(data), "create", source_path, annotated_schemas, suffix
+        copy.deepcopy(data), "create", source_path, annotated_schemas, suffix
       )
       if "$id" in transformed:
         transformed["$id"] = transformed["$id"].replace(".json", "_req.json")
@@ -346,11 +346,11 @@ def process_schema(
         out_path = os.path.join(dest_dir, dir_path, out_name)
         suffix = f" {op.capitalize()} Request"
         transformed = transform_schema(
-            copy.deepcopy(data), op, source_path, annotated_schemas, suffix
+          copy.deepcopy(data), op, source_path, annotated_schemas, suffix
         )
         if "$id" in transformed:
           transformed["$id"] = transformed["$id"].replace(
-              ".json", f".{op}_req.json"
+            ".json", f".{op}_req.json"
           )
         write_json(transformed, out_path)
         generated.append(os.path.join(dir_path, out_name))
@@ -360,7 +360,7 @@ def process_schema(
     out_path = os.path.join(dest_dir, dir_path, out_name)
     suffix = " Response"
     transformed = transform_schema(
-        data, None, source_path, annotated_schemas, suffix
+      data, None, source_path, annotated_schemas, suffix
     )
     write_json(transformed, out_path)
     generated.append(os.path.join(dir_path, out_name))
@@ -368,7 +368,7 @@ def process_schema(
     # Non-annotated: copy with refs potentially rewritten
     out_path = os.path.join(dest_dir, rel_path)
     transformed = transform_schema(
-        data, None, source_path, annotated_schemas, ""
+      data, None, source_path, annotated_schemas, ""
     )
     write_json(transformed, out_path)
     generated.append(rel_path)
@@ -377,7 +377,7 @@ def process_schema(
 
 
 def process_openapi(
-    source_path: str, dest_path: str, annotated_schemas: dict[str, bool]
+  source_path: str, dest_path: str, annotated_schemas: dict[str, bool]
 ) -> None:
   """Splits components and converts refs. Preserves absolute URLs if present."""
   spec = schema_utils.load_json(source_path)
@@ -423,7 +423,7 @@ def process_openapi(
         req_comp = f"{name}_request"
         schemas[req_comp] = {"$ref": f"{base_ref}_req.json"}
         req_refs["create"] = req_refs["update"] = (
-            f"#/components/schemas/{req_comp}"
+          f"#/components/schemas/{req_comp}"
         )
       else:
         create_comp = f"{name}_create_request"
@@ -437,8 +437,8 @@ def process_openapi(
 
       # 4. Map Old -> New and Delete
       ref_map[f"#/components/schemas/{name}"] = {
-          "response": f"#/components/schemas/{resp_comp}",
-          **req_refs,
+        "response": f"#/components/schemas/{resp_comp}",
+        **req_refs,
       }
       del schemas[name]
 
@@ -507,7 +507,7 @@ def rewrite_refs_for_ecp(data: Any, annotated_schemas: set[str]) -> Any:
               anchor_part = "#" + anchor_part
             # Add _resp suffix if schema has ucp annotations
             if schema_path in annotated_schemas and schema_path.endswith(
-                ".json"
+              ".json"
             ):
               schema_path = schema_path[:-5] + "_resp.json"
             result[k] = f"../../schemas/shopping/{schema_path}{anchor_part}"
@@ -524,12 +524,12 @@ def rewrite_refs_for_ecp(data: Any, annotated_schemas: set[str]) -> Any:
 
 
 def transform_ecp_method(
-    method: dict[str, Any], annotated_schemas: set[str]
+  method: dict[str, Any], annotated_schemas: set[str]
 ) -> dict[str, Any]:
   """Transform an ECP method definition to OpenRPC format."""
   openrpc_method = {
-      "name": method["name"],
-      "summary": method.get("summary", ""),
+    "name": method["name"],
+    "summary": method.get("summary", ""),
   }
   if method.get("description"):
     openrpc_method["description"] = method["description"]
@@ -538,9 +538,9 @@ def transform_ecp_method(
     openrpc_method["params"] = []
     for param in method["params"]:
       openrpc_param = {
-          "name": param["name"],
-          "required": param.get("required", False),
-          "schema": rewrite_refs_for_ecp(param["schema"], annotated_schemas),
+        "name": param["name"],
+        "required": param.get("required", False),
+        "schema": rewrite_refs_for_ecp(param["schema"], annotated_schemas),
       }
       if "description" in param.get("schema", {}):
         openrpc_param["description"] = param["schema"]["description"]
@@ -549,8 +549,8 @@ def transform_ecp_method(
   if "result" in method:
     result = method["result"]
     openrpc_method["result"] = {
-        "name": result.get("name", "result"),
-        "schema": rewrite_refs_for_ecp(result["schema"], annotated_schemas),
+      "name": result.get("name", "result"),
+      "schema": rewrite_refs_for_ecp(result["schema"], annotated_schemas),
     }
 
   if "errors" in method:
@@ -569,8 +569,8 @@ def generate_ecp_spec(annotated_schemas: set[str]) -> int:
     number of files generated.
   """
   print(
-      f"\n{schema_utils.Colors.CYAN}Pass 3: Generating ECP OpenRPC"
-      f" spec...{schema_utils.Colors.RESET}\n"
+    f"\n{schema_utils.Colors.CYAN}Pass 3: Generating ECP OpenRPC"
+    f" spec...{schema_utils.Colors.RESET}\n"
   )
 
   methods = []
@@ -620,22 +620,22 @@ def generate_ecp_spec(annotated_schemas: set[str]) -> int:
 
   # Generate OpenRPC spec
   spec = {
-      "openrpc": "1.3.2",
-      "info": {
-          "title": ep_title,
-          "description": ep_description,
-          "version": ECP_VERSION,
-      },
-      "x-delegations": sorted(set(delegations)),
-      "methods": methods,
+    "openrpc": "1.3.2",
+    "info": {
+      "title": ep_title,
+      "description": ep_description,
+      "version": ECP_VERSION,
+    },
+    "x-delegations": sorted(set(delegations)),
+    "methods": methods,
   }
 
   out_path = os.path.join(SPEC_DIR, "services/shopping/embedded.openrpc.json")
   os.makedirs(os.path.dirname(out_path), exist_ok=True)
   write_json(spec, out_path)
   print(
-      f"{schema_utils.Colors.GREEN}✓{schema_utils.Colors.RESET}"
-      " services/shopping/embedded.openrpc.json"
+    f"{schema_utils.Colors.GREEN}✓{schema_utils.Colors.RESET}"
+    " services/shopping/embedded.openrpc.json"
   )
 
   return 1
@@ -644,30 +644,30 @@ def generate_ecp_spec(annotated_schemas: set[str]) -> int:
 def main() -> None:
   if not os.path.exists(SOURCE_DIR):
     print(
-        f"{schema_utils.Colors.RED}Error: '{SOURCE_DIR}' not"
-        f" found.{schema_utils.Colors.RESET}"
+      f"{schema_utils.Colors.RED}Error: '{SOURCE_DIR}' not"
+      f" found.{schema_utils.Colors.RESET}"
     )
     sys.exit(1)
 
   # Pass 1: Collect annotated schemas
   print(
-      f"{schema_utils.Colors.CYAN}Pass 1: Scanning for annotated"
-      f" schemas...{schema_utils.Colors.RESET}"
+    f"{schema_utils.Colors.CYAN}Pass 1: Scanning for annotated"
+    f" schemas...{schema_utils.Colors.RESET}"
   )
   annotated_schemas = collect_annotated_schemas(SOURCE_DIR)
   print(f"  Found {len(annotated_schemas)} annotated schema(s)\n")
 
   if os.path.exists(SPEC_DIR):
     print(
-        f"{schema_utils.Colors.YELLOW}Removing existing {SPEC_DIR}/"
-        f" ...{schema_utils.Colors.RESET}"
+      f"{schema_utils.Colors.YELLOW}Removing existing {SPEC_DIR}/"
+      f" ...{schema_utils.Colors.RESET}"
     )
     shutil.rmtree(SPEC_DIR)
 
   # Pass 2: Transform and generate
   print(
-      f"{schema_utils.Colors.CYAN}Pass 2: Generating {SOURCE_DIR}/ ->"
-      f" {SPEC_DIR}/{schema_utils.Colors.RESET}\n"
+    f"{schema_utils.Colors.CYAN}Pass 2: Generating {SOURCE_DIR}/ ->"
+    f" {SPEC_DIR}/{schema_utils.Colors.RESET}\n"
   )
 
   generated_count = 0
@@ -685,11 +685,10 @@ def main() -> None:
       if filename == "openapi.json" and rel_path.startswith("services/"):
         dest_rel = os.path.join(os.path.dirname(rel_path), "rest.openapi.json")
         process_openapi(
-            source_path, os.path.join(SPEC_DIR, dest_rel), annotated_schemas
+          source_path, os.path.join(SPEC_DIR, dest_rel), annotated_schemas
         )
         print(
-            f"{schema_utils.Colors.GREEN}✓{schema_utils.Colors.RESET}"
-            f" {dest_rel}"
+          f"{schema_utils.Colors.GREEN}✓{schema_utils.Colors.RESET} {dest_rel}"
         )
         generated_count += 1
 
@@ -700,7 +699,7 @@ def main() -> None:
       # 3. Standard Handling: JSON Schemas (The Generator)
       elif filename.endswith(".json") and filename != "openrpc.json":
         generated, errors = process_schema(
-            source_path, SPEC_DIR, rel_path, annotated_schemas
+          source_path, SPEC_DIR, rel_path, annotated_schemas
         )
         for g in generated:
           print(f"{schema_utils.Colors.GREEN}✓{schema_utils.Colors.RESET} {g}")
@@ -710,7 +709,7 @@ def main() -> None:
       # 4. Fallback: Copy other files (e.g. openrpc.json)
       else:
         dest_name = (
-            "mcp.openrpc.json" if filename == "openrpc.json" else filename
+          "mcp.openrpc.json" if filename == "openrpc.json" else filename
         )
         dest_rel_path = os.path.join(os.path.dirname(rel_path), dest_name)
         dest_path = os.path.join(SPEC_DIR, os.path.dirname(rel_path), dest_name)
@@ -718,8 +717,8 @@ def main() -> None:
           os.makedirs(os.path.dirname(dest_path), exist_ok=True)
           shutil.copy2(source_path, dest_path)
           print(
-              f"{schema_utils.Colors.GREEN}✓{schema_utils.Colors.RESET}"
-              f" {dest_rel_path}"
+            f"{schema_utils.Colors.GREEN}✓{schema_utils.Colors.RESET}"
+            f" {dest_rel_path}"
           )
           generated_count += 1
         except OSError as e:
@@ -742,14 +741,14 @@ def main() -> None:
     for err in all_errors:
       print(f"  {schema_utils.Colors.RED}✗{schema_utils.Colors.RESET} {err}")
     print(
-        f"\n{schema_utils.Colors.RED}🚨 Failed with"
-        f" {len(all_errors)} errors.{schema_utils.Colors.RESET}"
+      f"\n{schema_utils.Colors.RED}🚨 Failed with"
+      f" {len(all_errors)} errors.{schema_utils.Colors.RESET}"
     )
     sys.exit(1)
   else:
     print(
-        f"{schema_utils.Colors.GREEN}✅ Generated"
-        f" {generated_count} files.{schema_utils.Colors.RESET}"
+      f"{schema_utils.Colors.GREEN}✅ Generated"
+      f" {generated_count} files.{schema_utils.Colors.RESET}"
     )
     sys.exit(0)
 

--- a/main.py
+++ b/main.py
@@ -42,20 +42,20 @@ def define_env(env):
   """
 
   # --- CONFIGURATION ---
-  openapi_dir = 'spec/services/shopping/'
+  openapi_dir = "spec/services/shopping/"
   schemas_dirs = [
-      'spec/handlers/google_pay/',
-      'spec/schemas/',
-      'spec/schemas/shopping/',
-      'spec/schemas/shopping/types/',
+    "spec/handlers/google_pay/",
+    "spec/schemas/",
+    "spec/schemas/shopping/",
+    "spec/schemas/shopping/types/",
   ]
 
   def _load_json_file(entity_name):
     """Helper to try loading a JSON file from the configured directories."""
     for schemas_dir in schemas_dirs:
-      full_path = schemas_dir + entity_name + '.json'
+      full_path = schemas_dir + entity_name + ".json"
       try:
-        with open(full_path, 'r', encoding='utf-8') as f:
+        with open(full_path, "r", encoding="utf-8") as f:
           return json.load(f)
       except FileNotFoundError:
         continue
@@ -74,22 +74,22 @@ def define_env(env):
     if not context:
       return _load_json_file(entity_name)
 
-    io_type = context.get('io_type')
-    op_id = context.get('operation_id', '').lower()
+    io_type = context.get("io_type")
+    op_id = context.get("operation_id", "").lower()
 
     variant_name = None
 
     # 1. Determine the target filename based on IO type and Operation ID
-    if io_type == 'response':
+    if io_type == "response":
       # e.g., checkout -> checkout_resp
-      variant_name = f'{entity_name}_resp'
+      variant_name = f"{entity_name}_resp"
 
-    elif io_type == 'request':
+    elif io_type == "request":
       # Heuristic: Determine if this is a create or update operation
-      if 'create' in op_id:
-        variant_name = f'{entity_name}.create_req'
-      elif 'update' in op_id or 'patch' in op_id:
-        variant_name = f'{entity_name}.update_req'
+      if "create" in op_id:
+        variant_name = f"{entity_name}.create_req"
+      elif "update" in op_id or "patch" in op_id:
+        variant_name = f"{entity_name}.update_req"
 
     # 2. Try to load the variant
     if variant_name:
@@ -115,69 +115,69 @@ def define_env(env):
     # Refer to checkout.json for ap2-mandates.json entities that are not
     # explicitly defined in ap2-mandates.json.
     if (
-        spec_file_name == 'ap2-mandates'
-        and 'ap2_mandate' not in ref_string
-        and not ref_string.startswith('#')
+      spec_file_name == "ap2-mandates"
+      and "ap2_mandate" not in ref_string
+      and not ref_string.startswith("#")
     ):
-      spec_file_name = 'checkout'
+      spec_file_name = "checkout"
 
     filename = os.path.basename(ref_string)
 
     # Check if this reference comes from the core UCP schema
-    is_ucp = 'ucp.json' in ref_string
+    is_ucp = "ucp.json" in ref_string
 
     # 1. Clean extension and paths
-    raw_name = filename.replace('.json', '')
-    if filename.endswith('#/schema'):
-      raw_name = raw_name.replace('#/schema', '')
+    raw_name = filename.replace(".json", "")
+    if filename.endswith("#/schema"):
+      raw_name = raw_name.replace("#/schema", "")
 
     # 2. Generate Link Text (Visual)
     # e.g. "checkout_response" -> "Checkout Response"
     link_text = (
-        raw_name.replace('_', ' ').replace('.', ' ').replace('-', ' ').title()
+      raw_name.replace("_", " ").replace(".", " ").replace("-", " ").title()
     )
-    if link_text.endswith('Resp'):
-      link_text = link_text.replace('Resp', 'Response')
-    elif link_text.endswith('Req'):
-      link_text = link_text.replace('Req', 'Request')
+    if link_text.endswith("Resp"):
+      link_text = link_text.replace("Resp", "Response")
+    elif link_text.endswith("Req"):
+      link_text = link_text.replace("Req", "Request")
 
     # FIX: Explicitly add UCP prefix for core UCP definitions if missing
-    if is_ucp and 'Ucp' not in link_text and 'UCP' not in link_text:
-      link_text = f'UCP {link_text}'
+    if is_ucp and "Ucp" not in link_text and "UCP" not in link_text:
+      link_text = f"UCP {link_text}"
 
     # 3. Generate Anchor (Target)
     # We want "types/line_item.create_req.json" -> "#line-item-create_request"
     # This matches the pattern: "Line Item" H3 -> "Create Request" H4
 
     # 3. Generate Anchor (Target)
-    parts = raw_name.split('.')
+    parts = raw_name.split(".")
     base_entity = parts[0]
 
-    anchor_name = base_entity.replace('_', '-')
+    anchor_name = base_entity.replace("_", "-")
 
     if len(parts) > 1:
       variant = parts[1]
       variant_expanded = (
-          variant.replace('create_req', 'create-request')
-          .replace('update_req', 'update-request')
-          .replace('resp', 'response')
-          .replace('-', ' ')
+        variant.replace("create_req", "create-request")
+        .replace("update_req", "update-request")
+        .replace("resp", "response")
+        .replace("-", " ")
       )
-      anchor_name = f'{anchor_name}-{variant_expanded}'.replace(' ', '-')
-    elif raw_name.endswith('_resp'):
-      anchor_name = raw_name.replace('_', '-').replace('-resp', '-response')
-    elif raw_name.endswith('_req'):
-      anchor_name = raw_name.replace('_', '-').replace('-req', '-request')
+      anchor_name = f"{anchor_name}-{variant_expanded}".replace(" ", "-")
+    elif raw_name.endswith("_resp"):
+      anchor_name = raw_name.replace("_", "-").replace("-resp", "-response")
+    elif raw_name.endswith("_req"):
+      anchor_name = raw_name.replace("_", "-").replace("-req", "-request")
 
     # FIX: Ensure anchor starts with ucp- for UCP definitions
-    if is_ucp and not anchor_name.startswith('ucp-'):
-      anchor_name = f'ucp-{anchor_name}'
+    if is_ucp and not anchor_name.startswith("ucp-"):
+      anchor_name = f"ucp-{anchor_name}"
 
-    base = f'site:specification/{spec_file_name}/#'
-    return f'[{link_text}]({base}{anchor_name.lower()})'
+    base = f"site:specification/{spec_file_name}/#"
+    return f"[{link_text}]({base}{anchor_name.lower()})"
 
   def _render_table_from_ref(
-      properties_ref, required_list, spec_file_name, context=None
+    properties_ref, required_list, spec_file_name, context=None
   ):
     """Helper function to further inline fields from a given list of properties.
 
@@ -196,37 +196,37 @@ def define_env(env):
     """
 
     # Clean up ref to get entity name
-    ref_clean = properties_ref.split('#')[0]
-    if ref_clean.endswith('/schema'):
-      ref_clean = ref_clean.replace('/schema', '')
+    ref_clean = properties_ref.split("#")[0]
+    if ref_clean.endswith("/schema"):
+      ref_clean = ref_clean.replace("/schema", "")
 
-    ref_entity_name = os.path.basename(ref_clean).replace('.json', '')
+    ref_entity_name = os.path.basename(ref_clean).replace(".json", "")
 
     # LOAD DATA WITH CONTEXT
     ref_schema_data = _load_schema_variant(ref_entity_name, context)
 
     if ref_schema_data:
       # Handle embedded anchors (e.g. file.json#/$defs/Something)
-      if '#' in properties_ref and '$defs' in properties_ref:
-        def_name = properties_ref.split('/')[-1]
-        ref_schema_data = ref_schema_data.get('$defs', {}).get(def_name)
+      if "#" in properties_ref and "$defs" in properties_ref:
+        def_name = properties_ref.split("/")[-1]
+        ref_schema_data = ref_schema_data.get("$defs", {}).get(def_name)
 
       if ref_schema_data and not any(
-          key in ref_schema_data for key in ('properties', 'allOf', '$ref')
+        key in ref_schema_data for key in ("properties", "allOf", "$ref")
       ):
-        ref_schema_data = ref_schema_data.get('schema', ref_schema_data)
+        ref_schema_data = ref_schema_data.get("schema", ref_schema_data)
 
       return _render_table_from_schema(
-          ref_schema_data, spec_file_name, False, required_list, context
+        ref_schema_data, spec_file_name, False, required_list, context
       )
     else:
       # If purely external and not found locally
-      if properties_ref.startswith('http'):
-        return f'_See [{properties_ref}]({properties_ref})_'
-      return ''
+      if properties_ref.startswith("http"):
+        return f"_See [{properties_ref}]({properties_ref})_"
+      return ""
 
   def _render_embedded_table(
-      properties_list, required_list, spec_file_name, context=None
+    properties_list, required_list, spec_file_name, context=None
   ):
     """Helper function to further inline fields from a given list of properties.
 
@@ -244,43 +244,43 @@ def define_env(env):
       or a message indicating why a table could not be rendered.
     """
     if not properties_list:
-      return '_No content fields defined._'
+      return "_No content fields defined._"
 
     # Special handling for capability.
     if (
-        len(properties_list) == 2
-        and len(properties_list[1].keys()) == 1
-        and 'required' in properties_list[1].keys()
+      len(properties_list) == 2
+      and len(properties_list[1].keys()) == 1
+      and "required" in properties_list[1].keys()
     ):
       return _read_schema_from_defs(
-          'capability.json' + properties_list[0].get('$ref', ''),
-          spec_file_name,
-          False,
-          properties_list[1].get('required', []),
+        "capability.json" + properties_list[0].get("$ref", ""),
+        spec_file_name,
+        False,
+        properties_list[1].get("required", []),
       )
 
     md = []
     for properties in properties_list:
-      if len(properties) == 1 and '$ref' in properties.keys():
+      if len(properties) == 1 and "$ref" in properties.keys():
         embedded_data = _render_table_from_ref(
-            properties['$ref'], required_list, spec_file_name, context
+          properties["$ref"], required_list, spec_file_name, context
         )
         md.append(embedded_data)
         continue
       md.append(
-          _render_table_from_schema(
-              properties, spec_file_name, False, required_list, context
-          )
+        _render_table_from_schema(
+          properties, spec_file_name, False, required_list, context
+        )
       )
 
-    return '\n'.join(md)
+    return "\n".join(md)
 
   def _render_table_from_schema(
-      schema_data,
-      spec_file_name,
-      need_header=True,
-      parent_required_list=None,
-      context=None,
+    schema_data,
+    spec_file_name,
+    need_header=True,
+    parent_required_list=None,
+    context=None,
   ):
     """Shared logic to render a Markdown table from a schema dictionary.
 
@@ -302,30 +302,30 @@ def define_env(env):
       or a message indicating why a table could not be rendered.
     """
     if not schema_data:
-      return '_No content fields defined._'
+      return "_No content fields defined._"
 
     # If schema is ONLY a oneOf, render as prose instead of table
     if (
-        'oneOf' in schema_data
-        and not schema_data.get('properties')
-        and not schema_data.get('allOf')
-        and not schema_data.get('$ref')
+      "oneOf" in schema_data
+      and not schema_data.get("properties")
+      and not schema_data.get("allOf")
+      and not schema_data.get("$ref")
     ):
       links = []
-      for item in schema_data['oneOf']:
-        if '$ref' in item:
-          links.append(create_link(item['$ref'], spec_file_name))
-        elif item.get('type'):
+      for item in schema_data["oneOf"]:
+        if "$ref" in item:
+          links.append(create_link(item["$ref"], spec_file_name))
+        elif item.get("type"):
           links.append(f"`{item.get('type')}`")
       if links:
         return (
-            '\nThis object MUST be one of the following types: '
-            + ', '.join(links)
-            + '.\n'
+          "\nThis object MUST be one of the following types: "
+          + ", ".join(links)
+          + ".\n"
         )
 
-    properties = schema_data.get('properties', {})
-    required_list = schema_data.get('required', [])
+    properties = schema_data.get("properties", {})
+    required_list = schema_data.get("required", [])
 
     if parent_required_list:
       # Used for embedded schemas, we will only enforce the uppermost level
@@ -333,138 +333,138 @@ def define_env(env):
       required_list = parent_required_list
 
     if (
-        not properties
-        and 'allOf' not in schema_data
-        and 'oneOf' not in schema_data
-        and '$ref' not in schema_data
+      not properties
+      and "allOf" not in schema_data
+      and "oneOf" not in schema_data
+      and "$ref" not in schema_data
     ):
       # Fallback for scalar schemas (Enums, Strings with patterns, etc.)
-      s_type = schema_data.get('type')
-      enum_val = schema_data.get('enum')
-      pattern_val = schema_data.get('pattern')
+      s_type = schema_data.get("type")
+      enum_val = schema_data.get("enum")
+      pattern_val = schema_data.get("pattern")
 
       if s_type or enum_val:
-        desc = schema_data.get('description', '')
+        desc = schema_data.get("description", "")
         if pattern_val:
-          desc += f'\n\n**Pattern:** `{pattern_val}`'
+          desc += f"\n\n**Pattern:** `{pattern_val}`"
         if enum_val:
-          formatted = ', '.join([f'`{v}`' for v in enum_val])
-          desc += f'\n\n**Enum:** {formatted}'
+          formatted = ", ".join([f"`{v}`" for v in enum_val])
+          desc += f"\n\n**Enum:** {formatted}"
         return desc
 
-      return '_No properties defined._'
+      return "_No properties defined._"
 
     md = []
     if need_header:
-      md = ['| Name | Type | Required | Description |']
-      md.append('| :--- | :--- | :--- | :--- |')
+      md = ["| Name | Type | Required | Description |"]
+      md.append("| :--- | :--- | :--- | :--- |")
 
-    if 'allOf' in properties.keys():
+    if "allOf" in properties.keys():
       md.append(
-          _render_embedded_table(
-              properties.get('allOf', []),
-              required_list,
-              spec_file_name,
-              context,
-          )
+        _render_embedded_table(
+          properties.get("allOf", []),
+          required_list,
+          spec_file_name,
+          context,
+        )
       )
-    elif 'allOf' in schema_data:
+    elif "allOf" in schema_data:
       md.append(
-          _render_embedded_table(
-              schema_data.get('allOf', []),
-              required_list,
-              spec_file_name,
-              context,
-          )
+        _render_embedded_table(
+          schema_data.get("allOf", []),
+          required_list,
+          spec_file_name,
+          context,
+        )
       )
-    elif '$ref' in schema_data:
+    elif "$ref" in schema_data:
       md.append(
-          _render_table_from_ref(
-              schema_data.get('$ref'), required_list, spec_file_name, context
-          )
+        _render_table_from_ref(
+          schema_data.get("$ref"), required_list, spec_file_name, context
+        )
       )
     else:
       for field_name, details in properties.items():
-        if field_name == '$ref':
+        if field_name == "$ref":
           md.append(
-              _render_table_from_ref(
-                  details, required_list, spec_file_name, context
-              )
+            _render_table_from_ref(
+              details, required_list, spec_file_name, context
+            )
           )
           continue
 
-        f_type = details.get('type', 'any')
-        ref = details.get('$ref')
+        f_type = details.get("type", "any")
+        ref = details.get("$ref")
 
         # Check for Array specific logic
-        items = details.get('items', {})
-        items_ref = items.get('$ref')
+        items = details.get("items", {})
+        items_ref = items.get("$ref")
 
         # Special handling for UCP version
         version_data = None
-        if ref and ref.endswith('#/$defs/version'):
+        if ref and ref.endswith("#/$defs/version"):
           try:
-            with open('spec/schemas/ucp.json', 'r', encoding='utf-8') as f:
+            with open("spec/schemas/ucp.json", "r", encoding="utf-8") as f:
               data = json.load(f)
-              version_data = data.get('$defs', {}).get('version', {})
+              version_data = data.get("$defs", {}).get("version", {})
           except json.JSONDecodeError as e:
             print(f"**Error loading schema {'ucp.json' + ref}':** {e}")
 
         # --- Logic to determine Display Type ---
-        if 'oneOf' in details.keys():
+        if "oneOf" in details.keys():
           # List of values embedded within an oneOf
-          f_type = 'OneOf['
-          for idx, one_of_type in enumerate(details.get('oneOf', [])):
-            if '$ref' in one_of_type.keys():
-              f_type += create_link(one_of_type['$ref'], spec_file_name)
-              if idx < len(details.get('oneOf', [])) - 1:
-                f_type += ', '
-          f_type += ']'
+          f_type = "OneOf["
+          for idx, one_of_type in enumerate(details.get("oneOf", [])):
+            if "$ref" in one_of_type.keys():
+              f_type += create_link(one_of_type["$ref"], spec_file_name)
+              if idx < len(details.get("oneOf", [])) - 1:
+                f_type += ", "
+          f_type += "]"
         elif ref:
           if version_data:
-            f_type = version_data.get('type', 'any')
+            f_type = version_data.get("type", "any")
           else:
             # Direct Reference
             f_type = create_link(ref, spec_file_name)
-        elif f_type == 'array' and items_ref:
+        elif f_type == "array" and items_ref:
           # Array of References
           link = create_link(items_ref, spec_file_name)
-          f_type = f'Array[{link}]'
-        elif f_type == 'array':
+          f_type = f"Array[{link}]"
+        elif f_type == "array":
           # Array of Primitives
-          inner_type = items.get('type', 'any')
-          f_type = f'Array[{inner_type}]'
+          inner_type = items.get("type", "any")
+          f_type = f"Array[{inner_type}]"
 
         # --- Handle Description ---
-        desc = ''
+        desc = ""
         # Handle additional description text for constant
-        if 'const' in details.keys():
-          desc += f'**Constant = {details.get("const")}**. '
+        if "const" in details.keys():
+          desc += f"**Constant = {details.get('const')}**. "
         # Special handling for UCP version
-        elif version_data and ref == '#/$defs/version':
-          desc += version_data.get('description', '')
+        elif version_data and ref == "#/$defs/version":
+          desc += version_data.get("description", "")
 
-        desc += details.get('description', '')
-        enum_values = details.get('enum')
+        desc += details.get("description", "")
+        enum_values = details.get("enum")
 
         # --- Handle Enum ---
         if enum_values and isinstance(enum_values, list):
           # Format values like: `val1`, `val2`
-          formatted_enums = ', '.join([f'`{str(v)}`' for v in enum_values])
+          formatted_enums = ", ".join([f"`{str(v)}`" for v in enum_values])
           # Add a line break if description exists, then append Enum list
           if desc:
-            desc += '<br>'
-          desc += f'**Enum:** {formatted_enums}'
+            desc += "<br>"
+          desc += f"**Enum:** {formatted_enums}"
 
         # --- Handle Required ---
         if field_name in required_list:
-          req_display = '**Yes**'
+          req_display = "**Yes**"
         else:
-          req_display = 'No'
+          req_display = "No"
 
-        md.append(f'| {field_name} | {f_type} | {req_display} | {desc} |')
+        md.append(f"| {field_name} | {f_type} | {req_display} | {desc} |")
 
-    return '\n'.join(md)
+    return "\n".join(md)
 
   def _resolve_ref(ref, root_data):
     """Resolves a local reference (e.g., '#/components/parameters/id')."""
@@ -480,18 +480,18 @@ def define_env(env):
     return _loader
 
   def _read_schema_from_defs(
-      entity_name, spec_file_name, need_header=True, parent_required_list=None
+    entity_name, spec_file_name, need_header=True, parent_required_list=None
   ):
     """Parse a standalone JSON Schema file with ref definitions, render a table."""
-    if '.json#/' not in entity_name:
-      return f'**Error:** Invalid entity name format for def: {entity_name}'
+    if ".json#/" not in entity_name:
+      return f"**Error:** Invalid entity name format for def: {entity_name}"
 
     try:
-      core_entity_name, def_path = entity_name.split('.json#', 1)
-      core_entity_name += '.json'
-      def_path = '#' + def_path
+      core_entity_name, def_path = entity_name.split(".json#", 1)
+      core_entity_name += ".json"
+      def_path = "#" + def_path
     except ValueError:
-      return f'**Error:** Malformed entity name: {entity_name}'
+      return f"**Error:** Malformed entity name: {entity_name}"
 
     for schemas_dir in schemas_dirs:
       full_path = os.path.join(schemas_dir, core_entity_name)
@@ -502,23 +502,23 @@ def define_env(env):
         if embedded_schema_data is not None:
           # Resolve allOf/refs before rendering to flatten composed schemas
           resolved_schema = schema_utils.resolve_schema(
-              embedded_schema_data, data, file_loader
+            embedded_schema_data, data, file_loader
           )
           return _render_table_from_schema(
-              resolved_schema,
-              spec_file_name,
-              need_header,
-              parent_required_list,
+            resolved_schema,
+            spec_file_name,
+            need_header,
+            parent_required_list,
           )
         else:
           return (
-              f"**Error:** Definition '{def_path}' not found in '{full_path}'"
+            f"**Error:** Definition '{def_path}' not found in '{full_path}'"
           )
       # Try next directory if load_json returned None
 
     return (
-        f"**Error:** Schema file '{core_entity_name}' not found in any schema"
-        ' directory.'
+      f"**Error:** Schema file '{core_entity_name}' not found in any schema"
+      " directory."
     )
 
   # --- MACRO 1: For Standalone JSON Schemas ---
@@ -536,9 +536,9 @@ def define_env(env):
     data = None
     loaded_path = None
     for schemas_dir in schemas_dirs:
-      full_path = schemas_dir + entity_name + '.json'
+      full_path = schemas_dir + entity_name + ".json"
       try:
-        with open(full_path, 'r') as f:
+        with open(full_path, "r") as f:
           data = json.load(f)
           loaded_path = full_path
           break
@@ -552,7 +552,7 @@ def define_env(env):
       resolved_schema = schema_utils.resolve_schema(data, data, file_loader)
       return _render_table_from_schema(resolved_schema, spec_file_name)
     return (
-        f"**Error:** Schema '{entity_name}' not found in any schema directory."
+      f"**Error:** Schema '{entity_name}' not found in any schema directory."
     )
 
   @env.macro
@@ -571,10 +571,10 @@ def define_env(env):
 
   @env.macro
   def auto_generate_schema_reference(
-      sub_dir='.',
-      spec_file_name='reference',
-      include_extensions=True,
-      include_capability=True,
+    sub_dir=".",
+    spec_file_name="reference",
+    include_extensions=True,
+    include_capability=True,
   ):
     """Scans a dir for JSON schemas and generates documentation.
 
@@ -588,37 +588,37 @@ def define_env(env):
       include_capability: If true, includes schemas without 'Extension' in
         title.
     """
-    schema_base_path = 'spec/schemas/shopping'
+    schema_base_path = "spec/schemas/shopping"
     scan_path = (
-        os.path.join(schema_base_path, sub_dir)
-        if sub_dir != '.'
-        else schema_base_path
+      os.path.join(schema_base_path, sub_dir)
+      if sub_dir != "."
+      else schema_base_path
     )
 
     if not os.path.isdir(scan_path):
-      return f'<p><em>Schema directory not found: {scan_path}</em></p>'
+      return f"<p><em>Schema directory not found: {scan_path}</em></p>"
 
     output = []
     try:
       schema_files = sorted(
-          [f for f in os.listdir(scan_path) if f.endswith('.json')]
+        [f for f in os.listdir(scan_path) if f.endswith(".json")]
       )
     except FileNotFoundError:
-      return f'<p><em>Schema directory not found: {scan_path}</em></p>'
+      return f"<p><em>Schema directory not found: {scan_path}</em></p>"
 
     if not schema_files:
-      return f'<p><em>No schema files found in {scan_path}</em></p>'
+      return f"<p><em>No schema files found in {scan_path}</em></p>"
 
     for schema_file in schema_files:
       entity_name_base = os.path.splitext(schema_file)[0]
-      if sub_dir == '.':
+      if sub_dir == ".":
         entity_name = entity_name_base
       else:
-        entity_name = sub_dir.replace(os.sep, '/') + '/' + entity_name_base
+        entity_name = sub_dir.replace(os.sep, "/") + "/" + entity_name_base
 
       schema_data = _load_json_file(entity_name)
       if schema_data:
-        is_extension = 'Extension' in schema_data.get('title', '')
+        is_extension = "Extension" in schema_data.get("title", "")
         if is_extension and not include_extensions:
           continue
         if not is_extension and not include_capability:
@@ -627,68 +627,68 @@ def define_env(env):
         # If a schema has no structural elements worth documenting here,
         # skip it.
         if (
-            not schema_data.get('properties')
-            and not schema_data.get('allOf')
-            and not schema_data.get('oneOf')
-            and not schema_data.get('$ref')
-            and not schema_data.get('$defs')
+          not schema_data.get("properties")
+          and not schema_data.get("allOf")
+          and not schema_data.get("oneOf")
+          and not schema_data.get("$ref")
+          and not schema_data.get("$defs")
         ):
           continue
         schema_title = schema_data.get(
-            'title', entity_name_base.replace('_', ' ').title()
+          "title", entity_name_base.replace("_", " ").title()
         )
         if is_extension:
-          output.append(f'### {schema_title}\n')
-          defs = schema_data.get('$defs', {})
+          output.append(f"### {schema_title}\n")
+          defs = schema_data.get("$defs", {})
           def_count = 0
           for def_name, def_schema in defs.items():
             def_count += 1
             def_title = def_schema.get(
-                'title', def_name.replace('_', ' ').title()
+              "title", def_name.replace("_", " ").title()
             )
-            output.append(f'#### {def_title}\n')
+            output.append(f"#### {def_title}\n")
             rendered_table = _read_schema_from_defs(
-                f'{entity_name}.json#/$defs/{def_name}', spec_file_name
+              f"{entity_name}.json#/$defs/{def_name}", spec_file_name
             )
             output.append(rendered_table)
-            output.append('\n')
+            output.append("\n")
 
           if def_count > 0:
-            output.append('\n---\n')
+            output.append("\n---\n")
           elif (
-              schema_data.get('properties')
-              or schema_data.get('allOf')
-              or schema_data.get('oneOf')
-              or schema_data.get('$ref')
+            schema_data.get("properties")
+            or schema_data.get("allOf")
+            or schema_data.get("oneOf")
+            or schema_data.get("$ref")
           ):
             rendered_table = _render_table_from_schema(
-                schema_data, spec_file_name
+              schema_data, spec_file_name
             )
-            if rendered_table == '_No properties defined._':
+            if rendered_table == "_No properties defined._":
               output.pop()  # remove title
               continue
             output.append(rendered_table)
-            output.append('\n---\n')
+            output.append("\n---\n")
           else:
             output.pop()  # remove title
             continue
         else:
           rendered_table = _render_table_from_schema(
-              schema_data, spec_file_name
+            schema_data, spec_file_name
           )
-          if rendered_table == '_No properties defined._':
+          if rendered_table == "_No properties defined._":
             continue
-          output.append(f'### {schema_title}\n')
+          output.append(f"### {schema_title}\n")
           output.append(rendered_table)
-          output.append('\n---\n')
+          output.append("\n---\n")
       else:
-        output.append(f'### {entity_name_base}\n')
+        output.append(f"### {entity_name_base}\n")
         output.append(
-            f'<p><em>Could not load schema for entity: {entity_name}</em></p>'
+          f"<p><em>Could not load schema for entity: {entity_name}</em></p>"
         )
-        output.append('\n---\n')
+        output.append("\n---\n")
 
-    return '\n'.join(output)
+    return "\n".join(output)
 
   # --- MACRO 2: For Standalone JSON Extensions ---
   @env.macro
@@ -703,24 +703,24 @@ def define_env(env):
         should be rendered (e.g., "checkout", "fulfillment").
     """
     # Construct full path based on new structure
-    full_path = 'spec/schemas/shopping/' + entity_name + '.json'
+    full_path = "spec/schemas/shopping/" + entity_name + ".json"
     try:
-      with open(full_path, 'r', encoding='utf-8') as f:
+      with open(full_path, "r", encoding="utf-8") as f:
         data = json.load(f)
 
       # Extension schemas have their composed type in $defs.checkout
       # or $defs.order_line_item.
-      defs = data.get('$defs', {})
+      defs = data.get("$defs", {})
       # Find the composed type (checkout or order_line_item)
-      composed_type = defs.get('checkout') or defs.get('order_line_item')
-      if composed_type and 'allOf' in composed_type:
+      composed_type = defs.get("checkout") or defs.get("order_line_item")
+      if composed_type and "allOf" in composed_type:
         # Get the extension-specific properties (second element of allOf)
-        for item in composed_type['allOf']:
-          if 'properties' in item:
+        for item in composed_type["allOf"]:
+          if "properties" in item:
             return _render_table_from_schema(item, spec_file_name)
 
       return (
-          f"**Error:** Could not find extension properties in '{entity_name}'"
+        f"**Error:** Could not find extension properties in '{entity_name}'"
       )
     except (FileNotFoundError, json.JSONDecodeError) as e:
       return f"**Error loading extension '{entity_name}':** {e}"
@@ -741,7 +741,7 @@ def define_env(env):
     full_path = openapi_dir + file_name
 
     try:
-      with open(full_path, 'r', encoding='utf-8') as f:
+      with open(full_path, "r", encoding="utf-8") as f:
         data = json.load(f)
 
       # 1. Find the Operation Object by ID (search paths first, then webhooks)
@@ -749,50 +749,50 @@ def define_env(env):
       path_parameters = []
 
       # Search in paths
-      paths = data.get('paths', {})
+      paths = data.get("paths", {})
       for _, path_item in paths.items():
         for _, op_data in path_item.items():
           if not isinstance(op_data, dict):
             continue
-          if op_data.get('operationId') == operation_id:
+          if op_data.get("operationId") == operation_id:
             operation = op_data
-            path_parameters = path_item.get('parameters', [])
+            path_parameters = path_item.get("parameters", [])
             break
         if operation:
           break
 
       # If not found in paths, search in webhooks (OpenAPI 3.1+)
       if not operation:
-        webhooks = data.get('webhooks', {})
+        webhooks = data.get("webhooks", {})
         for _, webhook_item in webhooks.items():
           for _, op_data in webhook_item.items():
             if not isinstance(op_data, dict):
               continue
-            if op_data.get('operationId') == operation_id:
+            if op_data.get("operationId") == operation_id:
               operation = op_data
               break
           if operation:
             break
 
       if not operation:
-        return f'**Error:** Operation ID `{operation_id}` not found.'
+        return f"**Error:** Operation ID `{operation_id}` not found."
 
       # 2. Extract Request Schema
-      req_content = operation.get('requestBody', {}).get('content', {})
-      req_schema = req_content.get('application/json', {}).get('schema', {})
+      req_content = operation.get("requestBody", {}).get("content", {})
+      req_schema = req_content.get("application/json", {}).get("schema", {})
 
       # 3. Extract Parameters (Path + Operation)
-      op_parameters = operation.get('parameters', [])
+      op_parameters = operation.get("parameters", [])
       all_parameters = path_parameters + op_parameters
 
       # 4. Extract Response Schema
-      success_response_codes = ['200', '201']
+      success_response_codes = ["200", "201"]
       res_schema = {}
-      res = operation.get('responses', {})
+      res = operation.get("responses", {})
       for code in success_response_codes:
         if code in res.keys():
-          res_content = res.get(code, {}).get('content', {})
-          res_schema = res_content.get('application/json', {}).get('schema', {})
+          res_content = res.get(code, {}).get("content", {})
+          res_schema = res_content.get("application/json", {}).get("schema", {})
           break
 
       # --- FIX: Targeted Reference Resolution ---
@@ -804,76 +804,76 @@ def define_env(env):
         if not schema:
           return schema
         # 1. Resolve Top-Level Ref (e.g. "create_checkout")
-        if '$ref' in schema and schema['$ref'].startswith('#/'):
-          resolved = _resolve_ref(schema['$ref'], root)
+        if "$ref" in schema and schema["$ref"].startswith("#/"):
+          resolved = _resolve_ref(schema["$ref"], root)
           if resolved:
             schema = resolved
 
         # 2. Resolve Composition Refs (e.g. "complete_checkout" response)
-        if 'allOf' in schema:
+        if "allOf" in schema:
           new_all_of = []
-          for item in schema['allOf']:
-            if '$ref' in item and item['$ref'].startswith('#/'):
-              resolved = _resolve_ref(item['$ref'], root)
+          for item in schema["allOf"]:
+            if "$ref" in item and item["$ref"].startswith("#/"):
+              resolved = _resolve_ref(item["$ref"], root)
               new_all_of.append(resolved if resolved else item)
             else:
               new_all_of.append(item)
-          schema['allOf'] = new_all_of
+          schema["allOf"] = new_all_of
         return schema
 
       req_schema = resolve_structure(req_schema, data)
       res_schema = resolve_structure(res_schema, data)
       # ------------------------------------------
 
-      output = ''
+      output = ""
 
       # -- Render Request --
-      if io_type is None or io_type == 'request':
-        req_context = {'io_type': 'request', 'operation_id': operation_id}
+      if io_type is None or io_type == "request":
+        req_context = {"io_type": "request", "operation_id": operation_id}
 
         param_props = {}
         param_required_fields = []
         for param in all_parameters:
           # Resolve param refs explicitly if needed (rare for params but good
           # safety)
-          if '$ref' in param and param['$ref'].startswith('#/'):
-            resolved = _resolve_ref(param['$ref'], data)
+          if "$ref" in param and param["$ref"].startswith("#/"):
+            resolved = _resolve_ref(param["$ref"], data)
             if resolved:
               param = resolved
 
           # Filter out headers (transport-specific)
-          if param.get('in') == 'header':
+          if param.get("in") == "header":
             continue
-          name = param.get('name', '')
+          name = param.get("name", "")
           if not name:
             continue
 
           # Convert to schema property format
-          prop_schema = param.get('schema', {}).copy()
-          if 'description' in param:
-            prop_schema['description'] = param['description']
+          prop_schema = param.get("schema", {}).copy()
+          if "description" in param:
+            prop_schema["description"] = param["description"]
 
           # Add additional annotation for path parameters
-          if param.get('in', '') == 'path':
-            prop_schema['description'] = (
-                prop_schema.get('description', '') + 'Defined in path.'
+          if param.get("in", "") == "path":
+            prop_schema["description"] = (
+              prop_schema.get("description", "") + "Defined in path."
             )
           param_props[name] = prop_schema
-          if param.get('required'):
+          if param.get("required"):
             param_required_fields.append(name)
 
         param_schema = None
         if param_props:
           param_schema = {
-              'properties': param_props,
-              'required': param_required_fields,
+            "properties": param_props,
+            "required": param_required_fields,
           }
 
         # 5. Combine Parameters and Request Body into a single "Inputs" schema
         combined_schema = None
         if param_schema and req_schema:
           combined_schema = {
-              'properties': {'allOf': [param_schema, req_schema]}
+            "properties": {"allOf": [param_schema, req_schema]}
           }
         elif param_schema:
           combined_schema = param_schema
@@ -881,36 +881,36 @@ def define_env(env):
           combined_schema = req_schema
 
         if combined_schema:
-          output += '**Inputs**\n\n'
+          output += "**Inputs**\n\n"
           output += (
-              _render_table_from_schema(
-                  combined_schema, spec_file_name, context=req_context
-              )
-              + '\n\n'
+            _render_table_from_schema(
+              combined_schema, spec_file_name, context=req_context
+            )
+            + "\n\n"
           )
-        elif io_type is None or io_type == 'request':
-          output += '_No inputs defined._\n\n'
+        elif io_type is None or io_type == "request":
+          output += "_No inputs defined._\n\n"
 
       # -- Render Output --
-      if io_type is None or io_type == 'response':
+      if io_type is None or io_type == "response":
         if io_type is None and res_schema:
-          output += '**Output**\n\n'
+          output += "**Output**\n\n"
 
         if res_schema:
-          res_context = {'io_type': 'response', 'operation_id': operation_id}
+          res_context = {"io_type": "response", "operation_id": operation_id}
           output += (
-              _render_table_from_schema(
-                  res_schema, spec_file_name, context=res_context
-              )
-              + '\n\n'
+            _render_table_from_schema(
+              res_schema, spec_file_name, context=res_context
+            )
+            + "\n\n"
           )
-        elif io_type is None or io_type == 'response':
-          output += '_No output defined._\n\n'
+        elif io_type is None or io_type == "response":
+          output += "_No output defined._\n\n"
 
       return output
 
     except (FileNotFoundError, json.JSONDecodeError) as e:
-      return f'**Error processing OpenAPI:** {e}'
+      return f"**Error processing OpenAPI:** {e}"
 
   # --- MACRO 4: For HTTP Headers ---
   @env.macro
@@ -924,95 +924,94 @@ def define_env(env):
     full_path = openapi_dir + file_name
 
     try:
-      with open(full_path, 'r', encoding='utf-8') as f:
+      with open(full_path, "r", encoding="utf-8") as f:
         data = json.load(f)
 
       # 1. Find the Operation Object by ID
       operation = None
       path_parameters = []
-      paths = data.get('paths', {})
+      paths = data.get("paths", {})
       for _, path_item in paths.items():
         for _, op_data in path_item.items():
-
           if not isinstance(op_data, dict):
             continue
 
-          if op_data.get('operationId') == operation_id:
+          if op_data.get("operationId") == operation_id:
             operation = op_data
             # Extract parameters defined at the path level
-            path_parameters = path_item.get('parameters', [])
+            path_parameters = path_item.get("parameters", [])
             break
         if operation:
           break
 
       if not operation:
-        return f'**Error:** Operation ID `{operation_id}` not found.'
+        return f"**Error:** Operation ID `{operation_id}` not found."
 
       # 2. Extract Request Parameters (Path + Operation)
-      op_parameters = operation.get('parameters', [])
+      op_parameters = operation.get("parameters", [])
       all_parameters = path_parameters + op_parameters
 
       req_headers = []
       for param in all_parameters:
         # Resolve reference if needed
-        if '$ref' in param:
-          resolved = _resolve_ref(param['$ref'], data)
+        if "$ref" in param:
+          resolved = _resolve_ref(param["$ref"], data)
           if resolved:
             param = resolved
           else:
             continue
 
-        if param.get('in') == 'header':
+        if param.get("in") == "header":
           req_headers.append(param)
 
       # 3. Extract Response Headers (Assumes 200 OK)
       res_headers_defs = (
-          operation.get('responses', {}).get('200', {}).get('headers', {})
+        operation.get("responses", {}).get("200", {}).get("headers", {})
       )
       res_headers = []
       for name, header in res_headers_defs.items():
-        if '$ref' in header:
-          resolved = _resolve_ref(header['$ref'], data)
+        if "$ref" in header:
+          resolved = _resolve_ref(header["$ref"], data)
           if resolved:
             h = resolved.copy()
-            h['name'] = name
+            h["name"] = name
             res_headers.append(h)
           else:
             # If ref not resolved, just use name
-            h = {'name': name, 'description': 'Ref not resolved'}
+            h = {"name": name, "description": "Ref not resolved"}
             res_headers.append(h)
         else:
           h = header.copy()
-          h['name'] = name
+          h["name"] = name
           res_headers.append(h)
 
       if not req_headers and not res_headers:
-        return '_No headers defined._'
+        return "_No headers defined._"
 
       def render_headers_table(headers_list):
         """Renders a list of headers into a Markdown table."""
-        md_table = ['| Header | Required | Description |']
-        md_table.append('| :--- | :--- | :--- |')
+        md_table = ["| Header | Required | Description |"]
+        md_table.append("| :--- | :--- | :--- |")
         for h in headers_list:
           name = f"`{h.get('name')}`"
-          required = '**Yes**' if h.get('required') else 'No'
-          desc = h.get('description', '')
+          required = "**Yes**" if h.get("required") else "No"
+          desc = h.get("description", "")
           # Handle line breaks in description
-          desc = desc.replace('\n', '<br>')
-          md_table.append(f'| {name} | {required} | {desc} |')
-        return '\n'.join(md_table)
+          desc = desc.replace("\n", "<br>")
+          md_table.append(f"| {name} | {required} | {desc} |")
+        return "\n".join(md_table)
 
       output_parts = []
       if req_headers:
         output_parts.append(
-            '**Request Headers**\n\n' + render_headers_table(req_headers)
+          "**Request Headers**\n\n" + render_headers_table(req_headers)
         )
       if res_headers:
         output_parts.append(
-            '**Response Headers**\n\n' + render_headers_table(res_headers)
+          "**Response Headers**\n\n" + render_headers_table(res_headers)
         )
 
-      return '\n\n'.join(output_parts)
+      return "\n\n".join(output_parts)
 
     except (FileNotFoundError, json.JSONDecodeError) as e:
-      return f'**Error processing OpenAPI:** {e}'
+      return f"**Error processing OpenAPI:** {e}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ preview = false
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "B", "C4", "SIM", "N", "UP", "D", "PTH", "T20"]
+ignore = ["D203", "D213"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/schema_utils.py
+++ b/schema_utils.py
@@ -95,7 +95,7 @@ def resolve_internal_ref(ref: str, root_data: Any) -> Optional[Any]:
 
 
 def merge_schemas(
-    base: dict[str, Any], overlay: dict[str, Any]
+  base: dict[str, Any], overlay: dict[str, Any]
 ) -> dict[str, Any]:
   """Merges two JSON schemas, with overlay taking precedence.
 
@@ -129,10 +129,10 @@ def merge_schemas(
 
 
 def resolve_schema(
-    schema: dict[str, Any],
-    root_data: dict[str, Any],
-    file_loader: Optional[callable] = None,
-    visited: Optional[set[str]] = None,
+  schema: dict[str, Any],
+  root_data: dict[str, Any],
+  file_loader: Optional[callable] = None,
+  visited: Optional[set[str]] = None,
 ) -> dict[str, Any]:
   """Recursively resolves $ref and allOf in a JSON schema.
 

--- a/validate_specs.py
+++ b/validate_specs.py
@@ -39,14 +39,14 @@ class Colors:
 
 
 def check_ref(
-    ref: str, current_file: str, root_data: Optional[Any] = None
+  ref: str, current_file: str, root_data: Optional[Any] = None
 ) -> Optional[str]:
   """Checks if a reference exists."""
   if ref.startswith("#"):
     if ref != "#" and not ref.startswith("#/"):
       return (
-          f"Invalid internal reference format in {current_file}: {ref} (Must"
-          " start with '#/')"
+        f"Invalid internal reference format in {current_file}: {ref} (Must"
+        " start with '#/')"
       )
     if root_data is not None:
       if schema_utils.resolve_internal_ref(ref, root_data) is None:
@@ -71,8 +71,8 @@ def check_ref(
   if anchor_part:
     if not anchor_part.startswith("/"):
       return (
-          f"Invalid anchor format in {current_file}: {ref} (Anchor must start"
-          " with '/')"
+        f"Invalid anchor format in {current_file}: {ref} (Anchor must start"
+        " with '/')"
       )
     try:
       with open(referenced_path, "r", encoding="utf-8") as f:
@@ -87,8 +87,8 @@ def check_ref(
       # Validate the anchor using resolve_internal_ref logic
       # We verify if '#/anchor' resolves in referenced_data
       if (
-          schema_utils.resolve_internal_ref("#" + anchor_part, referenced_data)
-          is None
+        schema_utils.resolve_internal_ref("#" + anchor_part, referenced_data)
+        is None
       ):
         return f"Broken anchor in external reference in {current_file}: {ref}"
 
@@ -98,15 +98,15 @@ def check_ref(
       # Ideally we should report a warning or error here, but for now
       # we'll assume it's fine or caught by other validation.
       return (
-          f"Could not parse referenced file for reference validation:"
-          f" {referenced_path}"
+        f"Could not parse referenced file for reference validation:"
+        f" {referenced_path}"
       )
 
   return None
 
 
 def check_refs(
-    data: Any, current_file: str, root_data: Optional[Any] = None
+  data: Any, current_file: str, root_data: Optional[Any] = None
 ) -> List[str]:
   """Recursively checks for broken references in a JSON/YAML object."""
   errors = []
@@ -169,8 +169,7 @@ def validate_file(filepath: str) -> Tuple[bool, Optional[str]]:
 def main() -> None:
   if not os.path.exists(SPEC_DIR):
     print(
-        f"{Colors.YELLOW}Warning: Directory '{SPEC_DIR}' not"
-        f" found.{Colors.RESET}"
+      f"{Colors.YELLOW}Warning: Directory '{SPEC_DIR}' not found.{Colors.RESET}"
     )
     sys.exit(0)
 
@@ -185,7 +184,7 @@ def main() -> None:
 
       # Skip hidden files or unrelated types
       if filename.startswith(".") or not filename.endswith(
-          (".json", ".yaml", ".yml")
+        (".json", ".yaml", ".yml")
       ):
         continue
 
@@ -207,8 +206,8 @@ def main() -> None:
   print("\n")
   if error_count == 0:
     print(
-        f"{Colors.GREEN}✅ Success! Scanned {file_count} files. No errors"
-        f" found.{Colors.RESET}"
+      f"{Colors.GREEN}✅ Success! Scanned {file_count} files. No errors"
+      f" found.{Colors.RESET}"
     )
     sys.exit(0)
   else:


### PR DESCRIPTION
# Description

Format all python files with `ruff` and ignore redundant formatting rules.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [ ] Documentation update
- [x] Style update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
