### PR TITLE
fix: align service definition docs with service.json schema

### DIFF
--- a/docs/specification/cart-rest.md
+++ b/docs/specification/cart-rest.md
@@ -30,14 +30,15 @@ Businesses advertise REST transport availability through their UCP profile at
   "ucp": {
     "version": "2026-01-15",
     "services": {
-      "dev.ucp.shopping": {
-        "version": "2026-01-15",
-        "spec": "https://ucp.dev/specification/overview",
-        "rest": {
-          "schema": "https://ucp.dev/services/shopping/openapi.json",
-          "endpoint": "https://business.example.com/ucp/v1"
+      "dev.ucp.shopping": [
+        {
+          "version": "2026-01-15",
+          "spec": "https://ucp.dev/specification/overview",
+          "transport": "rest",
+          "endpoint": "https://business.example.com/ucp/v1",
+          "schema": "https://ucp.dev/services/shopping/openapi.json"
         }
-      }
+      ]
     },
     "capabilities": [
       {
@@ -61,7 +62,8 @@ Businesses advertise REST transport availability through their UCP profile at
 
 All UCP REST endpoints are relative to the business's base URL, which is
 discovered through the UCP profile at `/.well-known/ucp`. The endpoint for the
-cart capability is defined in the `rest.endpoint` field of the business profile.
+cart capability is taken from the service binding whose `transport` is `rest`
+in the business profile.
 
 ### Content Types
 

--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -25,8 +25,8 @@ This document specifies the REST binding for the
 
 All UCP REST endpoints are relative to the business's base URL, which is
 discovered through the UCP profile at `/.well-known/ucp`. The endpoint for the
-checkout capability is defined in the `rest.endpoint` field of the
-business profile.
+checkout capability is taken from the service binding whose `transport` is
+`rest` in the business profile.
 
 ### Content Types
 

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -105,20 +105,13 @@ standard formats:
 
 #### Service Definition
 
-| Field             | Type   | Required | Description                         |
-| ----------------- | ------ | -------- | ----------------------------------- |
-| `version`         | string | Yes      | Service version (YYYY-MM-DD format) |
-| `spec`            | string | Yes      | URL to service documentation        |
-| `rest`            | object | No       | REST transport binding              |
-| `rest.schema`     | string | Yes      | URL to OpenAPI spec (JSON)          |
-| `rest.endpoint`   | string | Yes      | Business's REST endpoint            |
-| `mcp`             | object | No       | MCP transport binding               |
-| `mcp.schema`      | string | Yes      | URL to OpenRPC spec (JSON)          |
-| `mcp.endpoint`    | string | Yes      | Business's MCP endpoint             |
-| `a2a`             | object | No       | A2A transport binding               |
-| `a2a.endpoint`    | string | Yes      | Business's A2A Agent Card URL       |
-| `embedded`        | string | No       | Embedded transport binding          |
-| `embedded.schema` | string | Yes      | URL to OpenRPC spec (JSON)          |
+Each service binding in the `services` registry describes a single transport for
+that service. Multiple transports for the same service are represented as
+separate entries in the `services[{service_name}]` array.
+
+Service bindings follow the `service.json#/$defs/platform_schema` schema:
+
+{{ extension_schema_fields('service.json#/$defs/platform_schema', 'overview') }}
 
 Transport definitions **MUST** be thin: they declare method names and reference
 base schemas only. See [Requirements](#requirements) for details.


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Align Service Definition documentation with the canonical `service.json` schema and add a guard to prevent future drift.

This PR fixes #136 where the Service Definition section in `overview.md` still described the legacy nested `rest.schema` / `mcp.*` format, while the actual JSON schema and profile examples use a flat per-transport model with `transport`, `schema`, and `endpoint`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [x] Documentation update

---

### Is this a Breaking Change or Removal?

If you checked "Breaking change" above, or if you are removing **any** schema
files or fields:

- [ ] **I have added `!` to my PR title** (e.g., `feat!: remove field`).
- [ ] **I have added justification below.**

```text
## Breaking Changes / Removal Justification

(Please provide a detailed technical and strategic rationale here for why this
breaking change or removal is necessary.)
```

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---

### Pull Request Title

This repository enforces **Conventional Commits**. Your PR title must follow
this format: `type: description` or `type!: description` for breaking changes.

**Types:**

- `feat`: A new feature
- `fix`: A bug fix
- `docs`: Documentation only changes
- `style`: Changes that do not affect the meaning of the code (white-space,
  formatting, etc)
- `refactor`: A code change that neither fixes a bug nor adds a feature
- `perf`: A code change that improves performance
- `test`: Adding missing tests or correcting existing tests
- `chore`: Changes to the build process or auxiliary tools and libraries

**Breaking Changes:**

If your change is a breaking change (e.g., removing a field or file), you
**must** add `!` before the colon in your title:
`type!: description`

**Examples:**

- `feat: add new payment gateway`
- `fix: resolve crash on checkout`
- `docs: update setup guide`
- `feat!: remove deprecated buyer field from checkout`
