### PR TITLE
fix: update 2026-01-11 to use ucp-schema and latest version of main.py

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,10 +53,15 @@ jobs:
           git config --global user.name github-actions[bot]
           git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
 
-      - name: Fetch hooks.py from main
+      - name: Fetch hooks.py and main.py from main
         run: |
           git fetch origin main
-          git checkout origin/main -- hooks.py
+          git checkout origin/main -- hooks.py main.py
+
+      - name: Install ucp-schema for runtime resolution
+        run: |
+          cargo install ucp-schema
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install system dependencies
         run: |
@@ -142,8 +147,22 @@ jobs:
           export DOCS_MODE=spec
           VERSION_NAME=${GITHUB_REF#refs/heads/release/}
 
-          # Deploy this version, tag it as 'latest', and set it as the default site root
-          mike deploy --push --update-aliases $VERSION_NAME latest
+          # Fetch all release branches to determine if this is the latest
+          git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"
+          
+          # Find the highest version number among all release branches
+          LATEST_VERSION=$(git branch -r --list "origin/release/*" | sed 's|origin/release/||' | sort -V | tail -n 1 | tr -d ' ')
+
+          echo "Deploying version: $VERSION_NAME"
+          echo "Latest detected version: $LATEST_VERSION"
+
+          if [ "$VERSION_NAME" = "$LATEST_VERSION" ]; then
+            echo "This is the latest version. Updating 'latest' alias."
+            mike deploy --push --update-aliases "$VERSION_NAME" latest
+          else
+            echo "This is NOT the latest version. Deploying without updating 'latest' alias."
+            mike deploy --push "$VERSION_NAME"
+          fi
 
       - name: Create GitHub Release and Tag
         if: startsWith(github.ref, 'refs/heads/release/')

--- a/docs/specification/buyer-consent.md
+++ b/docs/specification/buyer-consent.md
@@ -58,7 +58,7 @@ The consent extension extends the **buyer object** within checkout:
 
 ### Consent Object
 
-{{ extension_schema_fields('buyer_consent_resp.json#/$defs/consent', 'buyer-consent') }}
+{{ extension_schema_fields('buyer_consent.json#/$defs/consent', 'buyer-consent') }}
 
 ## Usage
 

--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -1280,7 +1280,7 @@ place to set these expectations via `messages`.
 The following headers are defined for the HTTP binding and apply to all
 operations unless otherwise noted.
 
-{{ header_fields('create_checkout', 'rest.openapi.json') }}
+{{ header_fields('create_checkout', 'openapi.json') }}
 
 ### Specific Header Requirements
 

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -293,7 +293,7 @@ To be invoked by the platform when the user has expressed purchase intent
 product data (price/title etc.) provided by the business through the feeds
 **SHOULD** match the actual attributes returned in the response.
 
-{{ method_fields('create_checkout', 'rest.openapi.json', 'checkout') }}
+{{ method_fields('create_checkout', 'openapi.json', 'checkout') }}
 
 ### Get Checkout
 
@@ -306,7 +306,7 @@ checkout.
 The platform will honor the TTL provided by the business via `expires_at` at the
 time of checkout session creation.
 
-{{ method_fields('get_checkout', 'rest.openapi.json', 'checkout') }}
+{{ method_fields('get_checkout', 'openapi.json', 'checkout') }}
 
 ### Update Checkout
 
@@ -315,7 +315,7 @@ The platform is **REQUIRED** to send the entire checkout resource containing any
 data updates to write-only data fields. The resource provided in the request
 will replace the existing checkout session state on the business side.
 
-{{ method_fields('update_checkout', 'rest.openapi.json', 'checkout') }}
+{{ method_fields('update_checkout', 'openapi.json', 'checkout') }}
 
 ### Complete Checkout
 
@@ -331,7 +331,7 @@ to construct the order representation (i.e. information like `line_items`,
 After this call, other details will be updated through subsequent events
 as the order, and its associated items, moves through the supply chain.
 
-{{ method_fields('complete_checkout', 'rest.openapi.json', 'checkout') }}
+{{ method_fields('complete_checkout', 'openapi.json', 'checkout') }}
 
 ### Cancel Checkout
 
@@ -341,7 +341,7 @@ already canceled or completed), then businesses **SHOULD** send back an error
 indicating the operation is not allowed. Any checkout session with a status
 that is not equal to `completed` or `canceled` **SHOULD** be cancelable.
 
-{{ method_fields('cancel_checkout', 'rest.openapi.json', 'checkout') }}
+{{ method_fields('cancel_checkout', 'openapi.json', 'checkout') }}
 
 ## Transport Bindings
 
@@ -361,17 +361,17 @@ defined below:
 
 ### Fulfillment Option
 
-{{ extension_schema_fields('fulfillment_resp.json#/$defs/fulfillment_option', 'checkout') }}
+{{ extension_schema_fields('fulfillment.json#/$defs/fulfillment_option', 'checkout') }}
 
 ### Item
 
 #### Item Create Request
 
-{{ schema_fields('types/item.create_req', 'checkout') }}
+{{ schema_fields('types/item_create_req', 'checkout') }}
 
 #### Item Update Request
 
-{{ schema_fields('types/item.update_req', 'checkout') }}
+{{ schema_fields('types/item_update_req', 'checkout') }}
 
 #### Item Response
 
@@ -381,11 +381,11 @@ defined below:
 
 #### Line Item Create Request
 
-{{ schema_fields('types/line_item.create_req', 'checkout') }}
+{{ schema_fields('types/line_item_create_req', 'checkout') }}
 
 #### Line Item Update Request
 
-{{ schema_fields('types/line_item.update_req', 'checkout') }}
+{{ schema_fields('types/line_item_update_req', 'checkout') }}
 
 #### Line Item Response
 
@@ -432,11 +432,11 @@ field or omitting them.
 
 #### Payment Create Request
 
-{{ schema_fields('payment.create_req', 'checkout') }}
+{{ schema_fields('payment_create_req', 'checkout') }}
 
 #### Payment Update Request
 
-{{ schema_fields('payment.update_req', 'checkout') }}
+{{ schema_fields('payment_update_req', 'checkout') }}
 
 #### Payment Response
 
@@ -460,7 +460,7 @@ field or omitting them.
 
 ### Token Credential Response
 
-{{ schema_fields('token_credential.create_req', 'checkout') }}
+{{ schema_fields('token_credential_create_req', 'checkout') }}
 
 ### Card Credential
 

--- a/docs/specification/discount.md
+++ b/docs/specification/discount.md
@@ -60,15 +60,15 @@ When this capability is active, checkout is extended with a `discounts` object.
 
 ### Discounts Object
 
-{{ extension_schema_fields('discount_resp.json#/$defs/discounts_object', 'discount') }}
+{{ extension_schema_fields('discount.json#/$defs/discounts_object', 'discount') }}
 
 ### Applied Discount
 
-{{ extension_schema_fields('discount_resp.json#/$defs/applied_discount', 'discount') }}
+{{ extension_schema_fields('discount.json#/$defs/applied_discount', 'discount') }}
 
 ### Allocation
 
-{{ extension_schema_fields('discount_resp.json#/$defs/allocation', 'discount') }}
+{{ extension_schema_fields('discount.json#/$defs/allocation', 'discount') }}
 
 ## Allocation Details
 

--- a/docs/specification/embedded-checkout.md
+++ b/docs/specification/embedded-checkout.md
@@ -91,7 +91,7 @@ the `embedded` transport in their `/.well-known/ucp` profile, all checkout
         "dev.ucp.shopping": {
             "version": "2026-01-11",
             "rest": {
-                "schema": "https://ucp.dev/services/shopping/rest.openapi.json",
+                "schema": "https://ucp.dev/services/shopping/openapi.json",
                 "endpoint": "https://merchant.example.com/ucp/v1"
             },
             "mcp": {

--- a/docs/specification/fulfillment.md
+++ b/docs/specification/fulfillment.md
@@ -52,7 +52,7 @@ method.
 
 ### Properties
 
-{{ extension_fields('fulfillment_resp', 'fulfillment') }}
+{{ extension_fields('fulfillment', 'fulfillment') }}
 
 ### Entities
 

--- a/docs/specification/order.md
+++ b/docs/specification/order.md
@@ -265,7 +265,7 @@ Businesses send order status changes as events after order placement.
 Businesses POST order events to a webhook URL provided by the platform
 during partner onboarding. The URL format is platform-specific.
 
-{{ method_fields('order_event_webhook', 'rest.openapi.json', 'order') }}
+{{ method_fields('order_event_webhook', 'openapi.json', 'order') }}
 
 ### Webhook URL Configuration
 

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -132,7 +132,7 @@ appended to this endpoint to form the complete URL.
 
 ```json
 "rest": {
-  "schema": "https://ucp.dev/services/shopping/rest.openapi.json",
+  "schema": "https://ucp.dev/services/shopping/openapi.json",
   "endpoint": "https://business.example.com/api/v2"
 }
 ```
@@ -247,7 +247,7 @@ Businesses publish their profile at `/.well-known/ucp`. An example:
         "version": "2026-01-11",
         "spec": "https://ucp.dev/specification/overview",
         "rest": {
-          "schema": "https://ucp.dev/services/shopping/rest.openapi.json",
+          "schema": "https://ucp.dev/services/shopping/openapi.json",
           "endpoint": "https://business.example.com/ucp/v1"
         },
         "mcp": {

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"


### PR DESCRIPTION
# Description

Update 2026-01-11 to use ucp-schema and latest version of main.py for consistency across versions.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [x] Documentation update
