### PR TITLE
fix: Resolve broken assets when a space was in the name.

### DIFF
--- a/hooks.py
+++ b/hooks.py
@@ -281,21 +281,23 @@ def on_page_markdown(markdown, page, config, files):
 
     # Rewrite relative links to assets/ to absolute URLs
     # pointing to served assets folder.
-    markdown = root_pages_asset_link_rewrite(markdown, base_path)
+    markdown = _root_pages_asset_link_rewrite(markdown, base_path)
 
   return markdown
 
 
-def root_pages_asset_link_rewrite(markdown, base_path):
+def _root_pages_asset_link_rewrite(markdown, base_path):
+  """Rewrite asset references in the root/overview to absolute links.
 
+  Uses regex to find and replace asset links with root based links.
+  """
   # Targeting the assets
   target_base = f"{base_path}assets/"
 
   def replace_link(match):
     path = match.group(1)
     # Including quotes back into the rendered new URL
-    output = f"\"{target_base}{path}\""
-    log.info(f"root_pages_asset_link_rewrite::replace_link: {path} -> {output}")
+    output = f'"{target_base}{path}"'
     return output
 
   # Pattern matches: (  prefix  assets/  path  )


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Fixes issue with assets (images) with a space in the name not being handled correctly, specifically by ensuring the output URL is quoted.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

---

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
