### PR TITLE
fix: update broken URLs in demo and documentation to use correct ucp.dev paths

### DIFF
--- a/docs/playground.md
+++ b/docs/playground.md
@@ -476,14 +476,14 @@ const UcpData = {
     "dev.ucp.shopping.checkout": [
       {
         version: "2026-01-11",
-        spec: "https://ucp.dev/specs/checkout",
+        spec: "https://ucp.dev/specification/checkout",
         schema: "https://ucp.dev/schemas/shopping/checkout.json"
       }
     ],
     "dev.ucp.shopping.order": [
       {
         version: "2026-01-11",
-        spec: "https://ucp.dev/specs/order",
+        spec: "https://ucp.dev/specification/order",
         schema: "https://ucp.dev/schemas/shopping/order.json"
       }
     ],
@@ -491,7 +491,7 @@ const UcpData = {
       {
         extends: "dev.ucp.shopping.checkout",
         version: "2026-01-11",
-        spec: "https://ucp.dev/specs/fulfillment",
+        spec: "https://ucp.dev/specification/fulfillment",
         schema: "https://ucp.dev/schemas/shopping/fulfillment.json",
         config: {
           allows_multi_destination: {
@@ -509,7 +509,7 @@ const UcpData = {
       {
         extends: "dev.ucp.shopping.checkout",
         version: "2026-01-11",
-        spec: "https://ucp.dev/specs/discount",
+        spec: "https://ucp.dev/specification/discount",
         schema: "https://ucp.dev/schemas/shopping/discount.json"
       }
     ],
@@ -517,7 +517,7 @@ const UcpData = {
       {
         extends: "dev.ucp.shopping.checkout",
         version: "2026-01-11",
-        spec: "https://ucp.dev/specs/buyer_consent",
+        spec: "https://ucp.dev/specification/buyer-consent",
         schema: "https://ucp.dev/schemas/shopping/buyer_consent.json"
       }
     ],
@@ -525,8 +525,8 @@ const UcpData = {
       {
         extends: "dev.ucp.shopping.checkout",
         version: "2026-01-11",
-        spec: "https://ucp.dev/specs/ap2_mandates",
-        schema: "https://ucp.dev/schemas/shopping/ap2_mandates.json"
+        spec: "https://ucp.dev/specification/ap2-mandates",
+        schema: "https://ucp.dev/schemas/shopping/ap2_mandate.json"
       }
     ]
   },


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Fixes broken URLs in demo application and documentation that were returning HTTP 404 errors.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [x] Documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---
