### PR TITLE
feat: attestation extension for eligibility claims

### DIFF
--- a/source/schemas/shopping/attestation.json
+++ b/source/schemas/shopping/attestation.json
@@ -3,7 +3,7 @@
   "$id": "https://ucp.dev/schemas/shopping/attestation.json",
   "name": "dev.ucp.shopping.attestation",
   "title": "Attestation Extension",
-  "description": "Extends Cart and Checkout with cryptographic attestation for eligibility claims. Enables offline verification of non-instrument claims via signed proofs.",
+  "description": "Extends Cart and Checkout with cryptographic attestation for eligibility claims. Enables offline verification of non-instrument claims via signed proofs. Implementation note: payload MUST be treated as opaque and passed through without JSON re-serialization or key reordering — any transformation will break signature verification.",
 
   "$defs": {
     "attestation_object": {
@@ -39,7 +39,7 @@
         "expires_at": {
           "type": "string",
           "format": "date-time",
-          "description": "Timestamp after which the attestation is no longer valid. Lives outside payload because it is not covered by the signature — the Business checks this independently."
+          "description": "RFC 3339 timestamp after which the attestation is no longer valid. Lives outside payload because it is not covered by the signature — the Business checks this independently."
         }
       },
       "required": ["provider_jwks", "kid", "payload", "sig", "expires_at"]

--- a/source/schemas/shopping/attestation.json
+++ b/source/schemas/shopping/attestation.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/attestation.json",
+  "name": "dev.ucp.shopping.attestation",
+  "title": "Attestation Extension",
+  "description": "Extends Cart and Checkout with cryptographic attestation for eligibility claims. Enables offline verification of non-instrument claims via signed proofs.",
+
+  "$defs": {
+    "attestation_object": {
+      "type": "object",
+      "title": "Attestation",
+      "description": "A signed proof accompanying an eligibility claim. The Business verifies by fetching the JWKS from provider_jwks, selecting the key matching kid, and verifying sig over the canonical JSON serialization of payload.",
+      "properties": {
+        "provider_jwks": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI of the JSON Web Key Set containing the verification key."
+        },
+        "kid": {
+          "type": "string",
+          "description": "Key identifier for the signing key. Resolves via the JWKS endpoint."
+        },
+        "payload": {
+          "type": "object",
+          "description": "The exact signed attestation data, passed through from the provider without transformation. Contents are provider-specific. Platforms MUST preserve the provider's original serialization to ensure signature verification succeeds.",
+          "required": ["pass"],
+          "properties": {
+            "pass": {
+              "type": "boolean",
+              "description": "Whether the attested condition was met."
+            }
+          },
+          "additionalProperties": true
+        },
+        "sig": {
+          "type": "string",
+          "description": "Base64-encoded signature over the canonical JSON serialization of payload. Algorithm is declared in the JWKS key."
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp after which the attestation is no longer valid. Lives outside payload because it is not covered by the signature — the Business checks this independently."
+        }
+      },
+      "required": ["provider_jwks", "kid", "payload", "sig", "expires_at"]
+    },
+
+    "attestations_map": {
+      "type": "object",
+      "description": "Map of eligibility claim to its attestation proof. Keys correspond to values in context.eligibility.",
+      "propertyNames": {
+        "$ref": "types/reverse_domain_name.json"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/attestation_object"
+      }
+    },
+
+    "dev.ucp.shopping.cart": {
+      "title": "Cart with Attestation",
+      "description": "Cart extended with attestation capability.",
+      "allOf": [
+        { "$ref": "cart.json" },
+        {
+          "type": "object",
+          "properties": {
+            "attestations": {
+              "$ref": "#/$defs/attestations_map",
+              "ucp_request": {
+                "create": "optional",
+                "update": "optional"
+              }
+            }
+          }
+        }
+      ]
+    },
+
+    "dev.ucp.shopping.checkout": {
+      "title": "Checkout with Attestation",
+      "description": "Checkout extended with attestation capability.",
+      "allOf": [
+        { "$ref": "checkout.json" },
+        {
+          "type": "object",
+          "properties": {
+            "attestations": {
+              "$ref": "#/$defs/attestations_map",
+              "ucp_request": {
+                "create": "optional",
+                "update": "optional",
+                "complete": "optional"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Adds a capability extension that complements eligibility (#250) with
cryptographic attestation proofs for non-instrument claims (token holdings,
on-chain credentials, membership status).

Discussed and invited in #203 and #250:

- **#203**: @igrigorik established the `provider_jwks` / `kid` / `payload` /
  `sig` attestation pattern in the signals spec
- **#250**: @igrigorik confirmed attestation as ["a great candidate for a
  capability extension that complements eligibility. Additive and
  non-breaking."](https://github.com/Universal-Commerce-Protocol/ucp/pull/250#issuecomment-4048233895)
  and specified the [sibling map
  pattern](https://github.com/Universal-Commerce-Protocol/ucp/pull/250#issuecomment-4050845563)
  — attestations keyed by eligibility claim, on the cart/checkout object
  similar to the discount extension

### How it works

- Platforms relay signed attestations from third-party verifiers alongside
  `context.eligibility` claims
- Businesses verify offline: fetch JWKS from `provider_jwks`, select key by
  `kid`, verify `sig` over `payload`
- `payload` is an opaque passthrough of the provider's signed object — no
  transformation, so signature verification works end-to-end
- `expires_at` lives outside `payload` because it is not covered by the
  signature — the Business checks this independently

Follows the discount extension pattern (`allOf` on Cart and Checkout, sibling
map keyed by reverse-domain eligibility claims).

### Wire format example

```json
{
  "context": {
    "eligibility": ["com.example.token_holder"]
  },
  "attestations": {
    "com.example.token_holder": {
      "provider_jwks": "https://example.com/.well-known/jwks.json",
      "kid": "example-key-2026-01",
      "payload": {
        "id": "att-7c3e9f",
        "pass": true,
        "results": ["..."],
        "attestedAt": "2026-03-13T19:20:32.530Z"
      },
      "sig": "base64...",
      "expires_at": "2026-03-13T19:50:32.530Z"
    }
  }
}
```

### Verification flow

1. Business receives checkout with `context.eligibility` claim + matching
   `attestations` entry
2. Fetches JWKS from `provider_jwks`, selects key matching `kid`
3. Verifies `sig` over the payload (platforms must preserve the provider's
   original serialization)
4. Checks `expires_at` hasn't passed
5. Reads `payload.pass` to confirm the claim is met

No callback to the Platform or attestation provider required — fully offline.

### Relationship to #280

This PR and #280 (wallet attestation mechanism type) are complementary but
independent:

- **This PR** adds an extension to shopping capabilities — *where* attestation
  data appears in cart/checkout wire format.
- **#280** adds a mechanism type to `identity_linking` — *how* a business
  establishes identity via wallet attestation.

Neither PR depends on the other. When both are present, the mechanism provides
the signed attestation and the extension provides the wire format for attaching
it.

---

## Files Changed

| File | Change |
|---|---|
| `source/schemas/shopping/attestation.json` | New extension schema — attestation map on Cart and Checkout via `allOf` |

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes