### PR TITLE
feat: Add first-class errors concept

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -49,6 +49,7 @@ checkout
 credentialless
 credentialization
 datamodel
+delisted
 dpan
 ewallet
 fontawesome

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -196,6 +196,26 @@ ELSE IF requires_buyer_review is not empty
   handoff_context = "ready for final review by the buyer"
 ```
 
+#### Standard Errors
+
+Standard errors are standardized error codes that platforms are expected to
+handle with specific, appropriate UX rather than generic error treatment.
+
+| Code                     | Description                                                                |
+| :----------------------- | :------------------------------------------------------------------------- |
+| `out_of_stock`           | Specific item or variant is unavailable                                    |
+| `item_unavailable`       | Item cannot be purchased (e.g. delisted)                                   |
+| `address_undeliverable`  | Cannot deliver to the provided address                                     |
+| `payment_failed`         | Payment processing failed                                                  |
+
+Businesses **SHOULD** mark standard errors with `severity: recoverable` to
+signal that platforms should provide appropriate UX (out-of-stock messaging,
+address validation prompts, payment method changes) rather than generic error
+messages or deferring to checkout completion.
+
+Example: `out_of_stock` requires specific upfront UX, whereas
+`payment_required` can be handled generically at submission.
+
 ## Continue URL
 
 The `continue_url` field enables checkout handoff from platform to business UI,

--- a/source/schemas/shopping/types/error_code.json
+++ b/source/schemas/shopping/types/error_code.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/types/error_code.json",
+  "title": "Error Code",
+  "description": "Error code identifying the type of error. Standard errors are defined in specification (see examples), and have standardized semantics; freeform codes are permitted.",
+  "type": "string",
+  "examples": [
+    "out_of_stock",
+    "item_unavailable",
+    "address_undeliverable",
+    "payment_failed"
+  ]
+}

--- a/source/schemas/shopping/types/message_error.json
+++ b/source/schemas/shopping/types/message_error.json
@@ -16,8 +16,7 @@
       "description": "Message type discriminator."
     },
     "code": {
-      "type": "string",
-      "description": "Error code. Possible values include: missing, invalid, out_of_stock, payment_declined, requires_sign_in, requires_3ds, requires_identity_linking. Freeform codes also allowed."
+      "$ref": "error_code.json"
     },
     "path": {
       "type": "string",


### PR DESCRIPTION
It's helpful for Platforms to understand certain error codes and handle these scenarios with first-class treatment. Consider:

* ✅ `last_name_required`: No problem, maps to input field so can be handled with generic form validation
* ✅ `payment_required`: No problem, buyer hasn't reached this step yet
* ✅ `insufficient_stock`: No problem, business can allocate what's possible and give warning message on remaining quantity
* ❌ `OUT_OF_STOCK`: Problem! Platform may want to handle this immediately with a modal (e.g. `create_checkout`), only show in their Cart page UX (item goes out of stock some time after adding to cart), or elsewise provide specific/appropriate UX for this critical scenario.

Without this, Platforms need to understand each merchant's bespoke error code implementation. A small set of codes with first-class treatment is in the best interest of both merchant and buyer.

Given we also want merchant-defined codes, this cannot be an enum and is only defined in documentation.

This is not an exhaustive list, just a basic setup. PR reviewers: please note any other low-hanging fruit.

> Alt: A more generic pattern was considered, combining error messages with additional metadata. This approach seemed error-prone and higher-effort, and is not mutually exclusive with first-class errors if we want to add it down the line.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [ ] Documentation update

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules