### PR TITLE
docs: auto-generate service definition table from schema

### DIFF
--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -115,20 +115,7 @@ standard formats:
 
 #### Service Definition
 
-| Field             | Type   | Required | Description                         |
-| ----------------- | ------ | -------- | ----------------------------------- |
-| `version`         | string | Yes      | Service version (YYYY-MM-DD format) |
-| `spec`            | string | Yes      | URL to service documentation        |
-| `rest`            | object | No       | REST transport binding              |
-| `rest.schema`     | string | Yes      | URL to OpenAPI spec (JSON)          |
-| `rest.endpoint`   | string | Yes      | Business's REST endpoint            |
-| `mcp`             | object | No       | MCP transport binding               |
-| `mcp.schema`      | string | Yes      | URL to OpenRPC spec (JSON)          |
-| `mcp.endpoint`    | string | Yes      | Business's MCP endpoint             |
-| `a2a`             | object | No       | A2A transport binding               |
-| `a2a.endpoint`    | string | Yes      | Business's A2A Agent Card URL       |
-| `embedded`        | string | No       | Embedded transport binding          |
-| `embedded.schema` | string | Yes      | URL to OpenRPC spec (JSON)          |
+{{ extension_schema_fields('service.json#/$defs/platform_schema', 'overview') }}
 
 Transport definitions **MUST** be thin: they declare method names and reference
 base schemas only. See [Requirements](#requirements) for details.


### PR DESCRIPTION
# Description

Replace the hardcoded service definition table in the [Overview](https://ucp.dev/latest/specification/overview/#service-definition) page with the `extension_schema_fields` macro, which auto-generates the table from the actual `service.json` schema.

The previous hardcoded table described an outdated nested structure (`rest.schema`, `rest.endpoint`, `mcp.schema`, `mcp.endpoint`, etc.) that no longer matches the current flat transport-based schema which uses `transport`, `schema`, and `endpoint` as top-level fields.

By using the same macro approach already used for the Capability Definition table, the service definition documentation will now stay automatically in sync with any future schema changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

Fixes #136