### PR TITLE
fix: Mark checkout id as deprecated_required_to_omit for update requests

### DIFF
--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -185,7 +185,7 @@ so clients must include all previously set fields they wish to retain.
     Content-Type: application/json
 
     {
-      "id": "chk_123456789", // deprecated: id is redundant with URL path
+      "id": "chk_123456789", // deprecated: id is provided in URL path
       "buyer": {
         "email": "jane@example.com",
         "first_name": "Jane",
@@ -316,7 +316,7 @@ type & addresses.
     Content-Type: application/json
 
     {
-      "id": "chk_123456789", // deprecated: id is redundant with URL path
+      "id": "chk_123456789", // deprecated: id is provided in URL path
       "buyer": {
         "email": "jane@example.com",
         "first_name": "Jane",
@@ -518,7 +518,7 @@ Follow-up calls after initial `fulfillment` data to update selection.
     Content-Type: application/json
 
     {
-      "id": "chk_123456789", // deprecated: id is redundant with URL path
+      "id": "chk_123456789", // deprecated: id is provided in URL path
       "buyer": {
         "email": "jane@example.com",
         "first_name": "Jane",

--- a/docs/specification/playground.md
+++ b/docs/specification/playground.md
@@ -961,7 +961,7 @@ class UcpApp {
   }
 
   prepareUpdatePayload(checkoutResponse) {
-    const patch = { id: checkoutResponse.id }; // deprecated: id is redundant with URL path
+    const patch = { id: checkoutResponse.id }; // deprecated: id is provided in URL path
     const errors = checkoutResponse.messages || [];
 
     if (errors.some(e => e.path === "$.buyer.email")) {

--- a/source/schemas/shopping/checkout.json
+++ b/source/schemas/shopping/checkout.json
@@ -25,7 +25,7 @@
       "description": "Unique identifier of the checkout session.",
       "ucp_request": {
         "create": "omit",
-        "update": {"transition": {"from": "required", "to": "omit", "description": "The id field from the transport request is expected to be used."}},
+        "update": {"transition": {"from": "required", "to": "omit", "description": "ID is provided as argument on the request, this ID is redundant."}},
         "complete": "omit"
       }
     },


### PR DESCRIPTION
Dependency on https://github.com/Universal-Commerce-Protocol/ucp-schema/pull/6

<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

This change simplifies the checkout request schema by marking the id field as deprecated from all request types. Today we do this correctly for complete, but for update we accept a checkout id in both the transport layer as well as the checkout object being provided. This was a miss dating back to the 2026-01-11 release.

### Type of change
- [x] Documentation update

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
