### PR TITLE
chore(pre-commit): add local schema generation sync check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,13 @@
 exclude: '^(\.github/|\.vscode/).*|CODE_OF_CONDUCT\.md|CHANGELOG\.md'
 
 repos:
+  - repo: local
+    hooks:
+      - id: validate-generated-schema-types
+        name: validate generated schema types
+        entry: bash -c 'node generate_ts_schema_types.js && git diff --exit-code -- generated/schema-types.ts'
+        language: system
+        pass_filenames: false
   - repo: https://github.com/streetsidesoftware/cspell-cli
     rev: v9.3.3
     hooks:


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Adds a pre-commit hook that runs `node generate_ts_schema_types.js` and checks `git diff --exit-code -- generated/schema-types.ts` to catch schema desync locally before committing, giving instant feedback instead of waiting for CI.

This complements the CI workflow added in part 1 — CI remains as a safety net for contributors who bypass or don't have pre-commit installed.

**Depends on part 1 (#230) being merged first**, which fixes the generator's source path so the hook produces correct output.

This is part 2 of 3 from #13, split per maintainer request.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes