### PR TITLE
chore: respect .gitignore for biome linting

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,4 +1,9 @@
 {
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
   "linter": {
     "enabled": true,
     "rules": {


### PR DESCRIPTION
# Description

The `biome` tool doesn't respect many of the settings that super linter uses for ignoring files. This PR updates the `biome.json` config to respect `.gitignore`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
