### PR TITLE
feat: Adding currency field to top level of Order

### DIFF
--- a/source/schemas/shopping/order.json
+++ b/source/schemas/shopping/order.json
@@ -83,6 +83,10 @@
       },
       "description": "Append-only event log of money movements (refunds, returns, credits, disputes, cancellations, etc.) that exist independently of fulfillment."
     },
+    "currency": {
+      "type": "string",
+      "description": "ISO 4217 currency code reflecting the merchant's market determination.",
+    },
     "totals": {
       "type": "array",
       "items": {


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Adding a currency field to the top level of the Order entity, similar to Checkout.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

