### PR TITLE
fix: Add UCP-Agent header to the openapi.json.

### DIFF
--- a/source/services/shopping/openapi.json
+++ b/source/services/shopping/openapi.json
@@ -43,6 +43,9 @@
             "$ref": "#/components/parameters/user_agent"
           },
           {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
             "$ref": "#/components/parameters/content_type"
           },
           {
@@ -107,6 +110,9 @@
             "$ref": "#/components/parameters/user_agent"
           },
           {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
             "$ref": "#/components/parameters/content_type"
           },
           {
@@ -159,6 +165,9 @@
           },
           {
             "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
           },
           {
             "$ref": "#/components/parameters/content_type"
@@ -226,6 +235,9 @@
           },
           {
             "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
           },
           {
             "$ref": "#/components/parameters/content_type"
@@ -306,6 +318,9 @@
           },
           {
             "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
           },
           {
             "$ref": "#/components/parameters/content_type"
@@ -393,6 +408,7 @@
           { "$ref": "#/components/parameters/request_signature" },
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
+          { "$ref": "#/components/parameters/ucp_agent" },
           { "$ref": "#/components/parameters/content_type" },
           { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
@@ -426,6 +442,7 @@
           { "$ref": "#/components/parameters/idempotency_key" },
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
+          { "$ref": "#/components/parameters/ucp_agent" },
           { "$ref": "#/components/parameters/content_type" },
           { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
@@ -469,6 +486,7 @@
           { "$ref": "#/components/parameters/idempotency_key" },
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
+          { "$ref": "#/components/parameters/ucp_agent" },
           { "$ref": "#/components/parameters/content_type" },
           { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
@@ -623,6 +641,15 @@
           "type": "string"
         },
         "description": "Identifies the user agent string making the call."
+      },
+      "ucp_agent": {
+        "name": "UCP-Agent",
+        "in": "header",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Identifies the UCP agent making the call. All requests MUST include the UCP-Agent header containing the platform profile URI using Dictionary Structured Field syntax (RFC 8941). Format: profile=\"https://platform.example/profile\"."
       },
       "content_type": {
         "name": "Content-Type",


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Add mandatory UCP-Agent header to the OpenAPI spec file.

The header is described on https://ucp.dev/specification/checkout-rest/#http-headers but for some reason is missing from the spec. It leads to the generated code missing the header as well.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [ ] Documentation update

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---
