### PR TITLE
refactor!: Remove `full_name` fields across UCP APIs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -230,7 +230,8 @@ image: assets/banner.png
           "destinations": [
             {
               "id": "dest_1",
-              "full_name": "Elisa Beckett",
+              "first_name": "Elisa",
+              "last_name": "Beckett",
               "street_address": "1600 Amphitheatre Pkwy",
               "address_locality": "Mountain View",
               "address_region": "CA",
@@ -335,7 +336,8 @@ image: assets/banner.png
           "line_items": [{ "id": "li_1", "quantity": 1 }],
           "method_type": "shipping",
           "destination": {
-            "full_name": "Elisa Beckett",
+            "first_name": "Elisa",
+            "last_name": "Beckett",
             "street_address": "1600 Amphitheatre Pkwy",
             "address_locality": "Mountain View",
             "address_region": "CA",

--- a/generated/schema-types.ts
+++ b/generated/schema-types.ts
@@ -495,10 +495,6 @@ export declare interface PostalAddress {
    */
   last_name?: string;
   /**
-   * Optional. Full name of the contact associated with the address (if first_name or last_name fields are present they take precedence).
-   */
-  full_name?: string;
-  /**
    * Optional. Phone number of the contact associated with the address.
    */
   phone_number?: string;
@@ -605,10 +601,6 @@ export declare interface Buyer {
    * Last name of the buyer.
    */
   last_name?: string;
-  /**
-   * Optional, buyer's full name (if first_name or last_name fields are present they take precedence).
-   */
-  full_name?: string;
   /**
    * Email of the buyer.
    */

--- a/source/schemas/shopping/types/buyer.json
+++ b/source/schemas/shopping/types/buyer.json
@@ -13,10 +13,6 @@
       "type": "string",
       "description": "Last name of the buyer."
     },
-    "full_name": {
-      "type": "string",
-      "description": "Optional, buyer's full name (if first_name or last_name fields are present they take precedence)."
-    },
     "email": {
       "type": "string",
       "description": "Email of the buyer."

--- a/source/schemas/shopping/types/postal_address.json
+++ b/source/schemas/shopping/types/postal_address.json
@@ -36,10 +36,6 @@
       "type": "string",
       "description": "Optional. Last name of the contact associated with the address."
     },
-    "full_name": {
-      "type": "string",
-      "description": "Optional. Full name of the contact associated with the address (if first_name or last_name fields are present they take precedence)."
-    },
     "phone_number": {
       "type": "string",
       "description": "Optional. Phone number of the contact associated with the address."

--- a/spec/schemas/shopping/types/buyer.json
+++ b/spec/schemas/shopping/types/buyer.json
@@ -13,10 +13,6 @@
       "type": "string",
       "description": "Last name of the buyer."
     },
-    "full_name": {
-      "type": "string",
-      "description": "Optional, buyer's full name (if first_name or last_name fields are present they take precedence)."
-    },
     "email": {
       "type": "string",
       "description": "Email of the buyer."

--- a/spec/schemas/shopping/types/postal_address.json
+++ b/spec/schemas/shopping/types/postal_address.json
@@ -36,10 +36,6 @@
       "type": "string",
       "description": "Optional. Last name of the contact associated with the address."
     },
-    "full_name": {
-      "type": "string",
-      "description": "Optional. Full name of the contact associated with the address (if first_name or last_name fields are present they take precedence)."
-    },
     "phone_number": {
       "type": "string",
       "description": "Optional. Phone number of the contact associated with the address."


### PR DESCRIPTION
# Description

This PR removes the optional `full_name` field exposed for a few different objects in the schema. While implementing, it felt quite awkward that every merchant and partner would need to handle all the different cases of `first_/last_/full_name` being provided, and the rules for how those different parties should reflect this back was not clear.

We think separate, optional `first_name` and `last_name` fields provide the highest fidelity information, as it is possible for a business or agent to go from `first_name` + `last_name` to full name (provided they know the locale), but it is not always possible to do the reverse with just a `full_name`. UCP consumers that only know a single name have to do extra work to split out a `first_name` and `last_name` in their input, but they are the ones with the context to separate first and last name (including, optionally, omitting one of those fields, such as for mononyms).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [ ] Documentation update

---
### Is this a Breaking Change or Removal?

If you checked "Breaking change" above, or if you are removing **any** schema
files or fields:

- [ ] **I have added `!` to my PR title** (e.g., `feat!: remove field`).
- [ ] **I have added justification below.**

```
## Breaking Changes / Removal Justification

(Please provide a detailed technical and strategic rationale here for why this
breaking change or removal is necessary.)
```
---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
