### PR TITLE
chore: add script to run super linter locally

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -65,6 +65,7 @@ openapi
 openrpc
 paypal
 permissionless
+podman
 preorders
 proto
 protobuf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
     "mkdocs-material[imaging]>=9.0.0",
     "mkdocs-redirects==1.2.2",
     "mkdocs-site-urls==0.3.1",
+    "pyyaml>=6.0.3",
     "yamllint==1.35.1",
 ]
 

--- a/scripts/super_linter_local.py
+++ b/scripts/super_linter_local.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env -S uv run
+
+"""Run super-linter locally using configuration from GitHub Actions."""
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def map_action_to_image(action_str):
+  """Map GitHub Action string to ghcr.io image."""
+  # super-linter/super-linter/slim@v8 ->
+  # ghcr.io/super-linter/super-linter:slim-v8
+  match = re.match(r"super-linter/super-linter/(.*)@(.*)", action_str)
+
+  if match:
+    variant = match.group(1)
+    version = match.group(2)
+    return f"ghcr.io/super-linter/super-linter:{variant}-{version}"
+
+  return action_str
+
+
+def main():
+  """Parse workflow and run linter."""
+  default_runtime = "podman" if shutil.which("podman") else "docker"
+
+  parser = argparse.ArgumentParser(
+    description=(
+      "Run super-linter locally using configuration from GitHub Actions."
+    )
+  )
+  parser.add_argument(
+    "--runtime",
+    choices=["docker", "podman"],
+    default=default_runtime,
+    help="Container runtime to use (default: %(default)s)",
+  )
+  parser.add_argument(
+    "--branch",
+    default="main",
+    help="Default branch to compare against (default: main)",
+  )
+
+  args = parser.parse_args()
+
+  workflow_path = Path(".github/workflows/linter.yaml")
+
+  if not workflow_path.exists():
+    print(f"Error: {workflow_path} not found.")
+    sys.exit(1)
+
+  with workflow_path.open() as f:
+    workflow = yaml.safe_load(f)
+
+  lint_step = None
+  jobs = workflow.get("jobs", {})
+
+  for job_data in jobs.values():
+    steps = job_data.get("steps", [])
+
+    for step in steps:
+      if step.get("name") == "Lint Code Base":
+        lint_step = step
+        break
+
+  if not lint_step:
+    print("Error: Could not find 'Lint Code Base' step in workflow.")
+    sys.exit(1)
+
+  assert lint_step is not None
+
+  lint_env = lint_step.get("env", {})
+  action_uses = lint_step.get("uses", "")
+  image = map_action_to_image(action_uses)
+
+  cmd = [
+    args.runtime,
+    "run",
+    "--rm",
+    "-e",
+    "RUN_LOCAL=true",
+    "-v",
+    f"{Path.cwd()}:/tmp/lint:Z",
+  ]
+
+  for key, value in lint_env.items():
+    if key == "DEFAULT_BRANCH":
+      val_str = str(args.branch)
+    elif isinstance(value, bool):
+      val_str = str(value).lower()
+    elif isinstance(value, str):
+      if "${{" in value:
+        continue
+      val_str = value
+    else:
+      val_str = str(value)
+
+    cmd.extend(["-e", f"{key}={val_str}"])
+
+  cmd.append(image)
+
+  print(f"Executing: {' '.join(cmd)}")
+
+  try:
+    result = subprocess.run(cmd, check=False)
+    sys.exit(result.returncode)
+  except KeyboardInterrupt:
+    print("\nInterrupted by user")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+  main()

--- a/uv.lock
+++ b/uv.lock
@@ -1470,6 +1470,7 @@ dev = [
     { name = "mkdocs-material", extra = ["imaging"] },
     { name = "mkdocs-redirects" },
     { name = "mkdocs-site-urls" },
+    { name = "pyyaml" },
     { name = "yamllint" },
 ]
 
@@ -1484,6 +1485,7 @@ dev = [
     { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.0.0" },
     { name = "mkdocs-redirects", specifier = "==1.2.2" },
     { name = "mkdocs-site-urls", specifier = "==0.3.1" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "yamllint", specifier = "==1.35.1" },
 ]
 


### PR DESCRIPTION
# Description

This PR introduces `scripts/super_linter_local.py` that runs our super linter Github action locally. The script reads the `yaml` config for the action and converts it into a command that runs a local container for super linter.

The command supports two container runtimes via the `--runtime` flag: `docker` and `podman`. A default is chosen based on the contents of your `PATH`.

The command supports providing a branch to compare against via the `--branch` flag. The default is `main`.

Here's an example invocation:

```
./scripts/super_linter_local.py --runtime podman --branch main
```

For usage information, run:

```
./scripts/super_linter_local.py -h
```

## Type of change

Please delete options that are not relevant.

- [x] Chore

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
