### PR TITLE
chore(ci): validate schema generation in CI

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -19,6 +19,19 @@ on:
     branches:
       - main
       - 'release/**'
+    paths:
+      - ".github/workflows/linter.yaml"
+      - ".github/workflows/schema-validation.yml"
+      - ".github/linters/**"
+      - ".pre-commit-config.yaml"
+      - "pyproject.toml"
+      - "package.json"
+      - "package-lock.json"
+      - "biome.json"
+      - "scripts/**"
+      - "source/**"
+      - "docs/**"
+      - "*.py"
 
 permissions:
   contents: read      # Required to checkout the code

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -1,0 +1,75 @@
+---
+#   Copyright 2026 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+name: Schema Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+    paths:
+      - ".github/workflows/schema-validation.yml"
+      - "generate_ts_schema_types.js"
+      - "generated/schema-types.ts"
+      - "package.json"
+      - "package-lock.json"
+      - "source/**"
+  push:
+    branches:
+      - main
+      - 'release/**'
+    paths:
+      - ".github/workflows/schema-validation.yml"
+      - "generate_ts_schema_types.js"
+      - "generated/schema-types.ts"
+      - "package.json"
+      - "package-lock.json"
+      - "source/**"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-schemas:
+    name: Generate and Validate Schemas
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install ucp-schema
+        run: |
+          cargo install ucp-schema
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Lint source schemas
+        run: ucp-schema lint source/
+
+      - name: Generate TypeScript schema types
+        run: node generate_ts_schema_types.js
+
+      - name: Verify generated files are in sync
+        run: git diff --exit-code -- generated/schema-types.ts

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -16,6 +16,12 @@ name: "Check Spelling"
 on:
   pull_request:
     branches: [main]
+    paths:
+      - ".github/workflows/spellcheck.yaml"
+      - ".github/workflows/schema-validation.yml"
+      - ".cspell.json"
+      - "**/*.md"
+      - "docs/**"
 
 jobs:
   spellcheck:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,13 @@
 exclude: '^(\.github/|\.vscode/).*|CODE_OF_CONDUCT\.md|CHANGELOG\.md'
 
 repos:
+  - repo: local
+    hooks:
+      - id: validate-generated-schema-types
+        name: validate generated schema types
+        entry: bash -c 'node generate_ts_schema_types.js && git diff --exit-code -- generated/schema-types.ts'
+        language: system
+        pass_filenames: false
   - repo: https://github.com/streetsidesoftware/cspell-cli
     rev: v9.3.3
     hooks:

--- a/generate_ts_schema_types.js
+++ b/generate_ts_schema_types.js
@@ -2,7 +2,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { compile } = require('json-schema-to-typescript');
 
-const SOURCE_ROOT = path.resolve(__dirname, 'spec');
+const SOURCE_ROOT = path.resolve(__dirname, 'source');
 const OUTPUT_FILE = path.resolve(__dirname, './generated/schema-types.ts');
 const WRAPPER_NAME = 'SCHEMA_WRAPPER';
 


### PR DESCRIPTION
As requested by maintainer Anyforget:

Wrapped up the schema-validation CI work and resolved the conflict set from PR #13.

- Added a dedicated schema-validation.yml workflow (generate, lint, and sync check)

- Added a local pre-commit hook to catch schema type drift before commit

- Updated workflow path triggers in docs.yml, linter.yaml, and spellcheck.yaml to match current repo structure

Also fixed generate_ts_schema_types.js to use source/ (not spec/) so generation runs against the current layout.