### PR TITLE
docs: Allow JSON and ucp-schema CLI not found errors to propagate up the call stack

### DIFF
--- a/docs/specification/embedded-checkout.md
+++ b/docs/specification/embedded-checkout.md
@@ -197,6 +197,9 @@ parameters from business-specific query parameters:
 - `ec_delegate` (string, **OPTIONAL**): Comma-delimited list of delegations
     the host wants to handle. **SHOULD** be a subset of `config.delegate`
     from the embedded service binding.
+- `ec_color_scheme` (string, **OPTIONAL**): The color scheme preference for
+    the checkout UI. Valid values: `light`, `dark`. When not provided, the
+    Embedded Checkout follows system preference.
 
 #### Authentication
 
@@ -253,6 +256,43 @@ specification for available options.
 
 ```text
 ?ec_version=2026-01-11&ec_delegate=payment.instruments_change,payment.credential,fulfillment.address_change
+```
+
+#### Color Scheme
+
+The optional `ec_color_scheme` parameter allows the host to specify which color
+scheme the Embedded Checkout should use, enabling visual consistency between
+the host application and the checkout UI.
+
+**Valid Values:**
+
+| Value   | Description                                          |
+| :------ | :--------------------------------------------------- |
+| `light` | Use light color scheme (light background, dark text) |
+| `dark`  | Use dark color scheme (dark background, light text)  |
+
+**Default Behavior:**
+
+When `ec_color_scheme` is not provided, the Embedded Checkout can
+use the buyer's system preference via the
+[`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+media query or the
+[`Sec-CH-Prefers-Color-Scheme`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-Prefers-Color-Scheme)
+HTTP client hint, and **SHOULD** listen for changes and update accordingly.
+
+**Implementation Notes:**
+
+- By default, the Embedded Checkout **SHOULD** respect the buyer's system
+  color scheme preference and listen for changes to update accordingly
+- When `ec_color_scheme` is explicitly provided, it **MUST** override the
+  system preference, be applied immediately upon load, and be enforced
+  for the duration of the session.
+- Businesses **MAY** ignore unsupported values
+
+**Example:**
+
+```text
+https://example.com/checkout/abc123?ec_version=2026-01-11&ec_color_scheme=dark
 ```
 
 #### Delegation Negotiation

--- a/source/schemas/transports/embedded_config.json
+++ b/source/schemas/transports/embedded_config.json
@@ -9,6 +9,14 @@
       "type": "array",
       "items": { "type": "string" },
       "description": "Delegations the business allows. At service-level, declares available delegations. In checkout responses, confirms accepted delegations for this session."
+    },
+    "color_scheme": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["light", "dark"]
+      },
+      "description": "Color schemes the business supports. Hosts use ec_color_scheme query parameter to request a scheme from this list."
     }
   }
 }


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Allow certain catastrophic documentation build errors (e.g JSON and ucp-schema CLI not found errors) to propagate up the call stack. This is useful when the ucp-schema is not found in the local dev environment, or errors occur during Github-side doc build. The additional error logging will aid with debugging the doc build issue.

Example error for missing/not found `ucp-schema` CLI (after this fix/PR):
<img width="1166" height="989" alt="82SNWUWAX76GXCF" src="https://github.com/user-attachments/assets/249dc0c4-f774-440e-a9fd-e61786043786" />


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update