### PR TITLE
fix: Remove 'checkout' wrapper from doc examples

### DIFF
--- a/docs/specification/cart-mcp.md
+++ b/docs/specification/cart-mcp.md
@@ -165,55 +165,53 @@ Maps to the [Create Cart](cart.md#create-cart) operation.
       "id": 1,
       "result": {
         "structuredContent": {
-          "cart": {
-            "ucp": {
-              "version": "2026-01-15",
-              "capabilities": [
-                {
-                  "name": "dev.ucp.shopping.checkout",
-                  "version": "2026-01-11"
-                },
-                {
-                  "name": "dev.ucp.shopping.cart",
-                  "version": "2026-01-15"
-                }
-              ]
-            },
-            "id": "cart_abc123",
-            "line_items": [
+          "ucp": {
+            "version": "2026-01-15",
+            "capabilities": [
               {
-                "id": "li_1",
-                "item": {
-                  "id": "item_123",
-                  "title": "Red T-Shirt",
-                  "price": 2500
-                },
-                "quantity": 2,
-                "totals": [
-                  {"type": "subtotal", "amount": 5000},
-                  {"type": "total", "amount": 5000}
-                ]
-              }
-            ],
-            "currency": "USD",
-            "totals": [
-              {
-                "type": "subtotal",
-                "amount": 5000
+                "name": "dev.ucp.shopping.checkout",
+                "version": "2026-01-11"
               },
               {
-                "type": "total",
-                "amount": 5000
+                "name": "dev.ucp.shopping.cart",
+                "version": "2026-01-15"
               }
-            ],
-            "continue_url": "https://business.example.com/checkout?cart=cart_abc123",
-            "expires_at": "2026-01-16T12:00:00Z"
-          }
+            ]
+          },
+          "id": "cart_abc123",
+          "line_items": [
+            {
+              "id": "li_1",
+              "item": {
+                "id": "item_123",
+                "title": "Red T-Shirt",
+                "price": 2500
+              },
+              "quantity": 2,
+              "totals": [
+                {"type": "subtotal", "amount": 5000},
+                {"type": "total", "amount": 5000}
+              ]
+            }
+          ],
+          "currency": "USD",
+          "totals": [
+            {
+              "type": "subtotal",
+              "amount": 5000
+            },
+            {
+              "type": "total",
+              "amount": 5000
+            }
+          ],
+          "continue_url": "https://business.example.com/checkout?cart=cart_abc123",
+          "expires_at": "2026-01-16T12:00:00Z"
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"cart\":{\"ucp\":{...},\"id\":\"cart_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"cart_abc123\",...}"
           }
         ]
       }
@@ -291,55 +289,53 @@ Maps to the [Get Cart](cart.md#get-cart) operation.
       "id": 1,
       "result": {
         "structuredContent": {
-          "cart": {
-            "ucp": {
-              "version": "2026-01-15",
-              "capabilities": [
-                {
-                  "name": "dev.ucp.shopping.checkout",
-                  "version": "2026-01-11"
-                },
-                {
-                  "name": "dev.ucp.shopping.cart",
-                  "version": "2026-01-15"
-                }
-              ]
-            },
-            "id": "cart_abc123",
-            "line_items": [
+          "ucp": {
+            "version": "2026-01-15",
+            "capabilities": [
               {
-                "id": "li_1",
-                "item": {
-                  "id": "item_123",
-                  "title": "Red T-Shirt",
-                  "price": 2500
-                },
-                "quantity": 2,
-                "totals": [
-                  {"type": "subtotal", "amount": 5000},
-                  {"type": "total", "amount": 5000}
-                ]
-              }
-            ],
-            "currency": "USD",
-            "totals": [
-              {
-                "type": "subtotal",
-                "amount": 5000
+                "name": "dev.ucp.shopping.checkout",
+                "version": "2026-01-11"
               },
               {
-                "type": "total",
-                "amount": 5000
+                "name": "dev.ucp.shopping.cart",
+                "version": "2026-01-15"
               }
-            ],
-            "continue_url": "https://business.example.com/checkout?cart=cart_abc123",
-            "expires_at": "2026-01-16T12:00:00Z"
-          }
+            ]
+          },
+          "id": "cart_abc123",
+          "line_items": [
+            {
+              "id": "li_1",
+              "item": {
+                "id": "item_123",
+                "title": "Red T-Shirt",
+                "price": 2500
+              },
+              "quantity": 2,
+              "totals": [
+                {"type": "subtotal", "amount": 5000},
+                {"type": "total", "amount": 5000}
+              ]
+            }
+          ],
+          "currency": "USD",
+          "totals": [
+            {
+              "type": "subtotal",
+              "amount": 5000
+            },
+            {
+              "type": "total",
+              "amount": 5000
+            }
+          ],
+          "continue_url": "https://business.example.com/checkout?cart=cart_abc123",
+          "expires_at": "2026-01-16T12:00:00Z"
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"cart\":{\"ucp\":{...},\"id\":\"cart_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"cart_abc123\",...}"
           }
         ]
       }
