### PR TITLE
feat!: Update the Order schema to make currency a required field

### DIFF
--- a/source/schemas/shopping/order.json
+++ b/source/schemas/shopping/order.json
@@ -86,13 +86,7 @@
     "currency": {
       "type": "string",
       "description": "ISO 4217 currency code. MUST match the currency from the originating checkout session.",
-      "ucp_request": {
-        "transition": {
-          "from": "optional",
-          "to": "required",
-          "description": "Global requirement for currency in all Order requests."
-        }
-      }, 
+      "ucp_request": "omit", 
       "ucp_response": {
         "transition": {
           "from": "optional",


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

This PR is making the currency field in Order required. This is a followup change from PR 210. When adding the currency field to the Order schema the intention was to make it required during the next version update / breaking change.

## Type of change

Please delete options that are not relevant.

- [x] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)

---

### Is this a Breaking Change or Removal?

If you checked "Breaking change" above, or if you are removing **any** schema
files or fields:

- [x] **I have added `!` to my PR title** (e.g., `feat!: remove field`).
- [x] **I have added justification below.**

```text
## Breaking Changes / Removal Justification

The total values within the Order capability are only represented by an amount and rely on platforms having context of the currency established during Checkout. Currency has sense been added to the Order schema but as an optional field to avoid a breaking change. The intention was to make this required during the next version update / breaking change. Currency should be a required field because capabilities are meant to function independently of one another and the monetary values contained within Order are incomplete without this context. 
```
