### PR TITLE
feat: add card verification and billing address constraints

### DIFF
--- a/docs/specification/payment-handler-guide.md
+++ b/docs/specification/payment-handler-guide.md
@@ -212,7 +212,7 @@ signal of what the merchant requires — no guesswork, no retry loops.
 |---------------------------------|---------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `brands`                        | array   | -        | Limit to specific card brands (e.g. `["visa", "mastercard"]`).                                                                                                         |
 | `requires_card_verification`    | boolean | `false`  | When `true`, the handler requires card verification data appropriate to the credential type (e.g., CVC for FPAN).                                                      |
-| `requires_billing_address_data` | string  | `"none"` | Level of billing address data required. `full_address`: complete billing address. `postal_code`: postal code only (e.g. for AVS). `none`: no billing address required. |
+| `billing_address_granularity`   | string  | `"none"` | Level of billing address required. `full_address` — complete billing address; `postal_code` — postal code only (e.g., for AVS); `none` — not required. |
 
 **Example — merchant requires card verification and billing address:**
 
@@ -224,7 +224,7 @@ signal of what the merchant requires — no guesswork, no retry loops.
       "constraints": {
         "brands": ["visa", "mastercard"],
         "requires_card_verification": true,
-        "requires_billing_address_data": "full_address"
+        "billing_address_granularity": "full_address"
       }
     }
   ]
@@ -323,7 +323,7 @@ and typically includes different configuration:
       "constraints": {
         "brands": ["visa", "mastercard"],
         "requires_card_verification": true,
-        "requires_billing_address_data": "full_address"
+        "billing_address_granularity": "full_address"
       }
     }
   ],
@@ -575,7 +575,7 @@ defines `available_card_payment_instrument` with card-specific constraints.
 | Schema                                                                                                 | Constraints                                                                                           |
 | :----------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------- |
 | [`available_payment_instrument.json`](site:schemas/shopping/types/available_payment_instrument.json)   | Base: type, constraints (open object)                                                                 |
-| `card_payment_instrument.json#/$defs/available_card_payment_instrument`                                | Extends base with `constraints.brands`, `requires_card_verification`, `requires_billing_address_data` |
+| `card_payment_instrument.json#/$defs/available_card_payment_instrument`                                | Extends base with `constraints.brands`, `requires_card_verification`, `billing_address_granularity` |
 
 Handlers reference these instrument-defined schemas when declaring
 `available_instruments`. The **instrument schema authors** define what

--- a/docs/specification/payment-handler-guide.md
+++ b/docs/specification/payment-handler-guide.md
@@ -197,6 +197,54 @@ instrument types defined by its handler schema. When present, it narrows the
 advertised types and/or applies additional constraints (e.g., limiting card
 brands to `["visa", "mastercard"]`).
 
+#### Card Constraints
+
+For card instruments, the `constraints` object supports additional properties
+beyond `brands` that communicate per-merchant requirements to the platform.
+
+Many instrument and credential properties are optional at the protocol level
+but required by individual merchants and their PSPs. For example, CVC is
+optional in `card_credential.json` but most merchants require it for
+card-not-present transactions. Named constraints give the platform a clear
+signal of what the merchant requires — no guesswork, no retry loops.
+
+| Constraint                     | Type    | Description                                                                                                                      |
+|--------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------|
+| `brands`                       | array   | Limit to specific card brands (e.g., `["visa", "mastercard"]`)                                                                   |
+| `requires_card_verification`   | boolean | When `true`, the handler requires card verification data. For FPAN: CVC. For network tokens: cryptogram and ECI.                 |
+| `requires_billing_address`     | boolean | When `true`, the handler requires a billing address on the instrument.                                                           |
+| `requires_billing_postal_code` | boolean | When `true`, the handler requires a billing postal code for AVS verification. Ignored when `requires_billing_address` is `true`. |
+
+**Example — merchant requires card verification and billing address:**
+
+```json
+{
+  "available_instruments": [
+    {
+      "type": "card",
+      "constraints": {
+        "brands": ["visa", "mastercard"],
+        "requires_card_verification": true,
+        "requires_billing_address": true
+      }
+    }
+  ]
+}
+```
+
+The platform reads `constraints` from the resolved `available_instruments`
+in the response and knows exactly what the merchant requires before
+constructing the instrument.
+
+Because constraints live on `available_instruments`, they participate in the
+existing resolution flow and can vary per merchant — a handler like
+`dev.shopify.card` serves thousands of merchants, some requiring CVC and
+some not, and each checkout resolves the correct constraints for that
+merchant.
+
+When a constraint is absent or `false`, the handler places no additional
+requirement for that field. Platforms fall back to existing behavior.
+
 ---
 
 #### Handler Declaration Variants
@@ -267,7 +315,9 @@ and typically includes different configuration:
     {
       "type": "card",
       "constraints": {
-        "brands": ["visa", "mastercard"]
+        "brands": ["visa", "mastercard"],
+        "requires_card_verification": true,
+        "requires_billing_address": true
       }
     }
   ],
@@ -313,6 +363,11 @@ authoritative value returned in the `response_schema`.
 
 In this example, the business's PSP is not configured for Discover, so Discover
 is excluded from the response even though the platform supports it.
+
+Constraints participate in this resolution naturally: the business
+includes constraint values in the resolved `available_instruments` returned
+in the response. The platform reads these requirements at the same time it
+discovers which instruments are available — no additional round-trip needed.
 
 ---
 
@@ -509,12 +564,12 @@ multiple instrument types for different payment flows.
 Each instrument schema defines its own `available_*` variant in `$defs` that
 specifies what constraints are valid for that instrument type. For example,
 [`card_payment_instrument.json`](site:schemas/shopping/types/card_payment_instrument.json)
-defines `available_card_payment_instrument` with a `brands` constraint.
+defines `available_card_payment_instrument` with card-specific constraints.
 
-| Schema                                                                                                 | Constraints                                                     |
-| :----------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------- |
-| [`available_payment_instrument.json`](site:schemas/shopping/types/available_payment_instrument.json)   | Base: type, constraints (open object)                           |
-| `card_payment_instrument.json#/$defs/available_card_payment_instrument`                                | Extends base with `constraints.brands` for card networks        |
+| Schema                                                                                                 | Constraints                                                                                                                      |
+| :----------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| [`available_payment_instrument.json`](site:schemas/shopping/types/available_payment_instrument.json)   | Base: type, constraints (open object)                                                                                            |
+| `card_payment_instrument.json#/$defs/available_card_payment_instrument`                                | Extends base with `constraints.brands`, `requires_card_verification`, `requires_billing_address`, `requires_billing_postal_code` |
 
 Handlers reference these instrument-defined schemas when declaring
 `available_instruments`. The **instrument schema authors** define what

--- a/docs/specification/payment-handler-guide.md
+++ b/docs/specification/payment-handler-guide.md
@@ -208,12 +208,11 @@ optional in `card_credential.json` but most merchants require it for
 card-not-present transactions. Named constraints give the platform a clear
 signal of what the merchant requires — no guesswork, no retry loops.
 
-| Constraint                     | Type    | Default | Description                                                                                                                      |
-|--------------------------------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------|
-| `brands`                       | array   | —       | Limit to specific card brands (e.g., `["visa", "mastercard"]`)                                                                   |
-| `requires_card_verification`   | boolean | `false` | When `true`, the handler requires card verification data. For FPAN: CVC. For network tokens: cryptogram and ECI.                 |
-| `requires_billing_address`     | boolean | `false` | When `true`, the handler requires a billing address on the instrument.                                                           |
-| `requires_billing_postal_code` | boolean | `false` | When `true`, the handler requires a billing postal code for AVS verification. Ignored when `requires_billing_address` is `true`. |
+| Constraint                      | Type    | Default  | Description                                                                                                                                                            |
+|---------------------------------|---------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `brands`                        | array   | -        | Limit to specific card brands (e.g. `["visa", "mastercard"]`).                                                                                                         |
+| `requires_card_verification`    | boolean | `false`  | When `true`, the handler requires card verification data appropriate to the credential type (e.g., CVC for FPAN).                                                      |
+| `requires_billing_address_data` | string  | `"none"` | Level of billing address data required. `full_address`: complete billing address. `postal_code`: postal code only (e.g. for AVS). `none`: no billing address required. |
 
 **Example — merchant requires card verification and billing address:**
 
@@ -225,7 +224,7 @@ signal of what the merchant requires — no guesswork, no retry loops.
       "constraints": {
         "brands": ["visa", "mastercard"],
         "requires_card_verification": true,
-        "requires_billing_address": true
+        "requires_billing_address_data": "full_address"
       }
     }
   ]
@@ -242,8 +241,9 @@ existing resolution flow and can vary per merchant — a handler like
 some not, and each checkout resolves the correct constraints for that
 merchant.
 
-When a constraint is absent or `false`, the handler places no additional
-requirement for that field. Platforms fall back to existing behavior.
+When a constraint is absent or set to its default value, the handler places
+no additional requirement for that field. Platforms fall back to existing
+behavior.
 
 Constraints are additive to schema requirements. If the instrument or
 credential schema marks a field as required, the corresponding constraint
@@ -323,7 +323,7 @@ and typically includes different configuration:
       "constraints": {
         "brands": ["visa", "mastercard"],
         "requires_card_verification": true,
-        "requires_billing_address": true
+        "requires_billing_address_data": "full_address"
       }
     }
   ],
@@ -572,10 +572,10 @@ specifies what constraints are valid for that instrument type. For example,
 [`card_payment_instrument.json`](site:schemas/shopping/types/card_payment_instrument.json)
 defines `available_card_payment_instrument` with card-specific constraints.
 
-| Schema                                                                                                 | Constraints                                                                                                                      |
-| :----------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
-| [`available_payment_instrument.json`](site:schemas/shopping/types/available_payment_instrument.json)   | Base: type, constraints (open object)                                                                                            |
-| `card_payment_instrument.json#/$defs/available_card_payment_instrument`                                | Extends base with `constraints.brands`, `requires_card_verification`, `requires_billing_address`, `requires_billing_postal_code` |
+| Schema                                                                                                 | Constraints                                                                                           |
+| :----------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------- |
+| [`available_payment_instrument.json`](site:schemas/shopping/types/available_payment_instrument.json)   | Base: type, constraints (open object)                                                                 |
+| `card_payment_instrument.json#/$defs/available_card_payment_instrument`                                | Extends base with `constraints.brands`, `requires_card_verification`, `requires_billing_address_data` |
 
 Handlers reference these instrument-defined schemas when declaring
 `available_instruments`. The **instrument schema authors** define what

--- a/docs/specification/payment-handler-guide.md
+++ b/docs/specification/payment-handler-guide.md
@@ -208,12 +208,12 @@ optional in `card_credential.json` but most merchants require it for
 card-not-present transactions. Named constraints give the platform a clear
 signal of what the merchant requires — no guesswork, no retry loops.
 
-| Constraint                     | Type    | Description                                                                                                                      |
-|--------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------|
-| `brands`                       | array   | Limit to specific card brands (e.g., `["visa", "mastercard"]`)                                                                   |
-| `requires_card_verification`   | boolean | When `true`, the handler requires card verification data. For FPAN: CVC. For network tokens: cryptogram and ECI.                 |
-| `requires_billing_address`     | boolean | When `true`, the handler requires a billing address on the instrument.                                                           |
-| `requires_billing_postal_code` | boolean | When `true`, the handler requires a billing postal code for AVS verification. Ignored when `requires_billing_address` is `true`. |
+| Constraint                     | Type    | Default | Description                                                                                                                      |
+|--------------------------------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------|
+| `brands`                       | array   | —       | Limit to specific card brands (e.g., `["visa", "mastercard"]`)                                                                   |
+| `requires_card_verification`   | boolean | `false` | When `true`, the handler requires card verification data. For FPAN: CVC. For network tokens: cryptogram and ECI.                 |
+| `requires_billing_address`     | boolean | `false` | When `true`, the handler requires a billing address on the instrument.                                                           |
+| `requires_billing_postal_code` | boolean | `false` | When `true`, the handler requires a billing postal code for AVS verification. Ignored when `requires_billing_address` is `true`. |
 
 **Example — merchant requires card verification and billing address:**
 
@@ -244,6 +244,12 @@ merchant.
 
 When a constraint is absent or `false`, the handler places no additional
 requirement for that field. Platforms fall back to existing behavior.
+
+Constraints are additive to schema requirements. If the instrument or
+credential schema marks a field as required, the corresponding constraint
+is redundant and **MUST NOT** be interpreted as overriding the schema. A
+`requires_*` constraint of `false` or absent does not make a
+schema-required field optional.
 
 ---
 

--- a/source/schemas/shopping/types/card_payment_instrument.json
+++ b/source/schemas/shopping/types/card_payment_instrument.json
@@ -24,6 +24,18 @@
                   "minItems": 1,
                   "uniqueItems": true,
                   "description": "Limit to specific card brands (e.g., ['visa', 'mastercard', 'amex'])."
+                },
+                "requires_card_verification": {
+                  "type": "boolean",
+                  "description": "When true, the handler requires card verification data. For FPAN: CVC. For network tokens: cryptogram and ECI."
+                },
+                "requires_billing_address": {
+                  "type": "boolean",
+                  "description": "When true, the handler requires a billing address on the instrument."
+                },
+                "requires_billing_postal_code": {
+                  "type": "boolean",
+                  "description": "When true, the handler requires a billing postal code for AVS verification. Ignored when requires_billing_address is true."
                 }
               }
             }

--- a/source/schemas/shopping/types/card_payment_instrument.json
+++ b/source/schemas/shopping/types/card_payment_instrument.json
@@ -30,11 +30,11 @@
                   "default": false,
                   "description": "When true, the handler requires card verification data appropriate to the credential type (e.g., CVC for FPAN)."
                 },
-                "requires_billing_address_data": {
+                "billing_address_granularity": {
                   "type": "string",
                   "enum": ["full_address", "postal_code", "none"],
                   "default": "none",
-                  "description": "Specifies the level of billing address data the handler requires. full_address: complete billing address. postal_code: billing postal code only (e.g., for AVS). none: no billing address required."
+                  "description": "Level of billing address required. `full_address` — complete billing address; `postal_code` — postal code only (e.g., for AVS); `none` — not required."
                 }
               }
             }

--- a/source/schemas/shopping/types/card_payment_instrument.json
+++ b/source/schemas/shopping/types/card_payment_instrument.json
@@ -27,14 +27,17 @@
                 },
                 "requires_card_verification": {
                   "type": "boolean",
+                  "default": false,
                   "description": "When true, the handler requires card verification data. For FPAN: CVC. For network tokens: cryptogram and ECI."
                 },
                 "requires_billing_address": {
                   "type": "boolean",
+                  "default": false,
                   "description": "When true, the handler requires a billing address on the instrument."
                 },
                 "requires_billing_postal_code": {
                   "type": "boolean",
+                  "default": false,
                   "description": "When true, the handler requires a billing postal code for AVS verification. Ignored when requires_billing_address is true."
                 }
               }

--- a/source/schemas/shopping/types/card_payment_instrument.json
+++ b/source/schemas/shopping/types/card_payment_instrument.json
@@ -28,17 +28,13 @@
                 "requires_card_verification": {
                   "type": "boolean",
                   "default": false,
-                  "description": "When true, the handler requires card verification data. For FPAN: CVC. For network tokens: cryptogram and ECI."
+                  "description": "When true, the handler requires card verification data appropriate to the credential type (e.g., CVC for FPAN)."
                 },
-                "requires_billing_address": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "When true, the handler requires a billing address on the instrument."
-                },
-                "requires_billing_postal_code": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "When true, the handler requires a billing postal code for AVS verification. Ignored when requires_billing_address is true."
+                "requires_billing_address_data": {
+                  "type": "string",
+                  "enum": ["full_address", "postal_code", "none"],
+                  "default": "none",
+                  "description": "Specifies the level of billing address data the handler requires. full_address: complete billing address. postal_code: billing postal code only (e.g., for AVS). none: no billing address required."
                 }
               }
             }


### PR DESCRIPTION
# Enhancement Proposal: Card Payment Constraints

## Summary

Adds named constraints to `card_payment_instrument.json` that enable merchants to communicate per-checkout instrument requirements to platforms. This gives platforms a clear signal of what the merchant requires — no guesswork, no trial-and-error tokenization.

## Motivation

Many instrument and credential properties are optional at the protocol level but required by individual merchants and their PSPs. For example, CVC is optional in `card_credential.json` but most merchants require it for card-not-present transactions. A handler like `dev.shopify.card` serves thousands of merchants — some require CVC, some don't (it's a per-merchant fraud setting). Without a way to communicate these requirements, the platform must guess which optional fields the merchant actually needs.

## Design

Uses the existing `constraints` mechanism on `available_instruments`, consistent with how `brands` constraints already work. Constraints participate in the existing resolution flow and can vary per merchant without changing the handler schema.

### New Constraints

| Constraint                     | Type    | Description                                                                                                        |
|--------------------------------|---------|--------------------------------------------------------------------------------------------------------------------|
| `requires_card_verification`   | boolean | When `true`, the handler requires card verification data. For FPAN: CVC. For network tokens: cryptogram and ECI.   |
| `requires_billing_address`     | boolean | When `true`, the handler requires a billing address on the instrument.                                             |
| `requires_billing_postal_code` | boolean | When `true`, the handler requires a billing postal code for AVS verification. Ignored when `requires_billing_address` is `true`. |

### Example

```json
{
  "available_instruments": [
    {
      "type": "card",
      "constraints": {
        "brands": ["visa", "mastercard"],
        "requires_card_verification": true,
        "requires_billing_postal_code": true
      }
    }
  ]
}
```

### Per-`card_number_type` Semantics

The `requires_card_verification` constraint adapts to the credential mode:

| `card_number_type` | Verification fields required      |
|--------------------|-----------------------------------|
| `fpan`             | `cvc`                             |
| `network_token`    | `cryptogram`, `eci_value`         |

The spec documents these mappings. A future PR could make the schema fully self-documenting via a `verification` object with conditionals per `card_number_type` (as discussed in PR review), but named constraints provide a pragmatic step forward today.

## Code Changes

**Modified Files:**
- `source/schemas/shopping/types/card_payment_instrument.json` — Added `requires_card_verification`, `requires_billing_address`, and `requires_billing_postal_code` to the `available_card_payment_instrument` constraints
- `docs/specification/payment-handler-guide.md` — Added Card Constraints section with constraint table, example, and resolution flow documentation

## Test Plan

- [x] JSON Schema validation: new constraints accepted on `card_payment_instrument.json`
- [x] Spell check (cspell): 0 issues
- [x] Markdown lint (markdownlint): 0 issues
- [ ] Round-trip test: verify constraints flow through resolution in `available_instruments`

## References

- [PR #187](https://github.com/Universal-Commerce-Protocol/ucp/pull/187) — Original constraints mechanism
- [PR #49](https://github.com/Universal-Commerce-Protocol/ucp/pull/49) — Prior instrument schema discussion

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings