### PR TITLE
docs: use versioned schema URLs in docs

### DIFF
--- a/docs/documentation/schema-authoring.md
+++ b/docs/documentation/schema-authoring.md
@@ -158,17 +158,17 @@ by `name` rather than arrays of objects with `name` fields.
 ```json
 {
   "capabilities": {
-    "dev.ucp.shopping.checkout": [{"version": "2026-01-11"}],
-    "dev.ucp.shopping.fulfillment": [{"version": "2026-01-11"}]
+    "dev.ucp.shopping.checkout": [{"version": "2026-01-23"}],
+    "dev.ucp.shopping.fulfillment": [{"version": "2026-01-23"}]
   },
   "services": {
     "dev.ucp.shopping": [
-      {"version": "2026-01-11", "transport": "rest"},
-      {"version": "2026-01-11", "transport": "mcp"}
+      {"version": "2026-01-23", "transport": "rest"},
+      {"version": "2026-01-23", "transport": "mcp"}
     ]
   },
   "payment_handlers": {
-    "com.google.pay": [{"id": "gpay_1234", "version": "2026-01-11"}]
+    "com.google.pay": [{"id": "gpay_1234", "version": "2026-01-23"}]
   }
 }
 ```
@@ -204,9 +204,9 @@ Each entity type defines **three variants** for different contexts:
 ```json
 {
   "dev.ucp.shopping.fulfillment": [{
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "spec": "https://ucp.dev/specification/fulfillment",
-    "schema": "https://ucp.dev/schemas/shopping/fulfillment.json",
+    "schema": "https://ucp.dev/2026-01-23/schemas/shopping/fulfillment.json",
     "config": {
       "supports_multi_group": true
     }
@@ -219,7 +219,7 @@ Each entity type defines **three variants** for different contexts:
 ```json
 {
   "dev.ucp.shopping.fulfillment": [{
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "config": {
       "allows_multi_destination": {"shipping": true}
     }
@@ -233,7 +233,7 @@ Each entity type defines **three variants** for different contexts:
 {
   "ucp": {
     "capabilities": {
-      "dev.ucp.shopping.fulfillment": [{"version": "2026-01-11"}]
+      "dev.ucp.shopping.fulfillment": [{"version": "2026-01-23"}]
     }
   }
 }
@@ -284,9 +284,9 @@ A capability schema defines both payload structure and declaration variants:
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ucp.dev/schemas/shopping/checkout.json",
+  "$id": "https://ucp.dev/2026-01-23/schemas/shopping/checkout.json",
   "name": "dev.ucp.shopping.checkout",
-  "version": "2026-01-11",
+  "version": "2026-01-23",
   "title": "Checkout",
   "description": "Base checkout schema. Extensions compose via allOf.",
 

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -405,7 +405,7 @@ Accept: application/json</pre>
  * ------------------------------------------------------------------
  */
 const UcpData = {
-  version: "2026-01-11",
+  version: "2026-01-23",
 
   inventory: {
     "sku_stickers": { title: "UCP Demo Sticker Pack", price: 599, image_url: "https://example.com/images/stickers.jpg" },
@@ -416,7 +416,7 @@ const UcpData = {
     "com.shopify.shop_pay": [
       {
         id: "shop_pay",
-        version: "2026-01-11",
+        version: "2026-01-23",
         spec: "https://shopify.dev/docs/agents/checkout/shop-pay-handler",
         config_schema: "https://shopify.dev/ucp/shop-pay-handler/2026-01-11/config.json",
         instrument_schemas: ["https://shopify.dev/ucp/shop-pay-handler/2026-01-11/instrument.json"],
@@ -426,7 +426,7 @@ const UcpData = {
     "com.google.pay": [
       {
         id: "gpay",
-        version: "2026-01-11",
+        version: "2026-01-23",
         spec: "https://pay.google.com/gp/p/ucp/2026-01-11/",
         config_schema: "https://pay.google.com/gp/p/ucp/2026-01-11/schemas/config.json",
         instrument_schemas: [
@@ -466,14 +466,14 @@ const UcpData = {
   capabilities: {
     "dev.ucp.shopping.checkout": [
       {
-        version: "2026-01-11",
+        version: "2026-01-23",
         spec: "https://ucp.dev/specs/checkout",
         schema: "https://ucp.dev/schemas/shopping/checkout.json"
       }
     ],
     "dev.ucp.shopping.order": [
       {
-        version: "2026-01-11",
+        version: "2026-01-23",
         spec: "https://ucp.dev/specs/order",
         schema: "https://ucp.dev/schemas/shopping/order.json"
       }
@@ -481,7 +481,7 @@ const UcpData = {
     "dev.ucp.shopping.fulfillment": [
       {
         extends: "dev.ucp.shopping.checkout",
-        version: "2026-01-11",
+        version: "2026-01-23",
         spec: "https://ucp.dev/specs/fulfillment",
         schema: "https://ucp.dev/schemas/shopping/fulfillment.json",
         config: {
@@ -499,7 +499,7 @@ const UcpData = {
     "dev.ucp.shopping.discount": [
       {
         extends: "dev.ucp.shopping.checkout",
-        version: "2026-01-11",
+        version: "2026-01-23",
         spec: "https://ucp.dev/specs/discount",
         schema: "https://ucp.dev/schemas/shopping/discount.json"
       }
@@ -507,7 +507,7 @@ const UcpData = {
     "dev.ucp.shopping.buyer_consent": [
       {
         extends: "dev.ucp.shopping.checkout",
-        version: "2026-01-11",
+        version: "2026-01-23",
         spec: "https://ucp.dev/specs/buyer_consent",
         schema: "https://ucp.dev/schemas/shopping/buyer_consent.json"
       }
@@ -515,7 +515,7 @@ const UcpData = {
     "dev.ucp.shopping.ap2_mandates": [
       {
         extends: "dev.ucp.shopping.checkout",
-        version: "2026-01-11",
+        version: "2026-01-23",
         spec: "https://ucp.dev/specs/ap2_mandates",
         schema: "https://ucp.dev/schemas/shopping/ap2_mandates.json"
       }

--- a/docs/specification/ap2-mandates.md
+++ b/docs/specification/ap2-mandates.md
@@ -72,16 +72,16 @@ Businesses declare support by adding `dev.ucp.shopping.ap2_mandate` to their
   "capabilities": {
     "dev.ucp.shopping.checkout": [
       {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "spec": "https://ucp.dev/specification/checkout",
-        "schema": "https://ucp.dev/schemas/shopping/checkout.json"
+        "schema": "https://ucp.dev/2026-01-23/schemas/shopping/checkout.json"
       }
     ],
     "dev.ucp.shopping.ap2_mandate": [
       {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "spec": "https://ucp.dev/specification/ap2-mandates",
-        "schema": "https://ucp.dev/schemas/shopping/ap2_mandate.json",
+        "schema": "https://ucp.dev/2026-01-23/schemas/shopping/ap2_mandate.json",
         "extends": "dev.ucp.shopping.checkout",
         "config": {
           "vp_formats_supported": {

--- a/docs/specification/buyer-consent.md
+++ b/docs/specification/buyer-consent.md
@@ -41,7 +41,7 @@ Businesses advertise consent support in their profile:
   "capabilities": {
     "dev.ucp.shopping.buyer_consent": [
       {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "extends": "dev.ucp.shopping.checkout"
       }
     ]

--- a/docs/specification/checkout-a2a.md
+++ b/docs/specification/checkout-a2a.md
@@ -28,11 +28,11 @@ platforms to interact with the business services over A2A Protocol.
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "services": {
       "dev.ucp.shopping": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/overview",
           "transport": "a2a",
           "endpoint": "https://example-business.com/.well-known/agent-card.json"
@@ -87,11 +87,11 @@ An example:
       "params": {
         "capabilities": {
           "dev.ucp.shopping.checkout": [
-            {"version": "2026-01-11"}
+            {"version": "2026-01-23"}
           ],
           "dev.ucp.shopping.fulfillment": [
             {
-              "version": "2026-01-11",
+              "version": "2026-01-23",
               "extends": "dev.ucp.shopping.checkout"
             }
           ]

--- a/docs/specification/checkout-mcp.md
+++ b/docs/specification/checkout-mcp.md
@@ -29,14 +29,14 @@ Businesses advertise MCP transport availability through their UCP profile at
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "services": {
       "dev.ucp.shopping": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/overview",
           "transport": "mcp",
-          "schema": "https://ucp.dev/services/shopping/mcp.openrpc.json",
+          "schema": "https://ucp.dev/2026-01-23/services/shopping/mcp.openrpc.json",
           "endpoint": "https://business.example.com/ucp/mcp"
         }
       ]
@@ -44,16 +44,16 @@ Businesses advertise MCP transport availability through their UCP profile at
     "capabilities": {
       "dev.ucp.shopping.checkout": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/checkout",
-          "schema": "https://ucp.dev/schemas/shopping/checkout.json"
+          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/checkout.json"
         }
       ],
       "dev.ucp.shopping.fulfillment": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/fulfillment",
-          "schema": "https://ucp.dev/schemas/shopping/fulfillment.json",
+          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/fulfillment.json",
           "extends": "dev.ucp.shopping.checkout"
         }
       ]
@@ -62,7 +62,7 @@ Businesses advertise MCP transport availability through their UCP profile at
       "com.example.vendor.delegate_payment": [
         {
           "id": "handler_1",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://example.vendor.com/specs/delegate-payment",
           "schema": "https://example.vendor.com/schemas/delegate-payment-config.json",
           "config": {}
@@ -204,18 +204,18 @@ Maps to the [Create Checkout](checkout.md#create-checkout) operation.
       "id": 1,
       "result": {
         "ucp": {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "capabilities": {
             "dev.ucp.shopping.checkout": [
-              {"version": "2026-01-11"}
+              {"version": "2026-01-23"}
             ],
             "dev.ucp.shopping.fulfillment": [
-              {"version": "2026-01-11"}
+              {"version": "2026-01-23"}
             ]
           },
           "payment_handlers": {
             "com.example.vendor.delegate_payment": [
-              {"id": "handler_1", "version": "2026-01-11", "config": {}}
+              {"id": "handler_1", "version": "2026-01-23", "config": {}}
             ]
           }
         },
@@ -413,18 +413,18 @@ Maps to the [Update Checkout](checkout.md#update-checkout) operation.
       "id": 2,
       "result": {
         "ucp": {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "capabilities": {
             "dev.ucp.shopping.checkout": [
-              {"version": "2026-01-11"}
+              {"version": "2026-01-23"}
             ],
             "dev.ucp.shopping.fulfillment": [
-              {"version": "2026-01-11"}
+              {"version": "2026-01-23"}
             ]
           },
           "payment_handlers": {
             "com.example.vendor.delegate_payment": [
-              {"id": "handler_1", "version": "2026-01-11", "config": {}}
+              {"id": "handler_1", "version": "2026-01-23", "config": {}}
             ]
           }
         },

--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -85,17 +85,17 @@ All REST endpoints **MUST** be served over HTTPS with minimum TLS version
 
     {
       "ucp": {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "capabilities": {
           "dev.ucp.shopping.checkout": [
-            {"version": "2026-01-11"}
+            {"version": "2026-01-23"}
           ]
         },
         "payment_handlers": {
           "com.shopify.shop_pay": [
             {
               "id": "shop_pay_1234",
-              "version": "2026-01-11",
+              "version": "2026-01-23",
               "config": {
                 "merchant_id": "shop_merchant_123"
               }
@@ -210,17 +210,17 @@ so clients must include all previously set fields they wish to retain.
 
     {
       "ucp": {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "capabilities": {
           "dev.ucp.shopping.checkout": [
-            {"version": "2026-01-11"}
+            {"version": "2026-01-23"}
           ]
         },
         "payment_handlers": {
           "com.shopify.shop_pay": [
             {
               "id": "shop_pay_1234",
-              "version": "2026-01-11",
+              "version": "2026-01-23",
               "config": {
                 "merchant_id": "shop_merchant_123"
               }
@@ -354,17 +354,17 @@ type & addresses.
 
     {
       "ucp": {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "capabilities": {
           "dev.ucp.shopping.checkout": [
-            {"version": "2026-01-11"}
+            {"version": "2026-01-23"}
           ]
         },
         "payment_handlers": {
           "com.google.pay": [
             {
               "id": "gpay_1234",
-              "version": "2026-01-11",
+              "version": "2026-01-23",
               "config": {
                 "allowed_payment_methods": [
                   {
@@ -566,17 +566,17 @@ Follow-up calls after initial `fulfillment` data to update selection.
 
     {
       "ucp": {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "capabilities": {
           "dev.ucp.shopping.checkout": [
-            {"version": "2026-01-11"}
+            {"version": "2026-01-23"}
           ]
         },
         "payment_handlers": {
           "com.shopify.shop_pay": [
             {
               "id": "shop_pay_1234",
-              "version": "2026-01-11",
+              "version": "2026-01-23",
               "config": {
                 "merchant_id": "shop_merchant_123"
               }
@@ -749,17 +749,17 @@ place to set these expectations via `messages`.
 
     {
       "ucp": {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "capabilities": {
           "dev.ucp.shopping.checkout": [
-            {"version": "2026-01-11"}
+            {"version": "2026-01-23"}
           ]
         },
         "payment_handlers": {
           "com.google.pay": [
             {
               "id": "gpay_1234",
-              "version": "2026-01-11",
+              "version": "2026-01-23",
               "config": {
                 "allowed_payment_methods": [
                   {
@@ -910,17 +910,17 @@ place to set these expectations via `messages`.
 
     {
       "ucp": {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "capabilities": {
           "dev.ucp.shopping.checkout": [
-            {"version": "2026-01-11"}
+            {"version": "2026-01-23"}
           ]
         },
         "payment_handlers": {
           "com.shopify.shop_pay": [
             {
               "id": "shop_pay_1234",
-              "version": "2026-01-11",
+              "version": "2026-01-23",
               "config": {
                 "merchant_id": "shop_merchant_123"
               }
@@ -1062,17 +1062,17 @@ place to set these expectations via `messages`.
 
     {
       "ucp": {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "capabilities": {
           "dev.ucp.shopping.checkout": [
-            {"version": "2026-01-11"}
+            {"version": "2026-01-23"}
           ]
         },
         "payment_handlers": {
           "com.google.pay": [
             {
               "id": "gpay_1234",
-              "version": "2026-01-11",
+              "version": "2026-01-23",
               "config": {
                 "allowed_payment_methods": [
                   {

--- a/docs/specification/discount.md
+++ b/docs/specification/discount.md
@@ -42,14 +42,14 @@ Businesses advertise discount support in their profile:
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "capabilities": {
       "dev.ucp.shopping.discount": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "extends": "dev.ucp.shopping.checkout",
           "spec": "https://ucp.dev/specification/discount",
-          "schema": "https://ucp.dev/schemas/shopping/discount.json"
+          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/discount.json"
         }
       ]
     }

--- a/docs/specification/embedded-checkout.md
+++ b/docs/specification/embedded-checkout.md
@@ -95,21 +95,21 @@ profile, they declare support for the Embedded Checkout Protocol.
     "services": {
         "dev.ucp.shopping": [
             {
-                "version": "2026-01-11",
+                "version": "2026-01-23",
                 "transport": "rest",
-                "schema": "https://ucp.dev/services/shopping/rest.openapi.json",
+                "schema": "https://ucp.dev/2026-01-23/services/shopping/rest.openapi.json",
                 "endpoint": "https://merchant.example.com/ucp/v1"
             },
             {
-                "version": "2026-01-11",
+                "version": "2026-01-23",
                 "transport": "mcp",
-                "schema": "https://ucp.dev/services/shopping/mcp.openrpc.json",
+                "schema": "https://ucp.dev/2026-01-23/services/shopping/mcp.openrpc.json",
                 "endpoint": "https://merchant.example.com/ucp/mcp"
             },
             {
-                "version": "2026-01-11",
+                "version": "2026-01-23",
                 "transport": "embedded",
-                "schema": "https://ucp.dev/services/shopping/embedded.openrpc.json"
+                "schema": "https://ucp.dev/2026-01-23/services/shopping/embedded.openrpc.json"
             }
         ]
     }
@@ -134,11 +134,11 @@ indicate ECP availability and allowed delegations for a specific session.
     "status": "open",
     "continue_url": "https://merchant.example.com/checkout/abc123",
     "ucp": {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "services": {
             "dev.ucp.shopping": [
                 {
-                    "version": "2026-01-11",
+                    "version": "2026-01-23",
                     "transport": "embedded",
                     "config": {
                         "delegate": ["payment.credential", "fulfillment.address_change"]

--- a/docs/specification/examples/encrypted-credential-handler.md
+++ b/docs/specification/examples/encrypted-credential-handler.md
@@ -145,12 +145,12 @@ have their own compliance requirements.
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "payment_handlers": {
       "com.example.platform_encrypted": [
         {
           "id": "platform_encrypted",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://platform.example.com/ucp/encrypted-handler.json",
           "schema": "https://platform.example.com/ucp/encrypted-handler/schema.json",
           "config": {
@@ -237,12 +237,12 @@ registry using `platform_config`.
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "payment_handlers": {
       "com.example.platform_encrypted": [
         {
           "id": "platform_encrypted",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://platform.example.com/ucp/encrypted-handler.json",
           "schema": "https://platform.example.com/ucp/encrypted-handler/schema.json",
           "config": {

--- a/docs/specification/examples/platform-tokenizer-payment-handler.md
+++ b/docs/specification/examples/platform-tokenizer-payment-handler.md
@@ -195,12 +195,12 @@ credential type (e.g., PCI DSS for cards).
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "payment_handlers": {
       "com.example.platform_tokenizer": [
         {
           "id": "platform_wallet",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://platform.example.com/ucp/handler.json",
           "schema": "https://platform.example.com/ucp/handler/schema.json",
           "config": {
@@ -308,12 +308,12 @@ registry using `platform_config`.
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "payment_handlers": {
       "com.example.platform_tokenizer": [
         {
           "id": "platform_wallet",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://platform.example.com/ucp/handler.json",
           "schema": "https://platform.example.com/ucp/handler/schema.json",
           "config": {

--- a/docs/specification/examples/processor-tokenizer-payment-handler.md
+++ b/docs/specification/examples/processor-tokenizer-payment-handler.md
@@ -111,12 +111,12 @@ The handler's specification (referenced via the `spec` field) documents the
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "payment_handlers": {
       "com.example.processor_tokenizer": [
         {
           "id": "processor_tokenizer",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://example.com/ucp/processor-tokenizer.json",
           "schema": "https://example.com/ucp/processor-tokenizer/schema.json",
           "config": {
@@ -185,7 +185,7 @@ business's configuration.
       "com.example.processor_tokenizer": [
         {
           "id": "processor_tokenizer",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "config": {
             "environment": "production",
             "business_id": "merchant_xyz789"

--- a/docs/specification/fulfillment.md
+++ b/docs/specification/fulfillment.md
@@ -284,10 +284,10 @@ within each method.
 
 ```json
 // Default: single group per method
-{ "dev.ucp.shopping.fulfillment": [{"version": "2026-01-11"}] }
+{ "dev.ucp.shopping.fulfillment": [{"version": "2026-01-23"}] }
 
 // Opt-in: business MAY return multiple groups per method
-{ "dev.ucp.shopping.fulfillment": [{"version": "2026-01-11", "config": { "supports_multi_group": true }}] }
+{ "dev.ucp.shopping.fulfillment": [{"version": "2026-01-23", "config": { "supports_multi_group": true }}] }
 ```
 
 ### Business Profile
@@ -302,7 +302,7 @@ Businesses declare what fulfillment configurations they support using
   "capabilities": {
     "dev.ucp.shopping.fulfillment": [
       {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "config": {
           "allows_multi_destination": {
             "shipping": true

--- a/docs/specification/order.md
+++ b/docs/specification/order.md
@@ -160,9 +160,9 @@ Examples: `refund`, `return`, `credit`, `price_adjustment`, `dispute`,
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "capabilities": {
-      "dev.ucp.shopping.order": [{"version": "2026-01-11"}]
+      "dev.ucp.shopping.order": [{"version": "2026-01-23"}]
     }
   },
   "id": "order_abc123",
@@ -282,7 +282,7 @@ platform's profile and uses it to send order lifecycle events.
 {
   "dev.ucp.shopping.order": [
     {
-      "version": "2026-01-11",
+      "version": "2026-01-23",
       "config": {
         "webhook_url": "https://platform.example.com/webhooks/ucp/orders"
       }

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -134,9 +134,9 @@ appended to this endpoint to form the complete URL.
 
 ```json
 {
-  "version": "2026-01-11",
+  "version": "2026-01-23",
   "transport": "rest",
-  "schema": "https://ucp.dev/services/shopping/rest.openapi.json",
+  "schema": "https://ucp.dev/2026-01-23/services/shopping/rest.openapi.json",
   "endpoint": "https://business.example.com/api/v2"
 }
 ```
@@ -173,9 +173,9 @@ Extensions use the `extends` field to declare their parent:
 {
   "dev.ucp.shopping.fulfillment": [
     {
-      "version": "2026-01-11",
+      "version": "2026-01-23",
       "spec": "https://ucp.dev/specification/fulfillment",
-      "schema": "https://ucp.dev/schemas/shopping/fulfillment.json",
+      "schema": "https://ucp.dev/2026-01-23/schemas/shopping/fulfillment.json",
       "extends": "dev.ucp.shopping.checkout"
     }
   ]
@@ -249,58 +249,58 @@ Businesses publish their profile at `/.well-known/ucp`. An example:
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "services": {
       "dev.ucp.shopping": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/overview",
           "transport": "rest",
           "endpoint": "https://business.example.com/ucp/v1",
-          "schema": "https://ucp.dev/services/shopping/rest.openapi.json"
+          "schema": "https://ucp.dev/2026-01-23/services/shopping/rest.openapi.json"
         },
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/overview",
           "transport": "mcp",
           "endpoint": "https://business.example.com/ucp/mcp",
-          "schema": "https://ucp.dev/services/shopping/mcp.openrpc.json"
+          "schema": "https://ucp.dev/2026-01-23/services/shopping/mcp.openrpc.json"
         },
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/overview",
           "transport": "a2a",
           "endpoint": "https://business.example.com/.well-known/agent-card.json"
         },
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/overview",
           "transport": "embedded",
-          "schema": "https://ucp.dev/services/shopping/embedded.openrpc.json"
+          "schema": "https://ucp.dev/2026-01-23/services/shopping/embedded.openrpc.json"
         }
       ]
     },
     "capabilities": {
       "dev.ucp.shopping.checkout": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/checkout",
-          "schema": "https://ucp.dev/schemas/shopping/checkout.json"
+          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/checkout.json"
         }
       ],
       "dev.ucp.shopping.fulfillment": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/fulfillment",
-          "schema": "https://ucp.dev/schemas/shopping/fulfillment.json",
+          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/fulfillment.json",
           "extends": "dev.ucp.shopping.checkout"
         }
       ],
       "dev.ucp.shopping.discount": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/discount",
-          "schema": "https://ucp.dev/schemas/shopping/discount.json",
+          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/discount.json",
           "extends": "dev.ucp.shopping.checkout"
         }
       ]
@@ -309,7 +309,7 @@ Businesses publish their profile at `/.well-known/ucp`. An example:
       "com.example.processor_tokenizer": [
         {
           "id": "processor_tokenizer",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://example.com/specs/payments/processor_tokenizer",
           "schema": "https://example.com/specs/payments/merchant_tokenizer.json",
           "config": {
@@ -354,38 +354,38 @@ example:
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "services": {
       "dev.ucp.shopping": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/overview",
           "transport": "rest",
-          "schema": "https://ucp.dev/services/shopping/rest.openapi.json"
+          "schema": "https://ucp.dev/2026-01-23/services/shopping/rest.openapi.json"
         }
       ]
     },
     "capabilities": {
       "dev.ucp.shopping.checkout": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/checkout",
-          "schema": "https://ucp.dev/schemas/shopping/checkout.json"
+          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/checkout.json"
         }
       ],
       "dev.ucp.shopping.fulfillment": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/fulfillment",
-          "schema": "https://ucp.dev/schemas/shopping/fulfillment.json",
+          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/fulfillment.json",
           "extends": "dev.ucp.shopping.checkout"
         }
       ],
       "dev.ucp.shopping.order": [
         {
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specification/order",
-          "schema": "https://ucp.dev/schemas/shopping/order.json",
+          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/order.json",
           "config": {
             "webhook_url": "https://platform.example.com/webhooks/ucp/orders"
           }
@@ -398,13 +398,13 @@ example:
           "id": "gpay_1234",
           "version": "2024-12-03",
           "spec": "https://developers.google.com/merchant/ucp/guides/gpay-payment-handler",
-          "schema": "https://pay.google.com/gp/p/ucp/2026-01-11/schemas/gpay_config.json"
+          "schema": "https://pay.google.com/gp/p/ucp/2026-01-23/schemas/gpay_config.json"
         }
       ],
       "dev.shopify.shop_pay": [
         {
           "id": "shop_pay_1234",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://shopify.dev/ucp/shop-pay-handler",
           "schema": "https://shopify.dev/ucp/schemas/shop-pay-config.json"
         }
@@ -412,9 +412,9 @@ example:
       "dev.ucp.processor_tokenizer": [
         {
           "id": "processor_tokenizer",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://example.com/specs/payments/processor_tokenizer-payment",
-          "schema": "https://ucp.dev/schemas/payments/delegate-payment.json"
+          "schema": "https://ucp.dev/2026-01-23/schemas/payments/delegate-payment.json"
         }
       ]
     }
@@ -540,18 +540,18 @@ The `capabilities` registry in responses indicates active capabilities:
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "capabilities": {
       "dev.ucp.shopping.checkout": [
-        {"version": "2026-01-11"}
+        {"version": "2026-01-23"}
       ],
       "dev.ucp.shopping.fulfillment": [
-        {"version": "2026-01-11"}
+        {"version": "2026-01-23"}
       ]
     },
     "payment_handlers": {
       "com.example.processor_tokenizer": [
-        {"id": "processor_tokenizer", "version": "2026-01-11"}
+        {"id": "processor_tokenizer", "version": "2026-01-23"}
       ]
     }
   },
@@ -679,12 +679,12 @@ an encrypted payment token.
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "payment_handlers": {
       "com.google.pay": [
         {
           "id": "8c9202bd-63cc-4241-8d24-d57ce69ea31c",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "config": {
             "api_version": 2,
             "api_version_minor": 0,
@@ -716,7 +716,7 @@ an encrypted payment token.
       "dev.shopify.shop_pay": [
         {
           "id": "shop_pay_1234",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "config": {
             "shop_id": "shopify-559128571",
             "environment": "production"
@@ -791,7 +791,7 @@ request a challenge.
       "com.example.tokenizer": [
         {
           "id": "merchant_tokenizer",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://example.com/specs/tokenizer",
           "schema": "https://example.com/schemas/tokenizer.json",
           "config": {
@@ -868,9 +868,9 @@ session token, the agent generates cryptographic mandates.
       "dev.ucp.ap2_mandate_compatible_handlers": [
         {
           "id": "ap2_234352",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://ucp.dev/specs/ap2-handler",
-          "schema": "https://ucp.dev/schemas/ap2-handler.json"
+          "schema": "https://ucp.dev/2026-01-23/schemas/ap2-handler.json"
         }
       ]
     }
@@ -1123,7 +1123,7 @@ Both businesses and platforms declare a single version in their profiles:
     ```json
     {
       "ucp": {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "services": { ... },
         "capabilities": { ... },
         "payment_handlers": { ... }
@@ -1136,7 +1136,7 @@ Both businesses and platforms declare a single version in their profiles:
     ```json
     {
       "ucp": {
-        "version": "2026-01-11",
+        "version": "2026-01-23",
         "services": { ... },
         "capabilities": { ... },
         "payment_handlers": { ... }
@@ -1164,7 +1164,7 @@ Response with version confirmation:
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "capabilities": { ... },
     "payment_handlers": { ... }
   },
@@ -1182,7 +1182,7 @@ Version unsupported error:
   "messages": [{
     "type": "error",
     "code": "version_unsupported",
-    "message": "Version 2026-01-12 is not supported. This business implements version 2026-01-11.",
+    "message": "Version 2026-01-24 is not supported. This business implements version 2026-01-23.",
     "severity": "requires_buyer_input"
   }]
 }

--- a/docs/specification/payment-handler-guide.md
+++ b/docs/specification/payment-handler-guide.md
@@ -177,7 +177,7 @@ and desired configuration.
       "com.example.handler": [
         {
           "id": "processor_tokenizer_1234",
-          "version": "2026-01-11",
+          "version": "2026-01-23",
           "spec": "https://example.com/ucp/handler",
           "schema": "https://example.com/ucp/handler/schema.json",
           "config": {
@@ -209,7 +209,7 @@ and typically includes different configuration:
 ```json
 {
   "id": "processor_tokenizer_1234",
-  "version": "2026-01-11",
+  "version": "2026-01-23",
   "spec": "https://example.com/ucp/handler",
   "schema": "https://example.com/ucp/handler/schema.json",
   "config": {
@@ -224,7 +224,7 @@ and typically includes different configuration:
 ```json
 {
   "id": "platform_tokenizer_2345", // note: ids are for disambiguation, they may differ between business and platform
-  "version": "2026-01-11",
+  "version": "2026-01-23",
   "spec": "https://example.com/ucp/handler",
   "schema": "https://example.com/ucp/handler/schema.json",
   "config": {
@@ -239,7 +239,7 @@ and typically includes different configuration:
 ```json
 {
   "id": "processor_tokenizer_1234",
-  "version": "2026-01-11",
+  "version": "2026-01-23",
   "config": {
     "api_version": 2,
     "environment": "production",
@@ -276,7 +276,7 @@ Authors typically define each shape in its own file and reference them:
   "title": "Tokenizer Handler Schema",
   "description": "Schema for the com.example.tokenizer payment handler.",
   "name": "com.example.tokenizer",
-  "version": "2026-01-11",
+  "version": "2026-01-23",
 
   "$defs": {
     "tokenizer_token": { "$ref": "types/tokenizer_token.json" },

--- a/docs/specification/payment-handler-template.md
+++ b/docs/specification/payment-handler-template.md
@@ -136,7 +136,7 @@ for the full pattern.
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "payment_handlers": {
       "{handler_name}": [
         {
@@ -202,7 +202,7 @@ Platforms advertise support for this handler in their UCP profile's
 ```json
 {
   "ucp": {
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "payment_handlers": {
       "{handler_name}": [
         {

--- a/source/handlers/tokenization/openapi.json
+++ b/source/handlers/tokenization/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Tokenization API",
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "description": "Shared API for tokenization payment handlers. Tokenizer services implement these endpoints to enable secure credential exchange. See the Tokenization Guide for implementation details."
   },
   "paths": {

--- a/source/services/shopping/openapi.json
+++ b/source/services/shopping/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "UCP Shopping Service",
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "description": "Canonical REST interface for UCP Shopping service. Schema references are logical pointers - actual payload shape is determined by negotiated capabilities.\n\n**Endpoint Resolution:** This spec defines operations only. The base URL MUST be obtained from the merchant's discovery profile at `/.well-known/ucp` under `services[\"dev.ucp.shopping\"][transport=rest].endpoint`. The `{endpoint}` server variable below is a placeholder for tooling compatibility."
   },
   "servers": [

--- a/source/services/shopping/openrpc.json
+++ b/source/services/shopping/openrpc.json
@@ -2,7 +2,7 @@
   "openrpc": "1.3.2",
   "info": {
     "title": "UCP Shopping Service",
-    "version": "2026-01-11",
+    "version": "2026-01-23",
     "description": "Canonical MCP/JSON-RPC interface for UCP Shopping service. Schema references are logical pointers - actual payload shape is determined by negotiated capabilities.\n\n**Endpoint Resolution:** This spec defines methods only. The endpoint URL MUST be obtained from the merchant's discovery profile at `/.well-known/ucp` under `services[\"dev.ucp.shopping\"][transport=mcp].endpoint`. The server entry below is a placeholder for tooling compatibility."
   },
   "servers": [


### PR DESCRIPTION
I noticed that many of the docs were still using `2026-01-11` API versions, and almost none of the docs had been updated to use a versioned schema URL. This PR fixes both issues, with the `2026-01-23` API version used consistently. I assume we will want a better, more automated way of doing this as we continue to publish versions, but in the interim, I’d love to have the docs speak a little more consistently, and point folks to permanent URLs (`ucp.dev/*` and `ucp.dev/latest/*` will always work, but their content will be variable over time, and their versions will not match with the hardcoded version strings in examples that reference those URLs).