### PR TITLE
docs: wrap checkout input objects in a checkout object

### DIFF
--- a/docs/specification/checkout-mcp.md
+++ b/docs/specification/checkout-mcp.md
@@ -137,37 +137,39 @@ Maps to the [Create Checkout](checkout.md#create-checkout) operation.
           }
         },
         "idempotency_key": "550e8400-e29b-41d4-a716-446655440000",
-        "buyer": {
-          "email": "jane.doe@example.com",
-          "first_name": "Jane",
-          "last_name": "Doe"
-        },
-        "line_items": [
-          {
-            "item": {
-              "id": "item_123"
-            },
-            "quantity": 1
-          }
-        ],
-        "currency": "USD",
-        "fulfillment": {
-          "methods": [
+        "checkout": {
+          "buyer": {
+            "email": "jane.doe@example.com",
+            "first_name": "Jane",
+            "last_name": "Doe"
+          },
+          "line_items": [
             {
-              "type": "shipping",
-              "destinations": [
-                {
-                  "street_address": "123 Main St",
-                  "address_locality": "Springfield",
-                  "address_region": "IL",
-                  "postal_code": "62701",
-                  "address_country": "US"
-                }
-              ]
+              "item": {
+                "id": "item_123"
+              },
+              "quantity": 1
             }
-          ]
-        },
-        "payment": {}
+          ],
+          "currency": "USD",
+          "fulfillment": {
+            "methods": [
+              {
+                "type": "shipping",
+                "destinations": [
+                  {
+                    "street_address": "123 Main St",
+                    "address_locality": "Springfield",
+                    "address_region": "IL",
+                    "postal_code": "62701",
+                    "address_country": "US"
+                  }
+                ]
+              }
+            ]
+          },
+          "payment": {}
+        }
       },
       "id": 1
     }
@@ -358,35 +360,37 @@ Maps to the [Update Checkout](checkout.md#update-checkout) operation.
           }
         },
         "id": "checkout_abc123",
-        "buyer": {
-          "email": "jane.doe@example.com",
-          "first_name": "Jane",
-          "last_name": "Doe"
-        },
-        "line_items": [
-          {
-            "item": {
-              "id": "item_123"
-            },
-            "quantity": 1
-          }
-        ],
-        "currency": "USD",
-        "fulfillment": {
-          "methods": [
+        "checkout": {
+          "buyer": {
+            "email": "jane.doe@example.com",
+            "first_name": "Jane",
+            "last_name": "Doe"
+          },
+          "line_items": [
             {
-              "id": "shipping_1",
-              "line_item_ids": ["item_123"],
-              "groups": [
-                {
-                  "id": "package_1",
-                  "selected_option_id": "express"
-                }
-              ]
+              "item": {
+                "id": "item_123"
+              },
+              "quantity": 1
             }
-          ]
-        },
-        "payment": {}
+          ],
+          "currency": "USD",
+          "fulfillment": {
+            "methods": [
+              {
+                "id": "shipping_1",
+                "line_item_ids": ["item_123"],
+                "groups": [
+                  {
+                    "id": "package_1",
+                    "selected_option_id": "express"
+                  }
+                ]
+              }
+            ]
+          },
+          "payment": {}
+        }
       },
       "id": 2
     }


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Wrapping Checkout MCP request docs in a `checkout` object.
Before:
```json
{
  "id": "checkout_id",
  "line_items": {}
}
```

After:
```json
{
  "id": "checkout_id",
  "checkout": {
    "line_items": {}
  }
}
```

## Type of change
Documentation update

---
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---