@@ -441,68 +437,66 @@ Maps to the [Update Cart](cart.md#update-cart) operation.
       "id": 2,
       "result": {
         "structuredContent": {
-          "cart": {
-            "ucp": {
-              "version": "2026-01-15",
-              "capabilities": [
-                {
-                  "name": "dev.ucp.shopping.checkout",
-                  "version": "2026-01-11"
-                },
-                {
-                  "name": "dev.ucp.shopping.cart",
-                  "version": "2026-01-15"
-                }
+          "ucp": {
+            "version": "2026-01-15",
+            "capabilities": [
+              {
+                "name": "dev.ucp.shopping.checkout",
+                "version": "2026-01-11"
+              },
+              {
+                "name": "dev.ucp.shopping.cart",
+                "version": "2026-01-15"
+              }
+            ]
+          },
+          "id": "cart_abc123",
+          "line_items": [
+            {
+              "id": "li_1",
+              "item": {
+                "id": "item_123",
+                "title": "Red T-Shirt",
+                "price": 2500
+              },
+              "quantity": 3,
+              "totals": [
+                {"type": "subtotal", "amount": 7500},
+                {"type": "total", "amount": 7500}
               ]
             },
-            "id": "cart_abc123",
-            "line_items": [
-              {
-                "id": "li_1",
-                "item": {
-                  "id": "item_123",
-                  "title": "Red T-Shirt",
-                  "price": 2500
-                },
-                "quantity": 3,
-                "totals": [
-                  {"type": "subtotal", "amount": 7500},
-                  {"type": "total", "amount": 7500}
-                ]
+            {
+              "id": "li_2",
+              "item": {
+                "id": "item_456",
+                "title": "Blue Jeans",
+                "price": 7500
               },
-              {
-                "id": "li_2",
-                "item": {
-                  "id": "item_456",
-                  "title": "Blue Jeans",
-                  "price": 7500
-                },
-                "quantity": 1,
-                "totals": [
-                  {"type": "subtotal", "amount": 7500},
-                  {"type": "total", "amount": 7500}
-                ]
-              }
-            ],
-            "currency": "USD",
-            "totals": [
-              {
-                "type": "subtotal",
-                "amount": 15000
-              },
-              {
-                "type": "total",
-                "amount": 15000
-              }
-            ],
-            "continue_url": "https://business.example.com/checkout?cart=cart_abc123",
-            "expires_at": "2026-01-16T12:00:00Z"
-          }
+              "quantity": 1,
+              "totals": [
+                {"type": "subtotal", "amount": 7500},
+                {"type": "total", "amount": 7500}
+              ]
+            }
+          ],
+          "currency": "USD",
+          "totals": [
+            {
+              "type": "subtotal",
+              "amount": 15000
+            },
+            {
+              "type": "total",
+              "amount": 15000
+            }
+          ],
+          "continue_url": "https://business.example.com/checkout?cart=cart_abc123",
+          "expires_at": "2026-01-16T12:00:00Z"
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"cart\":{\"ucp\":{...},\"id\":\"cart_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"cart_abc123\",...}"
           }
         ]
       }
@@ -553,54 +547,52 @@ Maps to the [Cancel Cart](cart.md#cancel-cart) operation.
       "id": 1,
       "result": {
         "structuredContent": {
-          "cart": {
-            "ucp": {
-              "version": "2026-01-15",
-              "capabilities": [
-                {
-                  "name": "dev.ucp.shopping.checkout",
-                  "version": "2026-01-11"
-                },
-                {
-                  "name": "dev.ucp.shopping.cart",
-                  "version": "2026-01-15"
-                }
-              ]
-            },
-            "id": "cart_abc123",
-            "line_items": [
+          "ucp": {
+            "version": "2026-01-15",
+            "capabilities": [
               {
-                "id": "li_1",
-                "item": {
-                  "id": "item_123",
-                  "title": "Red T-Shirt",
-                  "price": 2500
-                },
-                "quantity": 2,
-                "totals": [
-                  {"type": "subtotal", "amount": 5000},
-                  {"type": "total", "amount": 5000}
-                ]
-              }
-            ],
-            "currency": "USD",
-            "totals": [
-              {
-                "type": "subtotal",
-                "amount": 5000
+                "name": "dev.ucp.shopping.checkout",
+                "version": "2026-01-11"
               },
               {
-                "type": "total",
-                "amount": 5000
+                "name": "dev.ucp.shopping.cart",
+                "version": "2026-01-15"
               }
-            ],
-            "continue_url": "https://business.example.com/checkout?cart=cart_abc123"
-          }
+            ]
+          },
+          "id": "cart_abc123",
+          "line_items": [
+            {
+              "id": "li_1",
+              "item": {
+                "id": "item_123",
+                "title": "Red T-Shirt",
+                "price": 2500
+              },
+              "quantity": 2,
+              "totals": [
+                {"type": "subtotal", "amount": 5000},
+                {"type": "total", "amount": 5000}
+              ]
+            }
+          ],
+          "currency": "USD",
+          "totals": [
+            {
+              "type": "subtotal",
+              "amount": 5000
+            },
+            {
+              "type": "total",
+              "amount": 5000
+            }
+          ],
+          "continue_url": "https://business.example.com/checkout?cart=cart_abc123"
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"cart\":{\"ucp\":{...},\"id\":\"cart_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"cart_abc123\",...}"
           }
         ]
       }
@@ -643,7 +635,7 @@ JSON-RPC `result` with `structuredContent` containing the UCP envelope and
       "continue_url": "https://merchant.com/"
     },
     "content": [
-      {"type": "text", "text": "{\"ucp\":{...},\"messages\":[...]}"}
+      {"type": "text", "text": "{\"ucp\":{...},\"messages\":[...],\"continue_url\":\"...\"}"}
     ]
   }
 }

--- a/docs/specification/checkout-mcp.md
+++ b/docs/specification/checkout-mcp.md
@@ -210,130 +210,128 @@ Maps to the [Create Checkout](checkout.md#create-checkout) operation.
       "id": 1,
       "result": {
         "structuredContent": {
-          "checkout": {
-            "ucp": {
-              "version": "2026-01-11",
-              "capabilities": {
-                "dev.ucp.shopping.checkout": [
-                  {"version": "2026-01-11"}
-                ],
-                "dev.ucp.shopping.fulfillment": [
-                  {"version": "2026-01-11"}
-                ]
-              },
-              "payment_handlers": {
-                "com.example.vendor.delegate_payment": [
-                  {"id": "handler_1", "version": "2026-01-11", "available_instruments": [{"type": "card"}], "config": {}}
-                ]
-              }
-            },
-            "id": "checkout_abc123",
-            "status": "incomplete",
-            "buyer": {
-              "email": "jane.doe@example.com",
-              "first_name": "Jane",
-              "last_name": "Doe"
-            },
-            "line_items": [
-              {
-                "id": "item_123",
-                "item": {
-                  "id": "item_123",
-                  "title": "Blue Jeans",
-                  "price": 5000
-                },
-                "quantity": 1,
-                "totals": [
-                  {"type": "subtotal", "amount": 5000},
-                  {"type": "total", "amount": 5000}
-                ]
-              }
-            ],
-            "currency": "USD",
-            "totals": [
-              {
-                "type": "subtotal",
-                "amount": 5000
-              },
-              {
-                "type": "fulfillment",
-                "display_text": "Shipping",
-                "amount": 500
-              },
-              {
-                "type": "total",
-                "amount": 5500
-              }
-            ],
-            "fulfillment": {
-              "methods": [
-                {
-                  "id": "shipping_1",
-                  "type": "shipping",
-                  "line_item_ids": ["item_123"],
-                  "selected_destination_id": "dest_home",
-                  "destinations": [
-                    {
-                      "id": "dest_home",
-                      "street_address": "123 Main St",
-                      "address_locality": "Springfield",
-                      "address_region": "IL",
-                      "postal_code": "62701",
-                      "address_country": "US"
-                    }
-                  ],
-                  "groups": [
-                    {
-                      "id": "package_1",
-                      "line_item_ids": ["item_123"],
-                      "selected_option_id": "standard",
-                      "options": [
-                        {
-                          "id": "standard",
-                          "title": "Standard Shipping",
-                          "description": "Arrives in 5-7 business days",
-                          "totals": [
-                            {
-                              "type": "total",
-                              "amount": 500
-                            }
-                          ]
-                        },
-                        {
-                          "id": "express",
-                          "title": "Express Shipping",
-                          "description": "Arrives in 2-3 business days",
-                          "totals": [
-                            {
-                              "type": "total",
-                              "amount": 1000
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
+          "ucp": {
+            "version": "2026-01-11",
+            "capabilities": {
+              "dev.ucp.shopping.checkout": [
+                {"version": "2026-01-11"}
+              ],
+              "dev.ucp.shopping.fulfillment": [
+                {"version": "2026-01-11"}
               ]
             },
-            "links": [
-              {
-                "type": "privacy_policy",
-                "url": "https://business.example.com/privacy"
+            "payment_handlers": {
+              "com.example.vendor.delegate_payment": [
+                {"id": "handler_1", "version": "2026-01-11", "available_instruments": [{"type": "card"}], "config": {}}
+              ]
+            }
+          },
+          "id": "checkout_abc123",
+          "status": "incomplete",
+          "buyer": {
+            "email": "jane.doe@example.com",
+            "first_name": "Jane",
+            "last_name": "Doe"
+          },
+          "line_items": [
+            {
+              "id": "item_123",
+              "item": {
+                "id": "item_123",
+                "title": "Blue Jeans",
+                "price": 5000
               },
+              "quantity": 1,
+              "totals": [
+                {"type": "subtotal", "amount": 5000},
+                {"type": "total", "amount": 5000}
+              ]
+            }
+          ],
+          "currency": "USD",
+          "totals": [
+            {
+              "type": "subtotal",
+              "amount": 5000
+            },
+            {
+              "type": "fulfillment",
+              "display_text": "Shipping",
+              "amount": 500
+            },
+            {
+              "type": "total",
+              "amount": 5500
+            }
+          ],
+          "fulfillment": {
+            "methods": [
               {
-                "type": "terms_of_service",
-                "url": "https://business.example.com/terms"
+                "id": "shipping_1",
+                "type": "shipping",
+                "line_item_ids": ["item_123"],
+                "selected_destination_id": "dest_home",
+                "destinations": [
+                  {
+                    "id": "dest_home",
+                    "street_address": "123 Main St",
+                    "address_locality": "Springfield",
+                    "address_region": "IL",
+                    "postal_code": "62701",
+                    "address_country": "US"
+                  }
+                ],
+                "groups": [
+                  {
+                    "id": "package_1",
+                    "line_item_ids": ["item_123"],
+                    "selected_option_id": "standard",
+                    "options": [
+                      {
+                        "id": "standard",
+                        "title": "Standard Shipping",
+                        "description": "Arrives in 5-7 business days",
+                        "totals": [
+                          {
+                            "type": "total",
+                            "amount": 500
+                          }
+                        ]
+                      },
+                      {
+                        "id": "express",
+                        "title": "Express Shipping",
+                        "description": "Arrives in 2-3 business days",
+                        "totals": [
+                          {
+                            "type": "total",
+                            "amount": 1000
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
-            ],
-            "continue_url": "https://business.example.com/checkout-sessions/checkout_abc123",
-            "expires_at": "2026-01-11T18:30:00Z"
-          }
+            ]
+          },
+          "links": [
+            {
+              "type": "privacy_policy",
+              "url": "https://business.example.com/privacy"
+            },
+            {
+              "type": "terms_of_service",
+              "url": "https://business.example.com/terms"
+            }
+          ],
+          "continue_url": "https://business.example.com/checkout-sessions/checkout_abc123",
+          "expires_at": "2026-01-11T18:30:00Z"
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"checkout\":{\"ucp\":{...},\"id\":\"checkout_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"checkout_abc123\",...}"
           }
         ]
       }
@@ -460,130 +458,128 @@ Maps to the [Update Checkout](checkout.md#update-checkout) operation.
       "id": 2,
       "result": {
         "structuredContent": {
-          "checkout": {
-            "ucp": {
-              "version": "2026-01-11",
-              "capabilities": {
-                "dev.ucp.shopping.checkout": [
-                  {"version": "2026-01-11"}
-                ],
-                "dev.ucp.shopping.fulfillment": [
-                  {"version": "2026-01-11"}
-                ]
-              },
-              "payment_handlers": {
-                "com.example.vendor.delegate_payment": [
-                  {"id": "handler_1", "version": "2026-01-11", "available_instruments": [{"type": "card"}], "config": {}}
-                ]
-              }
-            },
-            "id": "checkout_abc123",
-            "status": "incomplete",
-            "buyer": {
-              "email": "jane.doe@example.com",
-              "first_name": "Jane",
-              "last_name": "Doe"
-            },
-            "line_items": [
-              {
-                "id": "item_123",
-                "item": {
-                  "id": "item_123",
-                  "title": "Blue Jeans",
-                  "price": 5000
-                },
-                "quantity": 1,
-                "totals": [
-                  {"type": "subtotal", "amount": 5000},
-                  {"type": "total", "amount": 5000}
-                ]
-              }
-            ],
-            "currency": "USD",
-            "totals": [
-              {
-                "type": "subtotal",
-                "amount": 5000
-              },
-              {
-                "type": "fulfillment",
-                "display_text": "Shipping",
-                "amount": 1000
-              },
-              {
-                "type": "total",
-                "amount": 6000
-              }
-            ],
-            "fulfillment": {
-              "methods": [
-                {
-                  "id": "shipping_1",
-                  "type": "shipping",
-                  "line_item_ids": ["item_123"],
-                  "selected_destination_id": "dest_home",
-                  "destinations": [
-                    {
-                      "id": "dest_home",
-                      "street_address": "123 Main St",
-                      "address_locality": "Springfield",
-                      "address_region": "IL",
-                      "postal_code": "62701",
-                      "address_country": "US"
-                    }
-                  ],
-                  "groups": [
-                    {
-                      "id": "package_1",
-                      "line_item_ids": ["item_123"],
-                      "selected_option_id": "express",
-                      "options": [
-                        {
-                          "id": "standard",
-                          "title": "Standard Shipping",
-                          "description": "Arrives in 5-7 business days",
-                          "totals": [
-                            {
-                              "type": "total",
-                              "amount": 500
-                            }
-                          ]
-                        },
-                        {
-                          "id": "express",
-                          "title": "Express Shipping",
-                          "description": "Arrives in 2-3 business days",
-                          "totals": [
-                            {
-                              "type": "total",
-                              "amount": 1000
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
+          "ucp": {
+            "version": "2026-01-11",
+            "capabilities": {
+              "dev.ucp.shopping.checkout": [
+                {"version": "2026-01-11"}
+              ],
+              "dev.ucp.shopping.fulfillment": [
+                {"version": "2026-01-11"}
               ]
             },
-            "links": [
-              {
-                "type": "privacy_policy",
-                "url": "https://business.example.com/privacy"
+            "payment_handlers": {
+              "com.example.vendor.delegate_payment": [
+                {"id": "handler_1", "version": "2026-01-11", "available_instruments": [{"type": "card"}], "config": {}}
+              ]
+            }
+          },
+          "id": "checkout_abc123",
+          "status": "incomplete",
+          "buyer": {
+            "email": "jane.doe@example.com",
+            "first_name": "Jane",
+            "last_name": "Doe"
+          },
+          "line_items": [
+            {
+              "id": "item_123",
+              "item": {
+                "id": "item_123",
+                "title": "Blue Jeans",
+                "price": 5000
               },
+              "quantity": 1,
+              "totals": [
+                {"type": "subtotal", "amount": 5000},
+                {"type": "total", "amount": 5000}
+              ]
+            }
+          ],
+          "currency": "USD",
+          "totals": [
+            {
+              "type": "subtotal",
+              "amount": 5000
+            },
+            {
+              "type": "fulfillment",
+              "display_text": "Shipping",
+              "amount": 1000
+            },
+            {
+              "type": "total",
+              "amount": 6000
+            }
+          ],
+          "fulfillment": {
+            "methods": [
               {
-                "type": "terms_of_service",
-                "url": "https://business.example.com/terms"
+                "id": "shipping_1",
+                "type": "shipping",
+                "line_item_ids": ["item_123"],
+                "selected_destination_id": "dest_home",
+                "destinations": [
+                  {
+                    "id": "dest_home",
+                    "street_address": "123 Main St",
+                    "address_locality": "Springfield",
+                    "address_region": "IL",
+                    "postal_code": "62701",
+                    "address_country": "US"
+                  }
+                ],
+                "groups": [
+                  {
+                    "id": "package_1",
+                    "line_item_ids": ["item_123"],
+                    "selected_option_id": "express",
+                    "options": [
+                      {
+                        "id": "standard",
+                        "title": "Standard Shipping",
+                        "description": "Arrives in 5-7 business days",
+                        "totals": [
+                          {
+                            "type": "total",
+                            "amount": 500
+                          }
+                        ]
+                      },
+                      {
+                        "id": "express",
+                        "title": "Express Shipping",
+                        "description": "Arrives in 2-3 business days",
+                        "totals": [
+                          {
+                            "type": "total",
+                            "amount": 1000
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
-            ],
-            "continue_url": "https://business.example.com/checkout-sessions/checkout_abc123",
-            "expires_at": "2026-01-11T18:30:00Z"
-          }
+            ]
+          },
+          "links": [
+            {
+              "type": "privacy_policy",
+              "url": "https://business.example.com/privacy"
+            },
+            {
+              "type": "terms_of_service",
+              "url": "https://business.example.com/terms"
+            }
+          ],
+          "continue_url": "https://business.example.com/checkout-sessions/checkout_abc123",
+          "expires_at": "2026-01-11T18:30:00Z"
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"checkout\":{\"ucp\":{...},\"id\":\"checkout_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"checkout_abc123\",...}"
           }
         ]
       }
@@ -647,35 +643,33 @@ as JSON-RPC `result` with `structuredContent` containing the UCP envelope and
   "id": 1,
   "result": {
     "structuredContent": {
-      "checkout": {
-        "ucp": {
-          "version": "2026-01-11",
-          "capabilities": {
-            "dev.ucp.shopping.checkout": [{"version": "2026-01-11"}]
-          }
-        },
-        "id": "checkout_abc123",
-        "status": "incomplete",
-        "line_items": [
-          {
-            "id": "item_456",
-            "quantity": 100,
-            "available_quantity": 12
-          }
-        ],
-        "messages": [
-          {
-            "type": "warning",
-            "code": "quantity_adjusted",
-            "content": "Quantity adjusted, requested 100 units but only 12 available",
-            "path": "$.line_items[0].quantity"
-          }
-        ],
-        "continue_url": "https://merchant.com/checkout/checkout_abc123"
-      }
+      "ucp": {
+        "version": "2026-01-11",
+        "capabilities": {
+          "dev.ucp.shopping.checkout": [{"version": "2026-01-11"}]
+        }
+      },
+      "id": "checkout_abc123",
+      "status": "incomplete",
+      "line_items": [
+        {
+          "id": "item_456",
+          "quantity": 100,
+          "available_quantity": 12
+        }
+      ],
+      "messages": [
+        {
+          "type": "warning",
+          "code": "quantity_adjusted",
+          "content": "Quantity adjusted, requested 100 units but only 12 available",
+          "path": "$.line_items[0].quantity"
+        }
+      ],
+      "continue_url": "https://merchant.com/checkout/checkout_abc123"
     },
     "content": [
-      {"type": "text", "text": "{\"checkout\":{\"ucp\":{...},\"id\":\"checkout_abc123\",...}}"}
+      {"type": "text", "text": "{\"ucp\":{...},\"id\":\"checkout_abc123\",...}"}
     ]
   }
 }
@@ -770,7 +764,7 @@ Content-Digest: sha-256=:Y5fK8nLmPqRsT3vWxYzAbCdEfGhIjKlMnO...:
 Signature-Input: sig1=("@status" "content-digest" "content-type");keyid="merchant-2026"
 Signature: sig1=:MFQCIH7kL9nM2oP5qR8sT1uV4wX6yZaB3cD...:
 
-{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"..."}],"structuredContent":{"checkout":{"id":"checkout_abc123","status":"completed"}}}}
+{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"..."}],"structuredContent":{"id":"checkout_abc123","status":"completed"}}}
 ```
 
 See [Message Signatures - REST Response Signing](signatures.md#rest-response-signing)

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -1629,15 +1629,13 @@ MCP servers:
   "id": 1,
   "result": {
     "structuredContent": {
-      "checkout": {
-        "ucp": {"version": "2026-01-11", "capabilities": {...}},
-        "id": "checkout_abc123",
-        "status": "incomplete",
-        ...
-      }
+      "ucp": {"version": "2026-01-11", "capabilities": {...}},
+      "id": "checkout_abc123",
+      "status": "incomplete",
+      ...
     },
     "content": [
-      {"type": "text", "text": "{\"checkout\":{\"ucp\":{...},\"id\":\"checkout_abc123\",...}}"}
+      {"type": "text", "text": "{\"ucp\":{...},\"id\":\"checkout_abc123\",...}"}
     ]
   }
 }


### PR DESCRIPTION
# Description

https://github.com/Universal-Commerce-Protocol/ucp/pull/141 incorrectly added a `checkout` wrapper key in the documentation examples. This does not reflect the schema or what we believe to be correct, so fixing those examples.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [ ] Documentation update

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules