### PR TITLE
docs: align discovery examples with ucp schema

### DIFF
--- a/docs/specification/ap2-mandates.md
+++ b/docs/specification/ap2-mandates.md
@@ -68,26 +68,29 @@ Businesses declare support by adding `dev.ucp.shopping.ap2_mandate` to their
 **Business Profile Example:**
 ```json
 {
-  "capabilities": [
-    {
-      "name": "dev.ucp.shopping.checkout",
-      "version": "2026-01-11",
-      "spec": "https://ucp.dev/specification/checkout",
-      "schema": "https://ucp.dev/schemas/shopping/checkout.json"
-    },
-    {
-      "name": "dev.ucp.shopping.ap2_mandate",
-      "version": "2026-01-11",
-      "spec": "https://ucp.dev/specification/ap2-mandates",
-      "schema": "https://ucp.dev/schemas/shopping/ap2_mandate.json",
-      "extends": "dev.ucp.shopping.checkout",
-      "config": {
-        "vp_formats_supported": {
-          "dc+sd-jwt": { }
+  "ucp": {
+    "version": "2026-01-11",
+    "capabilities": [
+      {
+        "name": "dev.ucp.shopping.checkout",
+        "version": "2026-01-11",
+        "spec": "https://ucp.dev/specification/checkout",
+        "schema": "https://ucp.dev/schemas/shopping/checkout.json"
+      },
+      {
+        "name": "dev.ucp.shopping.ap2_mandate",
+        "version": "2026-01-11",
+        "spec": "https://ucp.dev/specification/ap2-mandates",
+        "schema": "https://ucp.dev/schemas/shopping/ap2_mandate.json",
+        "extends": "dev.ucp.shopping.checkout",
+        "config": {
+          "vp_formats_supported": {
+            "dc+sd-jwt": { }
+          }
         }
       }
-    }
-  ]
+    ]
+  }
 }
 ```
 

--- a/docs/specification/buyer-consent.md
+++ b/docs/specification/buyer-consent.md
@@ -32,19 +32,28 @@ with a `consent` field containing boolean consent states.
 This extension can be included in `create_checkout` and `update_checkout`
 operations.
 
+**Dependencies:**
+
+- Checkout Capability
+
 ## Discovery
 
 Businesses advertise consent support in their profile:
 
 ```json
 {
-  "capabilities": [
-    {
-      "name": "dev.ucp.shopping.buyer_consent",
-      "version": "2026-01-11",
-      "extends": "dev.ucp.shopping.checkout"
-    }
-  ]
+  "ucp": {
+    "version": "2026-01-11",
+    "capabilities": [
+      {
+        "name": "dev.ucp.shopping.buyer_consent",
+        "version": "2026-01-11",
+        "extends": "dev.ucp.shopping.checkout",
+        "spec": "https://ucp.dev/specification/buyer-consent",
+        "schema": "https://ucp.dev/schemas/shopping/buyer_consent.json"
+      }
+    ]
+  }
 }
 ```
 

--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -390,7 +390,7 @@ type & addresses.
             "name": "dev.ucp.shopping.checkout",
             "version": "2026-01-11"
           }
-        ],
+        ]
       },
       "id": "chk_1234567890",
       "status": "incomplete",
@@ -609,7 +609,7 @@ Follow-up calls after initial `fulfillment` data to update selection.
             "name": "dev.ucp.shopping.checkout",
             "version": "2026-01-11"
           }
-        ],
+        ]
       },
       "id": "chk_1234567890",
       "status": "ready_for_complete",
@@ -801,7 +801,7 @@ place to set these expectations via `messages`.
             "name": "dev.ucp.shopping.checkout",
             "version": "2026-01-11"
           }
-        ],
+        ]
       },
       "id": "chk_123456789",
       "status": "completed",
@@ -969,7 +969,7 @@ place to set these expectations via `messages`.
             "name": "dev.ucp.shopping.checkout",
             "version": "2026-01-11"
           }
-        ],
+        ]
       },
       "id": "chk_123456789",
       "status": "completed",
@@ -1137,7 +1137,7 @@ place to set these expectations via `messages`.
             "name": "dev.ucp.shopping.checkout",
             "version": "2026-01-11"
           }
-        ],
+        ]
       },
       "id": "chk_123456789",
       "status": "canceled", // Status is updated to canceled.

--- a/docs/specification/embedded-checkout.md
+++ b/docs/specification/embedded-checkout.md
@@ -87,19 +87,23 @@ the `embedded` transport in their `/.well-known/ucp` profile, all checkout
 
 ```json
 {
-    "services": {
-        "dev.ucp.shopping": {
-            "version": "2026-01-11",
-            "rest": {
-                "schema": "https://ucp.dev/services/shopping/rest.openapi.json",
-                "endpoint": "https://merchant.example.com/ucp/v1"
-            },
-            "mcp": {
-                "schema": "https://ucp.dev/services/shopping/mcp.openrpc.json",
-                "endpoint": "https://merchant.example.com/ucp/mcp"
-            },
-            "embedded": {
-                "schema": "https://ucp.dev/services/shopping/embedded.openrpc.json"
+    "ucp": {
+        "version": "2026-01-11",
+        "services": {
+            "dev.ucp.shopping": {
+                "version": "2026-01-11",
+                "spec": "https://ucp.dev/specification/overview",
+                "rest": {
+                    "schema": "https://ucp.dev/services/shopping/rest.openapi.json",
+                    "endpoint": "https://merchant.example.com/ucp/v1"
+                },
+                "mcp": {
+                    "schema": "https://ucp.dev/services/shopping/mcp.openrpc.json",
+                    "endpoint": "https://merchant.example.com/ucp/mcp"
+                },
+                "embedded": {
+                    "schema": "https://ucp.dev/services/shopping/embedded.openrpc.json"
+                }
             }
         }
     }

--- a/docs/specification/fulfillment.md
+++ b/docs/specification/fulfillment.md
@@ -299,16 +299,24 @@ Businesses declare what fulfillment configurations they support using
 
 ```json
 {
-  "capabilities": [{
-    "name": "dev.ucp.shopping.fulfillment",
+  "ucp": {
     "version": "2026-01-11",
-    "config": {
-      "allows_multi_destination": {
-        "shipping": true
-      },
-      "allows_method_combinations": [["shipping", "pickup"]]
-    }
-  }]
+    "capabilities": [
+      {
+        "name": "dev.ucp.shopping.fulfillment",
+        "version": "2026-01-11",
+        "spec": "https://ucp.dev/specification/fulfillment",
+        "schema": "https://ucp.dev/schemas/shopping/fulfillment.json",
+        "extends": "dev.ucp.shopping.checkout",
+        "config": {
+          "allows_multi_destination": {
+            "shipping": true
+          },
+          "allows_method_combinations": [["shipping", "pickup"]]
+        }
+      }
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
# Description

Align discovery examples with UCP schema

- wrap extension/service discovery examples with ucp
- add spec/schema/extends where required
- fix invalid JSON commas in REST examples

## Type of change

- [X] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
