### PR TITLE
docs: Allow JSON and ucp-schema CLI not found errors to propagate up the call stack

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ def _resolve_schema(
       data = json.loads(result.stdout)
       _resolved_schema_cache[cache_key] = data
       return data
-  except (subprocess.SubprocessError, json.JSONDecodeError, FileNotFoundError):
+  except (subprocess.SubprocessError):
     pass
   return None
 


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Allow certain catastrophic documentation build errors (e.g JSON and ucp-schema CLI not found errors) to propagate up the call stack. This is useful when the ucp-schema is not found in local dev environment, or errors occur during Github side doc build. The additional error logging will aid with debugging the doc build issue.

## Type of change

- [X] Documentation update