### PR TITLE
feat(order): Get Order operation w/ platform-auth

### DIFF
--- a/docs/specification/order-mcp.md
+++ b/docs/specification/order-mcp.md
@@ -1,0 +1,294 @@
+<!--
+   Copyright 2026 UCP Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# Order Capability - MCP Binding
+
+This document specifies the Model Context Protocol (MCP) binding for the
+[Order Capability](order.md).
+
+## Protocol Fundamentals
+
+### Discovery
+
+Businesses advertise MCP transport availability through their UCP profile at
+`/.well-known/ucp`.
+
+```json
+{
+  "ucp": {
+    "version": "2026-01",
+    "services": {
+      "dev.ucp.shopping": {
+        "version": "2026-01",
+        "spec": "https://ucp.dev/specification/overview",
+        "mcp": {
+          "schema": "https://ucp.dev/services/shopping/mcp.openrpc.json",
+          "endpoint": "https://business.example.com/ucp/mcp"
+        }
+      }
+    },
+    "capabilities": [
+      {
+        "name": "dev.ucp.shopping.order",
+        "version": "2026-01",
+        "spec": "https://ucp.dev/specification/order",
+        "schema": "https://ucp.dev/schemas/shopping/order.json"
+      }
+    ]
+  }
+}
+```
+
+### Request Metadata
+
+MCP clients **MUST** include a `meta` object in every request containing
+protocol metadata:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_order",
+    "arguments": {
+      "meta": {
+        "ucp-agent": {
+          "profile": "https://platform.example/.well-known/ucp"
+        }
+      },
+      "id": "order_abc123"
+    }
+  }
+}
+```
+
+The `meta["ucp-agent"]` field is **required** on all requests to enable
+[capability negotiation](overview.md#negotiation-protocol). Platforms **MAY**
+include additional metadata fields.
+
+## Tools
+
+UCP Capabilities map 1:1 to MCP Tools.
+
+| Tool | Operation | Description |
+| :---- | :---- | :---- |
+| `get_order` | [Get Order](order.md#get-order) | Get the current state of an order. |
+
+### `get_order`
+
+Maps to the [Get Order](order.md#get-order) operation. Returns the
+current-state snapshot of an order.
+
+#### Input Schema
+
+* `meta` (Object, required): Request metadata with `ucp-agent.profile`.
+* `id` (String, required): The ID of the order.
+
+#### Output Schema
+
+{{ schema_fields('order', 'order') }}
+
+#### Example
+
+=== "Request"
+
+    ```json
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "tools/call",
+      "params": {
+        "name": "get_order",
+        "arguments": {
+          "meta": {
+            "ucp-agent": {
+              "profile": "https://platform.example/.well-known/ucp"
+            }
+          },
+          "id": "order_abc123"
+        }
+      }
+    }
+    ```
+
+=== "Response"
+
+    ```json
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "structuredContent": {
+          "order": {
+            "ucp": {
+              "version": "2026-01",
+              "capabilities": {
+                "dev.ucp.shopping.order": [{"version": "2026-01"}]
+              }
+            },
+            "id": "order_abc123",
+            "checkout_id": "checkout_xyz789",
+            "permalink_url": "https://business.example.com/orders/abc123",
+            "line_items": [
+              {
+                "id": "li_shoes",
+                "item": { "id": "prod_shoes", "title": "Running Shoes", "price": 3000 },
+                "quantity": { "total": 1, "fulfilled": 1 },
+                "totals": [
+                  {"type": "subtotal", "amount": 3000},
+                  {"type": "total", "amount": 3000}
+                ],
+                "status": "fulfilled"
+              }
+            ],
+            "fulfillment": {
+              "expectations": [
+                {
+                  "id": "exp_1",
+                  "line_items": [{ "id": "li_shoes", "quantity": 1 }],
+                  "method_type": "shipping",
+                  "destination": {
+                    "street_address": "123 Main St",
+                    "address_locality": "Austin",
+                    "address_region": "TX",
+                    "address_country": "US",
+                    "postal_code": "78701"
+                  },
+                  "description": "Delivered"
+                }
+              ],
+              "events": [
+                {
+                  "id": "evt_1",
+                  "occurred_at": "2026-01-08T10:30:00Z",
+                  "type": "delivered",
+                  "line_items": [{ "id": "li_shoes", "quantity": 1 }],
+                  "tracking_number": "1Z999AA10123456784",
+                  "tracking_url": "https://ups.com/track/1Z999AA10123456784",
+                  "description": "Delivered to front door"
+                }
+              ]
+            },
+            "adjustments": [],
+            "totals": [
+              { "type": "subtotal", "amount": 3000 },
+              { "type": "fulfillment", "amount": 800 },
+              { "type": "tax", "amount": 304 },
+              { "type": "total", "amount": 4104 }
+            ]
+          }
+        },
+        "content": [
+          {
+            "type": "text",
+            "text": "{\"order\":{\"ucp\":{...},\"id\":\"order_abc123\",...}}"
+          }
+        ]
+      }
+    }
+    ```
+
+=== "Not Found"
+
+    ```json
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "structuredContent": {
+          "order": {
+            "ucp": {
+              "version": "2026-01",
+              "capabilities": {
+                "dev.ucp.shopping.order": [{"version": "2026-01"}]
+              }
+            },
+            "messages": [
+              {
+                "type": "error",
+                "code": "not_found",
+                "content": "Order not found."
+              }
+            ]
+          }
+        },
+        "content": [
+          {
+            "type": "text",
+            "text": "Order not found."
+          }
+        ]
+      }
+    }
+    ```
+
+=== "Not Authorized"
+
+    ```json
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "structuredContent": {
+          "order": {
+            "ucp": {
+              "version": "2026-01",
+              "capabilities": {
+                "dev.ucp.shopping.order": [{"version": "2026-01"}]
+              }
+            },
+            "messages": [
+              {
+                "type": "error",
+                "code": "unauthorized",
+                "content": "Not authorized to access this order."
+              }
+            ]
+          }
+        },
+        "content": [
+          {
+            "type": "text",
+            "text": "Not authorized to access this order."
+          }
+        ]
+      }
+    }
+    ```
+
+## Error Handling
+
+When the business cannot return an order, the response includes a `messages`
+array describing the outcome. Platforms **MUST** check `messages` before
+accessing order fields.
+
+## Conformance
+
+Platforms implementing the MCP binding:
+
+* **MUST** include `meta.ucp-agent.profile` on all requests
+* **MUST** check the `messages` array in responses before accessing order data
+* **SHOULD** delegate to the business via `permalink_url` for the authoritative
+  order experience - the business site is the source of truth for order details
+  and post-purchase operations
+* **SHOULD** rely on webhooks as the primary order update channel and use
+  `get_order` for reconciliation or on-demand retrieval
+
+Businesses implementing the MCP binding:
+
+* **MUST** authenticate requests to order data before returning a response
+  (see [Order Capability - Authorization](order.md#authorization))

--- a/docs/specification/order-rest.md
+++ b/docs/specification/order-rest.md
@@ -1,0 +1,261 @@
+<!--
+   Copyright 2026 UCP Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# Order Capability - REST Binding
+
+This document specifies the REST binding for the [Order Capability](order.md).
+
+## Protocol Fundamentals
+
+### Discovery
+
+Businesses advertise REST transport availability through their UCP profile at
+`/.well-known/ucp`.
+
+```json
+{
+  "ucp": {
+    "version": "2026-01",
+    "services": {
+      "dev.ucp.shopping": {
+        "version": "2026-01",
+        "spec": "https://ucp.dev/specification/overview",
+        "rest": {
+          "schema": "https://ucp.dev/services/shopping/openapi.json",
+          "endpoint": "https://business.example.com/ucp/v1"
+        }
+      }
+    },
+    "capabilities": [
+      {
+        "name": "dev.ucp.shopping.order",
+        "version": "2026-01",
+        "spec": "https://ucp.dev/specification/order",
+        "schema": "https://ucp.dev/schemas/shopping/order.json"
+      }
+    ]
+  }
+}
+```
+
+### Base URL
+
+All UCP REST endpoints are relative to the business's base URL, which is
+discovered through the UCP profile at `/.well-known/ucp`. The endpoint for the
+order capability is defined in the `rest.endpoint` field of the business profile.
+
+### Content Types
+
+* **Response**: `application/json`
+
+All response bodies **MUST** be valid JSON as specified in
+[RFC 8259](https://tools.ietf.org/html/rfc8259){ target="_blank" }.
+
+### Transport Security
+
+All REST endpoints **MUST** be served over HTTPS with minimum TLS version 1.3.
+
+## Operations
+
+| Operation | Method | Endpoint | Description |
+| :---- | :---- | :---- | :---- |
+| [Get Order](#get-order) | `GET` | `/orders/{id}` | Get the current state of an order. |
+
+For the Order Event Webhook (business -> platform push), see the
+[Order Capability overview](order.md#order-event-webhook).
+
+### Get Order
+
+Returns the current-state snapshot of an order.
+
+#### Input Schema
+
+* `id` (String, required): The order ID (path parameter).
+
+#### Output Schema
+
+{{ schema_fields('order', 'order') }}
+
+#### Example
+
+=== "Request"
+
+    ```json
+    GET /orders/order_abc123 HTTP/1.1
+    UCP-Agent: profile="https://platform.example/.well-known/ucp"
+    Accept: application/json
+    Signature-Input: sig1=("@method" "@authority" "@path" "ucp-agent");created=1706800000;keyid="platform-2026"
+    Signature: sig1=:MEUCIQDTxNq8h7LGHpvVZQp1iHkFp9+3N8Mxk2zH1wK4YuVN8w...:
+    ```
+
+=== "Response"
+
+    ```json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "ucp": {
+        "version": "2026-01",
+        "capabilities": {
+          "dev.ucp.shopping.order": [{"version": "2026-01"}]
+        }
+      },
+      "id": "order_abc123",
+      "checkout_id": "checkout_xyz789",
+      "permalink_url": "https://business.example.com/orders/abc123",
+      "line_items": [
+        {
+          "id": "li_shoes",
+          "item": { "id": "prod_shoes", "title": "Running Shoes", "price": 3000 },
+          "quantity": { "total": 1, "fulfilled": 1 },
+          "totals": [
+            {"type": "subtotal", "amount": 3000},
+            {"type": "total", "amount": 3000}
+          ],
+          "status": "fulfilled"
+        }
+      ],
+      "fulfillment": {
+        "expectations": [
+          {
+            "id": "exp_1",
+            "line_items": [{ "id": "li_shoes", "quantity": 1 }],
+            "method_type": "shipping",
+            "destination": {
+              "street_address": "123 Main St",
+              "address_locality": "Austin",
+              "address_region": "TX",
+              "address_country": "US",
+              "postal_code": "78701"
+            },
+            "description": "Delivered"
+          }
+        ],
+        "events": [
+          {
+            "id": "evt_1",
+            "occurred_at": "2026-01-08T10:30:00Z",
+            "type": "delivered",
+            "line_items": [{ "id": "li_shoes", "quantity": 1 }],
+            "tracking_number": "1Z999AA10123456784",
+            "tracking_url": "https://ups.com/track/1Z999AA10123456784",
+            "description": "Delivered to front door"
+          }
+        ]
+      },
+      "adjustments": [],
+      "totals": [
+        { "type": "subtotal", "amount": 3000 },
+        { "type": "fulfillment", "amount": 800 },
+        { "type": "tax", "amount": 304 },
+        { "type": "total", "amount": 4104 }
+      ]
+    }
+    ```
+
+=== "Not Found"
+
+    ```json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "ucp": {
+        "version": "2026-01",
+        "capabilities": {
+          "dev.ucp.shopping.order": [{"version": "2026-01"}]
+        }
+      },
+      "messages": [
+        {
+          "type": "error",
+          "code": "not_found",
+          "content": "Order not found."
+        }
+      ]
+    }
+    ```
+
+=== "Not Authorized"
+
+    ```json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "ucp": {
+        "version": "2026-01",
+        "capabilities": {
+          "dev.ucp.shopping.order": [{"version": "2026-01"}]
+        }
+      },
+      "messages": [
+        {
+          "type": "error",
+          "code": "unauthorized",
+          "content": "Not authorized to access this order."
+        }
+      ]
+    }
+    ```
+
+## HTTP Headers
+
+{{ header_fields('get_order', 'rest.openapi.json') }}
+
+### Specific Header Requirements
+
+**UCP-Agent** (required on all requests):
+
+Platform identification using
+[RFC 8941 Dictionary](https://www.rfc-editor.org/rfc/rfc8941#name-dictionaries){ target="_blank" }
+syntax:
+
+```http
+UCP-Agent: profile="https://platform.example/.well-known/ucp"
+```
+
+## Message Signing
+
+Request and response signatures follow the
+[Message Signatures](signatures.md) specification using RFC 9421 HTTP Message
+Signatures. See
+[REST Request Signing](signatures.md#rest-request-signing) and
+[REST Request Verification](signatures.md#rest-request-verification) for
+the complete algorithm.
+
+## Conformance
+
+Platforms implementing the REST binding:
+
+* **MUST** include `UCP-Agent` header with profile URL on all requests
+* **MUST** check the `messages` array in responses before accessing order data
+* **SHOULD** delegate to the business via `permalink_url` for the authoritative
+  order experience - the business site is the source of truth for order details
+  and post-purchase operations
+* **SHOULD** rely on webhooks as the primary order update channel and use
+  Get Order for reconciliation or on-demand retrieval
+* **SHOULD** treat order data as ephemeral and discard it when no longer needed
+  for active commerce flows
+
+Businesses implementing the REST binding:
+
+* **MUST** authenticate requests to order data before returning a response
+  (see [Order Capability - Authorization](order.md#authorization))
+* **MUST** serve all endpoints over HTTPS with TLS 1.3+
+* **SHOULD** sign responses per the
+  [Message Signatures](signatures.md) specification

--- a/docs/specification/order.md
+++ b/docs/specification/order.md
@@ -252,13 +252,101 @@ Examples: `refund`, `return`, `credit`, `price_adjustment`, `dispute`,
 }
 ```
 
