### PR TITLE
docs: use fulfillment instead of shipping in order totals example

### DIFF
--- a/docs/specification/order.md
+++ b/docs/specification/order.md
@@ -245,7 +245,7 @@ Examples: `refund`, `return`, `credit`, `price_adjustment`, `dispute`,
   ],
   "totals": [
     { "type": "subtotal", "amount": 13000 },
-    { "type": "shipping", "amount": 1200 },
+    { "type": "fulfillment", "amount": 1200 },
     { "type": "tax", "amount": 1142 },
     { "type": "total", "amount": 15342 }
   ]


### PR DESCRIPTION
# Description

Fixes the order capability example to use `"fulfillment"` instead of `"shipping"` in the totals array. The [Total schema](https://github.com/Universal-Commerce-Protocol/ucp/blob/main/source/schemas/shopping/types/total.json) defines the type enum as: items_discount, subtotal, discount, fulfillment, tax, fee, total. The value shipping is not valid for totals.

Single line change in docs/specification/order.md:
```diff
-    { "type": "shipping", "amount": 1200 },
+    { "type": "fulfillment", "amount": 1200 },
```

Note: Other "type": "shipping" occurrences in the codebase are in fulfillment.methods[].type context, which correctly references fulfillment_method.json (enum: shipping, pickup). Only this totals example was using the wrong value.

Fixes #63

## Type of change

- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules