### PR TITLE
feat: extend warning to support disclosure contract

### DIFF
--- a/docs/specification/catalog/index.md
+++ b/docs/specification/catalog/index.md
@@ -156,9 +156,10 @@ Messages communicate business outcomes and provide context:
 | `warning` | Important conditions affecting purchase | `DELAYED_FULFILLMENT`, `FINAL_SALE` |
 | `info` | Additional context without issues | `PROMOTIONAL_PRICING`, `LIMITED_AVAILABILITY` |
 
-Warnings with `disclosure: true` carry notices (e.g., allergen
+Warnings with `presentation: "disclosure"` carry notices (e.g., allergen
 declarations, safety warnings) that platforms must not hide or dismiss. See
-[Disclosures](../checkout.md#disclosures) for the full rendering contract.
+[Warning Presentation](../checkout.md#warning-presentation) for the full
+rendering contract.
 
 **Note**: All catalog errors use `severity: "recoverable"` - agents handle them programmatically (retry, inform user, show alternatives).
 
@@ -257,7 +258,7 @@ Agents correlate results using the `inputs` array on each variant. See
 #### Product Disclosure
 
 When a product requires a disclosure (e.g., allergen notice, safety warning),
-return it as a warning with `disclosure: true`. The `path` field targets the
+return it as a warning with `presentation: "disclosure"`. The `path` field targets the
 relevant component in the response — when it targets a product, the
 disclosure applies to all of its variants.
 
@@ -291,7 +292,7 @@ disclosure applies to all of its variants.
       "path": "$.products[0]",
       "content": "**Contains: tree nuts.** Produced in a facility that also processes peanuts, milk, and soy.",
       "content_type": "markdown",
-      "disclosure": true,
+      "presentation": "disclosure",
       "image_url": "https://merchant.com/allergen-tree-nuts.svg",
       "url": "https://merchant.com/allergen-info"
     }
@@ -299,8 +300,8 @@ disclosure applies to all of its variants.
 }
 ```
 
-See [Disclosures](../checkout.md#disclosures) for the full rendering
-contract.
+See [Warning Presentation](../checkout.md#warning-presentation) for the
+full rendering contract.
 
 ## Transport Bindings
 

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -326,34 +326,57 @@ payment instrument, or by removing the claim from `context.eligibility` to
 renegotiate the checkout (obtaining updated pricing, availability, etc.)
 and then resubmitting for completion.
 
-### Disclosures
+### Warning Presentation
 
-Warning messages with `disclosure: true` carry notices —
-safety warnings, allergen declarations, compliance content, etc. — that
-**MUST** follow the prescribed rendering contract below. The `disclosure`
-flag signals that the warning **MUST NOT** be treated as a dismissible
-notice.
+The `presentation` field on warning messages controls the rendering
+contract the platform **MUST** follow. When omitted, it defaults to
+`"notice"`.
 
-#### Platform Requirements
+| | `notice` (default) | `disclosure` |
+| :--- | :--- | :--- |
+| Display content | **MUST** | **MUST** |
+| Proximity to `path` | **MAY** | **MUST** |
+| Dismissible | **MAY** | **MUST NOT** |
+| Render `image_url` | **MAY** | **MUST** |
+| Render `url` | **MAY** | **SHOULD** |
+| Escalate if cannot honor | — | **MUST** via `continue_url` |
 
-When a warning has `disclosure: true`:
+#### `notice` (default)
+
+The default rendering contract for warnings. Platforms **MUST** display
+the warning content to the buyer. Platforms **MAY** render notices in a
+banner, tray, or toast, and **MAY** allow the buyer to dismiss them.
+
+#### `disclosure`
+
+Warnings with `presentation: "disclosure"` carry notices — safety
+warnings, allergen declarations, compliance content, etc. — that
+**MUST** follow the prescribed rendering contract below.
+
+**Platform requirements:**
 
 * **MUST** display the warning `content` to the buyer.
-* **MUST** display the warning in proximity to the component referenced by
-  `path`, preserving the association between the disclosure and its subject.
-  When `path` is omitted, the disclosure applies to the response as a whole.
+* **MUST** display the warning in proximity to the component referenced
+  by `path`, preserving the association between the disclosure and its
+  subject. When `path` is omitted, the disclosure applies to the response
+  as a whole.
 * **MUST NOT** hide, collapse, or auto-dismiss the warning.
 * **MUST** render `image_url` when present (e.g., warning symbol,
   energy class label).
 * **SHOULD** render `url` as a navigable reference link when present.
 
-Warnings with `disclosure: true` **SHOULD** be given rendering priority
-over regular warnings.
+Warnings with `presentation: "disclosure"` **SHOULD** be given rendering
+priority over notices.
 
-#### Business Requirements
+Platforms that cannot honor the disclosure rendering contract **MUST**
+escalate to merchant UI via `continue_url` rather than silently
+downgrading to a notice.
 
-* **MUST** set `disclosure: true` when the warning content must be displayed
-  alongside a specific item and must not be hidden or auto-dismissed.
+**Business requirements:**
+
+* **MUST** set `presentation: "disclosure"` when the warning content must
+  be displayed alongside a specific component and must not be hidden or
+  auto-dismissed.
 * **SHOULD** use the `path` field to associate disclosures with the
   relevant component in the response.
 * **SHOULD** provide a `code` that identifies the disclosure category
@@ -363,13 +386,12 @@ over regular warnings.
 * **SHOULD** provide `url` when a reference link is available for the
   buyer to learn more.
 
-#### Disclosure vs Acknowledgment
+#### Disclosure and Acknowledgment
 
-A warning with `disclosure: true` is a presentation mechanism — it
-controls how the warning is rendered, not whether the checkout can
-proceed. When affirmative buyer acknowledgment or authorization is also
-required, the business **MAY** combine the disclosure with the escalation
-mechanisms described in the
+The `presentation` field controls how the warning is rendered, not
+whether the checkout can proceed. When affirmative buyer acknowledgment
+or authorization is also required, the business **MAY** combine the
+disclosure with the escalation mechanisms described in the
 [Checkout Status Lifecycle](#checkout-status-lifecycle) to ensure the
 appropriate buyer input is obtained.
 
@@ -416,7 +438,7 @@ warning on a line item:
       "path": "$.line_items[0]",
       "content": "**Contains: tree nuts.** Produced in a facility that also processes peanuts, milk, and soy.",
       "content_type": "markdown",
-      "disclosure": true,
+      "presentation": "disclosure",
       "image_url": "https://merchant.com/allergen-tree-nuts.svg",
       "url": "https://merchant.com/allergen-info"
     }
@@ -425,11 +447,9 @@ warning on a line item:
 }
 ```
 
-The platform resolves the recoverable error programmatically while rendering
-the allergen disclosure in proximity to the referenced line item. Platforms
-that cannot honor the disclosure rendering contract **MUST** escalate to
-merchant UI via `continue_url` rather than silently downgrading to a
-regular warning.
+The platform resolves the recoverable error programmatically while
+rendering the allergen disclosure in proximity to the referenced line
+item.
 
 ## Continue URL
 

--- a/source/schemas/shopping/types/message_warning.json
+++ b/source/schemas/shopping/types/message_warning.json
@@ -35,10 +35,10 @@
       "default": "plain",
       "description": "Content format, default = plain."
     },
