### PR TITLE
docs: add versioning page

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,7 +11,8 @@
     ".cspell.json",
     "**/*.svg",
     ".gitignore",
-    "package.json"
+    "package.json",
+    ".pre-commit-config.yaml"
   ],
   "dictionaryDefinitions": [
     {

--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -55,6 +55,7 @@ gpay
 ingestions
 inlinehilite
 linenums
+llms
 llmstxt
 mastercard
 mkdocs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,5 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
+        args: [--unsafe]
     -   id: check-added-large-files

--- a/docs/specification/versioning.md
+++ b/docs/specification/versioning.md
@@ -1,0 +1,30 @@
+# Versioning
+
+UCP uses date-based version identifiers following the format YYYY-MM-DD, to
+indicate the last date backwards incompatible changes were made.
+
+New development occurs on the `main` branch. We will maintain long-lived
+branches for all supported releases of the spec.
+
+* When the Tech Council approves a new version of UCP, we will cut a
+  new branch named `release/YYYY-MM-DD` directly from the current state of
+  `main`.
+    * We will implement a code freeze on the release branch the moment a
+      `release/YYYY-MM-DD branch` is cut. Only critical bug fixes should move
+      during this window.
+    * Critical issues discovered after cutting a release branch should be fixed
+      in one of two ways:
+      1. The fix is made on the release branch and merged to `main`.
+      2. The fix is made on `main` and cherry-picked to the release branch.
+* Once finalized, we will merge the release branch into `main` and tag it (e.g.
+  `git tag -a YYYY-MM-DD`).  We will use a GitHub Action to detect the new Tag
+  and automatically generate a release notes draft and upload artifacts.
+* Unlike temporary feature branches, release/YYYY-MM-DD branches are long-lived
+  and correspond to specific versions of the spec for historical reference and
+  maintenance.
+
+## Breaking PRs
+
+* Breaking changes should include `!` in the PR title
+* Timing: We will announce the breaking change in Discussions 2 weeks
+  before the change is merged.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
         - Encrypted Credential: specification/examples/encrypted-credential-handler.md
     - Schema Authoring: documentation/schema-authoring.md
     - Reference: specification/reference.md
+    - Versioning: specification/versioning.md
   - UCP and AP2: documentation/ucp-and-ap2.md
   - Roadmap: documentation/roadmap.md
 
@@ -70,7 +71,9 @@ extra:
   ucp_url: https://ucp.dev
   analytics:
     provider: google
+    # cSpell:disable
     property: G-ZEGTBCTMJ9
+    # cSpell:enable
   consent:
     title: Cookie consent
     description: >-


### PR DESCRIPTION
# Description

Add a page explaining how UCP handles versioning.
