### PR TITLE
docs: Cleanup payment responses from checkout schema

### DIFF
--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -157,7 +157,7 @@ All REST endpoints **MUST** be served over HTTPS with minimum TLS version
             "handler_id": "shop_pay_1234",
             "type": "shop_pay",
             "selected": true,
-            "display_data": {
+            "display": {
               "email": "buyer@example.com"
             }
           }
@@ -287,7 +287,7 @@ so clients must include all previously set fields they wish to retain.
             "handler_id": "shop_pay_1234",
             "type": "shop_pay",
             "selected": true,
-            "display_data": {
+            "display": {
               "email": "buyer@example.com"
             }
           }
@@ -489,7 +489,7 @@ type & addresses.
             "handler_id": "gpay_1234",
             "type": "card",
             "selected": true,
-            "display_data": {
+            "display": {
               "brand": "mastercard",
               "last_digits": "5678",
               "rich_text_description": "Google Pay •••• 5678"
@@ -685,7 +685,7 @@ Follow-up calls after initial `fulfillment` data to update selection.
             "handler_id": "shop_pay_1234",
             "type": "shop_pay",
             "selected": true,
-            "display_data": {
+            "display": {
               "email": "buyer@example.com"
             }
           }
@@ -879,7 +879,7 @@ place to set these expectations via `messages`.
             "handler_id": "gpay_1234",
             "type": "card",
             "selected": true,
-            "display_data": {
+            "display": {
               "brand": "mastercard",
               "last_digits": "5678",
               "rich_text_description": "Google Pay •••• 5678"
@@ -1033,7 +1033,7 @@ place to set these expectations via `messages`.
             "handler_id": "shop_pay_1234",
             "type": "shop_pay",
             "selected": true,
-            "display_data": {
+            "display": {
               "email": "buyer@example.com"
             }
           }
@@ -1188,7 +1188,7 @@ place to set these expectations via `messages`.
             "handler_id": "gpay_1234",
             "type": "card",
             "selected": true,
-            "display_data": {
+            "display": {
               "brand": "mastercard",
               "last_digits": "5678",
               "rich_text_description": "Google Pay •••• 5678"

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -444,41 +444,15 @@ field or omitting them.
 
 ### Payment
 
-#### Payment Create Request
-
-{{ schema_fields('payment.create_req', 'checkout') }}
-
-#### Payment Update Request
-
-{{ schema_fields('payment.update_req', 'checkout') }}
-
-#### Payment Response
-
-{{ schema_fields('payment_resp', 'checkout') }}
-
-### Payment Handler Response
-
-{{ schema_fields('types/payment_handler_resp', 'checkout') }}
+{{ schema_fields('payment', 'checkout') }}
 
 ### Payment Instrument
 
 {{ schema_fields('payment_instrument', 'checkout') }}
 
-### Card Payment Instrument
-
-{{ schema_fields('card_payment_instrument', 'checkout') }}
-
 ### Payment Credential
 
 {{ schema_fields('payment_credential', 'checkout') }}
-
-### Token Credential Response
-
-{{ schema_fields('token_credential.create_req', 'checkout') }}
-
-### Card Credential
-
-{{ schema_fields('card_credential', 'checkout') }}
 
 ### Postal Address
 

--- a/source/schemas/shopping/types/payment_instrument.json
+++ b/source/schemas/shopping/types/payment_instrument.json
@@ -31,7 +31,7 @@
     },
     "display": {
       "type": "object",
-      "description": "Display information for this payment instrument."
+      "description": "Display information for this payment instrument. Each payment instrument schema defines its specific display properties, as outlined by the payment handler."
     }
   },
   "additionalProperties": true,

--- a/spec/schemas/shopping/types/payment_instrument.json
+++ b/spec/schemas/shopping/types/payment_instrument.json
@@ -31,7 +31,7 @@
     },
     "display": {
       "type": "object",
-      "description": "Display information for this payment instrument."
+      "description": "Display information for this payment instrument. Each payment instrument schema defines its specific display properties, as outlined by the payment handler."
     }
   },
   "additionalProperties": true,


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

A member of TC flagged that we have some disjointed references in checkout for display data and payment responses.
To resolve this, I'm clarifying that:
- display is the right obj on instruments for all examples.
- Payment has a single shape now (not the fragmented create/req objects).
- Payment handlers are not in base checkout anymore (already visible under the UCP schema).
- Card and Token instruments are not directly associated with checkout; these are entirely dependent on the merchants defined handlers, so they are removed from the base doc of checkout.

## Type of change
- [x] Documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