-## Events
+## Operations
 
-Businesses send order status changes as events after order placement.
+The order entity is a **current-state snapshot**: the authoritative latest
+state of the order at the time of retrieval or delivery. Both Get Order and the
+Order Event Webhook return the same order shape. Webhooks deliver state updates
+proactively so platforms avoid polling; Get Order provides synchronous access
+for reconciliation or on-demand retrieval.
 
-| Event Mechanism                             | Method | Endpoint              | Description                                            |
+The `permalink_url` is the authoritative reference for the full order
+experience - timeline, post-purchase operations, returns. The API provides
+programmatic access to current state for conversational and operational use
+cases.
+
+| Operation                                   | Method | Endpoint              | Description                                            |
 | :------------------------------------------ | :----- | :-------------------- | :----------------------------------------------------- |
+| [Get Order](#get-order)                     | `GET`  | `/orders/{id}`        | Platform retrieves current order state.                |
 | [Order Event Webhook](#order-event-webhook) | `POST` | Platform-provided URL | Business sends order lifecycle events to the platform. |
+
+Transport-specific details: [REST Binding](order-rest.md) |
+[MCP Binding](order-mcp.md)
+
+### Get Order
+
+Returns the current-state snapshot of an order.
+
+#### Authorization
+
+The business **MUST** authenticate requests to order data before returning a
+response, using any supported UCP mechanism - API keys, OAuth 2.0, mutual
+TLS, or HTTP Message Signatures (see
+[Identity and Authentication](checkout-rest.md#authentication)). The
+authentication method determines the scope of accessible orders:
+
+| Authentication | Recommended Access Scope |
+| :------------- | :----------------------- |
+| Platform credentials | Orders originated by the platform |
+| Buyer authorization | Orders originated by the buyer, subject to granted scope |
+
+**Platform credentials** (API key, signatures, OAuth client credentials) -
+businesses **MAY** allow access for orders the platform originated. The
+platform provided buyer and payment information during the checkout flow,
+observed the order confirmation, and is retrieving the latest state of an
+order it already has context for.
+
+**Buyer authorization** - the platform obtains buyer authorization via
+[Identity Linking](identity-linking.md) with the necessary scopes, or a
+similar mechanism. This grants access to the buyer's orders regardless of
+which platform originated them.
+
+Businesses **MAY** define additional access policies (e.g., trusted partner
+agreements), enforce data availability constraints (e.g., retention
+windows, regulatory erasure), and omit or redact fields from the response
+based on context, business policy, or other requirements - independently
+of authorization.
+
+#### Error Responses
+
+When the business cannot return an order, the response includes a `messages`
+array describing the outcome:
+
+**Order not found:**
+
+```json
+{
+  "ucp": {
+    "version": "2026-01",
+    "capabilities": {
+      "dev.ucp.shopping.order": [{"version": "2026-01"}]
+    }
+  },
+  "messages": [{
+    "type": "error",
+    "code": "not_found",
+    "content": "Order not found."
+  }]
+}
+```
+
+**Not authorized:**
+
+```json
+{
+  "ucp": {
+    "version": "2026-01",
+    "capabilities": {
+      "dev.ucp.shopping.order": [{"version": "2026-01"}]
+    }
+  },
+  "messages": [{
+    "type": "error",
+    "code": "unauthorized",
+    "content": "Not authorized to access this order."
+  }]
+}
+```
 
 ### Order Event Webhook
 
@@ -364,18 +452,25 @@ zero-downtime key rotation procedures.
 
 **Platform:**
 
-* **MUST** respond quickly with a 2xx HTTP status code to acknowledge receipt
-* Process events asynchronously after responding
+* **MUST** respond quickly with a 2xx HTTP status code to acknowledge webhook
+  receipt; process events asynchronously after responding
+* **SHOULD** rely on webhooks as the primary order update channel and use Get
+  Order for reconciliation or on-demand retrieval
+* **MUST** include `UCP-Agent` header with profile URL on all requests
+* **SHOULD** treat order data as ephemeral and discard it when no longer needed
+  for active commerce flows
 
 **Business:**
 
 * **MUST** include `UCP-Agent` header with profile URL for signer identification
 * **MUST** sign all webhook payloads per the
   [Message Signatures](signatures.md) specification using RFC 9421 headers
-  (`Signature`, `Signature-Input`, `Content-Digest`).
+  (`Signature`, `Signature-Input`, `Content-Digest`)
 * **MUST** send "Order created" event with fully populated order entity
 * **MUST** send full order entity on updates (not incremental deltas)
 * **MUST** retry failed webhook deliveries
+* **MUST** authenticate requests to order data before returning a response
+  (see [Order Capability - Authorization](#authorization))
 
 ## Entities
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,10 @@ nav:
           - Lookup: specification/catalog/lookup.md
           - HTTP/REST Binding: specification/catalog/rest.md
           - MCP Binding: specification/catalog/mcp.md
-      - Order Capability: specification/order.md
+      - Order Capability:
+          - Overview: specification/order.md
+          - HTTP/REST Binding: specification/order-rest.md
+          - MCP Binding: specification/order-mcp.md
       - Identity Linking Capability: specification/identity-linking.md
       - Payment Handlers:
           - Guide: specification/payment-handler-guide.md
@@ -233,6 +236,8 @@ plugins:
           - specification/catalog/mcp.md
         Other Capabilities:
           - specification/order.md
+          - specification/order-rest.md
+          - specification/order-mcp.md
           - specification/identity-linking.md
           - specification/payment-handler-guide.md
           - specification/payment-handler-template.md

--- a/source/schemas/shopping/order.json
+++ b/source/schemas/shopping/order.json
@@ -89,6 +89,13 @@
     "totals": {
       "$ref": "types/totals.json",
       "description": "Different totals for the order."
+    },
+    "messages": {
+      "type": "array",
+      "items": {
+        "$ref": "types/message.json"
+      },
+      "description": "Business outcome messages (errors, warnings, informational). Present when the business needs to communicate status or issues to the platform."
     }
   }
 }

--- a/source/services/shopping/mcp.openrpc.json
+++ b/source/services/shopping/mcp.openrpc.json
@@ -316,6 +316,27 @@
         "name": "response",
         "schema": {"$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_response"}
       }
+    },
+    {
+      "name": "get_order",
+      "summary": "Get order",
+      "description": "Get the current state of an order. Returns the full order entity as a current-state snapshot.",
+      "params": [
+        {
+          "name": "meta",
+          "required": true,
+          "schema": {"$ref": "#/components/schemas/meta"}
+        },
+        {
+          "name": "id",
+          "required": true,
+          "schema": {"type": "string", "description": "The unique identifier of the order."}
+        }
+      ],
+      "result": {
+        "name": "order",
+        "schema": {"$ref": "../../schemas/shopping/order.json"}
+      }
     }
   ]
 }