-    "disclosure": {
-      "type": "boolean",
-      "default": false,
-      "description": "When true, this warning carries a disclosure that MUST be displayed in proximity to the referenced component and MUST NOT be hidden or auto-dismissed."
+    "presentation": {
+      "type": "string",
+      "default": "notice",
+      "description": "Rendering contract for this warning. 'notice' (default): platform MUST display, MAY dismiss. 'disclosure': platform MUST display in proximity to the path-referenced component, MUST NOT hide or auto-dismiss. See specification for full contract."
     },
     "image_url": {
       "type": "string",


### PR DESCRIPTION
Resolves #222

Extends `message_warning` with a `presentation` field and two new optional fields (`image_url`, `url`). When `presentation: "disclosure"`, the warning carries a notice — safety warnings, allergen declarations, compliance content, etc. — that platforms MUST display in proximity to the referenced component and MUST NOT hide, collapse, or auto-dismiss.

The `presentation` field defines the rendering contract axis for warnings. Two values are defined today:

- `"notice"` (default) — current warning behavior: MUST display, MAY dismiss
- `"disclosure"` — MUST display in proximity to `path`, MUST NOT dismiss, MUST escalate via `continue_url` if cannot honor

### Why extend warning rather than a new message type or `line_item.disclosures[]`

This is an alternative to both `line_item.disclosures[]` (#222) and a separate `type: "disclosure"`:

- `messages[]` already works across all surfaces (checkout, cart, catalog_lookup, catalog_search)
- Path-based targeting enables product-level inheritance: a disclosure on `$.products[0]` applies to all variants
- Graceful degradation: platforms that don't recognize the `presentation` field still render the underlying warning
- Preserves the established error/warning/info model without setting a precedent for type proliferation

### Why `presentation` (string) rather than `disclosure` (boolean)

- `code` = **what** the warning is about (allergens, prop65, etc.)
- `presentation` = **how** the platform must render it (notice, disclosure)

Provides a natural home for future rendering contracts. For example, an `acknowledge` value could fill the gap between display-only (`disclosure`) and full escalation (`requires_buyer_review`) — where the platform natively collects buyer confirmation without handing off to merchant UI. That value isn't needed today, but the axis is ready for it without migration.

### Examples

**Catalog — allergen disclosure targeting a product (all variants inherit):**

```json
{
  "ucp": { "version": "2026-01-11", "status": "success" },
  "products": [
    {
      "id": "prod_nut_butter",
      "title": "Artisan Nut Butter Collection",
      "variants": [
        {
          "id": "var_almond",
          "title": "Almond Butter",
          "price": { "amount": 1299, "currency": "USD" },
          "availability": { "available": true }
        },
        {
          "id": "var_cashew",
          "title": "Cashew Butter",
          "price": { "amount": 1499, "currency": "USD" },
          "availability": { "available": true }
        }
      ]
    }
  ],
  "messages": [
    {
      "type": "warning",
      "code": "allergens",
      "path": "$.products[0]",
      "content": "**Contains: tree nuts.** Produced in a facility that also processes peanuts, milk, and soy.",
      "content_type": "markdown",
      "presentation": "disclosure",
      "image_url": "https://merchant.com/allergen-tree-nuts.svg",
      "url": "https://merchant.com/allergen-info"
    }
  ]
}
```

The path targets `$.products[0]` — both Almond Butter and Cashew Butter variants inherit the disclosure without duplication. This is the key advantage over `line_item.disclosures[]`, which would require repeating the disclosure on every variant.

**Checkout — disclosure co-existing with a recoverable error:**

```json
{
  "ucp": { "version": "2026-01-11", "status": "success" },
  "id": "chk_abc123",
  "status": "incomplete",
  "currency": "USD",
  "line_items": [
    {
      "id": "li_1",
      "item": { "id": "item_456", "title": "Artisan Nut Butter Collection", "image_url": "https://merchant.com/nut-butter.jpg" },
      "quantity": 1,
      "totals": [{ "type": "subtotal", "amount": 1299 }]
    }
  ],
  "totals": [{ "type": "total", "amount": 1299 }],
  "messages": [
    {
      "type": "error",
      "code": "field_required",
      "path": "$.buyer.email",
      "content": "Buyer email is required",
      "severity": "recoverable"
    },
    {
      "type": "warning",
      "code": "allergens",
      "path": "$.line_items[0]",
      "content": "**Contains: tree nuts.** Produced in a facility that also processes peanuts, milk, and soy.",
      "content_type": "markdown",
      "presentation": "disclosure",
      "image_url": "https://merchant.com/allergen-tree-nuts.svg",
      "url": "https://merchant.com/allergen-info"
    }
  ],
  "links": []
}
```

### Key design decisions

- **`presentation` on warning, not a new type** — preserves error/warning/info model; graceful degradation over schema purity
- **String, not boolean** — extensible without migration; `code` carries the "what", `presentation` carries the "how"
- **Business resolves jurisdiction** — businesses use buyer-provided data (`context` and other inputs) and product attributes to determine applicable disclosures; platforms do not affect or resolve disclosure applicability
- **`image_url` and `url` on warning only** — other message types (error, info) don't need these fields
- **`path` is SHOULD, not MUST** — kept optional in schema; when omitted, disclosure applies to response as a whole
- **Disclosure is a presentation mechanism** — it does not gate the checkout flow; when buyer acknowledgment is also required, business MAY combine with escalation mechanisms from the checkout status lifecycle
- **MUST-escalate fallback** — platforms that cannot honor the disclosure rendering contract MUST escalate to merchant UI via `continue_url` rather than silently downgrading

---

## Checklist
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
