### PR TITLE
fix: promote reverse_domain_name to standalone type

### DIFF
--- a/source/schemas/shopping/types/reverse_domain_name.json
+++ b/source/schemas/shopping/types/reverse_domain_name.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/types/reverse_domain_name.json",
+  "title": "Reverse Domain Name",
+  "description": "Reverse-domain identifier used for collision-safe namespacing of capabilities, services, handlers, eligibility claims, and extension-contributed keys. Must contain at least two dot-separated segments (e.g., 'dev.ucp.shopping.checkout', 'com.example.loyalty_gold').",
+  "type": "string",
+  "pattern": "^[a-z][a-z0-9]*(?:\\.[a-z][a-z0-9_]*)+$"
+}

--- a/source/schemas/ucp.json
+++ b/source/schemas/ucp.json
@@ -11,12 +11,6 @@
       "description": "UCP version in YYYY-MM-DD format."
     },
 
-    "reverse_domain_name": {
-      "type": "string",
-      "pattern": "^[a-z][a-z0-9]*(?:\\.[a-z][a-z0-9_]*)+$",
-      "description": "Reverse-domain identifier (e.g., com.google.pay, dev.ucp.shopping.checkout)"
-    },
-
     "version_constraint": {
       "type": "object",
       "description": "Version range requirement with minimum and optional maximum.",
@@ -45,7 +39,7 @@
         "capabilities": {
           "type": "object",
           "description": "Required capability versions, keyed by capability name. Keys must be a subset of the extension's $defs keys.",
-          "propertyNames": { "$ref": "#/$defs/reverse_domain_name" },
+          "propertyNames": { "$ref": "shopping/types/reverse_domain_name.json" },
           "additionalProperties": { "$ref": "#/$defs/version_constraint" }
         }
       },
@@ -98,7 +92,7 @@
         "services": {
           "type": "object",
           "description": "Service registry keyed by reverse-domain name.",
-          "propertyNames": { "$ref": "#/$defs/reverse_domain_name" },
+          "propertyNames": { "$ref": "shopping/types/reverse_domain_name.json" },
           "additionalProperties": {
             "type": "array",
             "items": { "$ref": "service.json#/$defs/base" }
@@ -107,7 +101,7 @@
         "capabilities": {
           "type": "object",
           "description": "Capability registry keyed by reverse-domain name.",
-          "propertyNames": { "$ref": "#/$defs/reverse_domain_name" },
+          "propertyNames": { "$ref": "shopping/types/reverse_domain_name.json" },
           "additionalProperties": {
             "type": "array",
             "items": { "$ref": "capability.json#/$defs/base" }
@@ -116,7 +110,7 @@
         "payment_handlers": {
           "type": "object",
           "description": "Payment handler registry keyed by reverse-domain name.",
-          "propertyNames": { "$ref": "#/$defs/reverse_domain_name" },
+          "propertyNames": { "$ref": "shopping/types/reverse_domain_name.json" },
           "additionalProperties": {
             "type": "array",
             "items": { "$ref": "payment_handler.json#/$defs/base" }


### PR DESCRIPTION
Fixes [current mkdocs build failures](https://github.com/Universal-Commerce-Protocol/ucp/actions/runs/23012845260/job/66827982052?pr=250#step:13:22).

Extract reverse_domain_name from ucp.json $defs into shopping/types/reverse_domain_name.json. Update all propertyNames refs in ucp.json to point to the standalone file directly.

The docs renderer generates page-local anchors for $defs entries (prefixed with the parent schema name), but standalone types get rendered on the reference page with a linkable section. The $defs indirection caused broken #ucp-reverse-domain-name anchors on checkout, cart, catalog, and reference pages.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
