### PR TITLE
docs: remove spurious fulfillment-option from checkout documentation

### DIFF
--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -642,10 +642,6 @@ requirements.
 
 {{ schema_fields('types/signals', 'checkout') }}
 
-### Fulfillment Option
-
-{{ extension_schema_fields('fulfillment.json#/$defs/fulfillment_option', 'checkout') }}
-
 ### Item
 
 #### Item Create Request

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -672,10 +672,6 @@ requirements.
 
 {{ schema_fields('types/attribution', 'checkout') }}
 
-### Fulfillment Option
-
-{{ extension_schema_fields('fulfillment.json#/$defs/fulfillment_option', 'checkout') }}
-
 ### Item
 
 #### Item Create Request


### PR DESCRIPTION
# Description

Remove the spurious `Fulfillment Option` entity section from the Checkout capability documentation. This entity is a child of `fulfillment_group` and belongs exclusively in the [Fulfillment Extension documentation](https://ucp.dev/latest/specification/fulfillment/), where it is already properly documented.

As reported in #101, the `Fulfillment Option` model appears in the checkout page's Table of Contents but is not referenced or linked from any other section of the checkout documentation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

Fixes #101