--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -647,6 +647,39 @@
           }
         }
       }
+    },
+    "/orders/{id}": {
+      "parameters": [
+        { "$ref": "#/components/parameters/order_id_path" }
+      ],
+      "get": {
+        "operationId": "get_order",
+        "summary": "Get Order",
+        "description": "Get the current state of an order. Returns the full order entity as a current-state snapshot. The business verifies the requesting platform created the checkout that produced this order.",
+        "parameters": [
+          { "$ref": "#/components/parameters/authorization" },
+          { "$ref": "#/components/parameters/x_api_key" },
+          { "$ref": "#/components/parameters/signature" },
+          { "$ref": "#/components/parameters/signature_input" },
+          { "$ref": "#/components/parameters/request_id" },
+          { "$ref": "#/components/parameters/user_agent" },
+          { "$ref": "#/components/parameters/ucp_agent" },
+          { "$ref": "#/components/parameters/content_type" },
+          { "$ref": "#/components/parameters/accept" },
+          { "$ref": "#/components/parameters/accept_language" },
+          { "$ref": "#/components/parameters/accept_encoding" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order retrieved or business outcome message",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/order" }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "webhooks": {
@@ -726,6 +759,15 @@
         "in": "path",
         "required": true,
         "description": "The unique identifier of the cart.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "order_id_path": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "The unique identifier of the order.",
         "schema": {
           "type": "string"
         }


### PR DESCRIPTION
## Description

Add synchronous GET endpoint for order retrieval, complementing the
existing webhook push mechanism. Both return the same current-state
snapshot shape - webhooks deliver proactively to avoid polling, GET
provides on-demand access for reconciliation and conversational use.

Authorization model:
- **Who** - MUST authenticate (non-negotiable, any UCP mechanism)
- **What** - MAY scope access (platform credentials -> own orders, buyer authorization -> buyer's orders, or custom policies). MAY omit or redact fields based on context or business policy.
- **When** - MAY enforce data availability (retention, erasure)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings