### PR TITLE
fix: update git tag to start with v

### DIFF
--- a/docs/specification/versioning.md
+++ b/docs/specification/versioning.md
@@ -17,7 +17,7 @@ branches for all supported releases of the spec.
       1. The fix is made on the release branch and merged to `main`.
       2. The fix is made on `main` and cherry-picked to the release branch.
 * Once finalized, we will merge the release branch into `main` and tag it (e.g.
-  `git tag -a YYYY-MM-DD`).  We will use a GitHub Action to detect the new Tag
+  `git tag -a vYYYY-MM-DD`).  We will use a GitHub Action to detect the new Tag
   and automatically generate a release notes draft and upload artifacts.
 * Unlike temporary feature branches, release/YYYY-MM-DD branches are long-lived
   and correspond to specific versions of the spec for historical reference and


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Update git tag to start with v for broader compatibility
