### PR TITLE
feat: add optional display_order to payment handlers

### DIFF
--- a/docs/specification/payment-handler-guide.md
+++ b/docs/specification/payment-handler-guide.md
@@ -314,6 +314,69 @@ authoritative value returned in the `response_schema`.
 In this example, the business's PSP is not configured for Discover, so Discover
 is excluded from the response even though the platform supports it.
 
+#### Display Ordering
+
+Businesses **MAY** include a `display_order` integer on each entry in
+`available_instruments` to suggest how payment options should be presented to
+the buyer. Lower values indicate higher preference (e.g., `0` = show first).
+
+Ordering is relative across **all** `available_instruments` entries across
+**all** handlers in the response. When the same instrument type appears in
+multiple handlers (e.g., `"card"` via both a wallet and a direct tokenizer),
+each entry carries its own `display_order` — this allows the business to rank
+distinct payment paths independently (e.g., "card via Google Pay" before "card
+via direct entry").
+
+**Semantics:**
+
+- `display_order` is **suggestive only** — platforms **MAY** override based on
+    user preference, localization, A/B tests, or other factors.
+- Entries without `display_order` express no preference and **SHOULD** be
+    placed after entries that declare one.
+- When multiple entries share the same `display_order` value, the platform
+    determines their relative order.
+- `display_order` participates in the `available_instruments` resolution flow:
+    the business includes it in the resolved `response_schema`, and platforms
+    **MUST** treat the response values as authoritative.
+
+**Example:**
+
+A business advertising three payment paths with suggested ordering:
+
+```json
+{
+  "ucp": {
+    "payment_handlers": {
+      "com.google.pay": [
+        {
+          "id": "gpay_handler",
+          "version": "{{ ucp_version }}",
+          "available_instruments": [
+            {"type": "card", "display_order": 0}
+          ],
+          "config": { "..." : "..." }
+        }
+      ],
+      "com.example.tokenizer": [
+        {
+          "id": "tokenizer_handler",
+          "version": "{{ ucp_version }}",
+          "available_instruments": [
+            {"type": "card", "constraints": {"brands": ["visa", "mastercard"]}, "display_order": 1},
+            {"type": "bank", "display_order": 2}
+          ],
+          "config": { "..." : "..." }
+        }
+      ]
+    }
+  }
+}
+```
+
+In this example the business suggests: Google Pay card first, then direct card
+entry, then bank transfer. The platform may follow this suggestion or adjust
+based on buyer context.
+
 ---
 
 #### Defining the Schema

--- a/source/schemas/shopping/types/available_payment_instrument.json
+++ b/source/schemas/shopping/types/available_payment_instrument.json
@@ -15,6 +15,11 @@
       "additionalProperties": true,
       "description": "Constraints on this instrument type. Structure depends on instrument type and active capabilities.",
       "minProperties": 1
+    },
+    "display_order": {
+      "type": "integer",
+      "description": "Business-suggested display priority for this instrument across all handlers. Lower values indicate higher preference. Ordering is suggestive; platforms MAY override based on user preference, localization, or other factors.",
+      "minimum": 0
     }
   }
 }


### PR DESCRIPTION
# Payment handler display order (merchant-suggested ordering)

## Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context.

Adds an optional **`display_order`** field to each payment handler in
`payment_handlers`. Businesses (merchants) can set an integer per handler
(lower = higher preference) to suggest how payment methods should be ordered
when presented to the user. The ordering is **suggestive only**: platforms and
agents MAY reorder (e.g. for user preference, localization, or A/B tests). Addresses #170 

This gives merchants a standard way to express their preferred order—e.g. for
fraud vs. conversion trade-offs—without requiring agents to follow it strictly.
Aligns with the same capability in the Agentic Commerce Protocol (ACP).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [ ] Documentation update

---

### Is this a Breaking Change or Removal?

N/A — optional additive field only.

---

## Motivation and context

Today the ordering of payment methods on the platform or agent side is
unspecified. Merchants know what works best for their fraud/conversion
trade-off and should be able to suggest an order at the spec level.

Fixes/Addresses: #[issue number] _(fill in the UCP issue number you created)_

---

## Example

**Handler with `display_order`:**

```json
{
  "id": "processor_tokenizer_1234",
  "version": "2026-01-11",
  "spec": "https://example.com/ucp/handler",
  "schema": "https://example.com/ucp/handler/schema.json",
  "config": { "environment": "production", "business_id": "business_xyz_789" },
  "display_order": 0
}
```

Lower `display_order` = higher preference (e.g. show first). Omission means no
suggestion.

---

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

### Pull Request Title

Use Conventional Commits, e.g.:

**`feat: add optional display_order to payment handlers`**

---

## Files changed

- **Schema:** `source/schemas/payment_handler.json` — added optional
  `display_order` (integer) to `base` definition.
- **Docs:** `docs/specification/payment-handler-guide.md` — added
  `display_order` to Business Schema example and a short description of the
  field.

---

## Additional notes

- **Backward compatible:** Optional field; existing implementations can ignore
  unknown properties. No breaking changes.
- If this project regenerates TypeScript types from the JSON schemas (e.g. via
  a script that reads `source/schemas`), re-run the generator so
  `display_order` appears in the generated types.
- Same capability is implemented in the Agentic Commerce Protocol (ACP); this
  keeps UCP and ACP aligned for merchant-suggested payment handler ordering.
