### PR TITLE
fix: resolve file exists error when symlinking specification

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -145,6 +145,7 @@ jobs:
           rm -rf site
 
           # Add redirects for all specification files
+          rm -rf specification
           ln -s latest/specification specification
 
           # Commit and push


### PR DESCRIPTION
# Description

Fixes a deployment failure in the `docs.yml` GitHub Actions workflow where the "Deploy development version from main branch" step would crash with a `File exists` error. Added `rm -rf specification` immediately preceding the `ln -s` command. This ensures any pre-existing file, directory, or symlink at that path is completely cleared out, guaranteeing a clean slate for the new root-level redirect.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [ ] Documentation update