### PR TITLE
feat: add event context extension for cart and checkout sessions

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -107,6 +107,16 @@ zapatillas
 yml
 jwks
 keyid
+CAPI
+dedup
+Dedup
+gbraid
+gclid
+Northbeam
 reauth
 reprepare
 sandboxing
+sess
+tiktok
+xjaw
+WVLA

--- a/docs/specification/event-context.md
+++ b/docs/specification/event-context.md
@@ -1,0 +1,216 @@
+<!--
+   Copyright 2026 UCP Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# Event Context Extension
+
+## Overview
+
+The Event Context extension enables referring platforms to pass referral context
+and deduplication keys through agentic checkout flows. When a user discovers a
+product through an external channel (a paid ad, an organic recommendation, an
+influencer link, or an AI agent's suggestion) and completes a purchase via
+agentic checkout, the merchant loses the referral context they normally receive
+via URL parameters on their landing page. This extension preserves that data.
+
+**Key features:**
+
+- Pass structured UTM parameters for compatibility with existing analytics tools
+- Provide deduplication keys so merchants can reconcile agentic transactions
+  with their server-side reporting
+- Support any referring platform via reverse domain naming
+- Pass platform-specific identifiers through an opaque `custom` field
+
+**Dependencies:**
+
+- Cart Capability or Checkout Capability
+
+## Discovery
+
+Businesses advertise event context support in their profile:
+
+```json
+{
+  "ucp": {
+    "version": "{{ ucp_version }}",
+    "capabilities": {
+      "dev.ucp.shopping.event_context": [
+        {
+          "version": "{{ ucp_version }}",
+          "extends": "dev.ucp.shopping.cart",
+          "spec": "https://ucp.dev/{{ ucp_version }}/specification/event-context",
+          "schema": "https://ucp.dev/{{ ucp_version }}/schemas/shopping/event_context.json"
+        },
+        {
+          "version": "{{ ucp_version }}",
+          "extends": "dev.ucp.shopping.checkout",
+          "spec": "https://ucp.dev/{{ ucp_version }}/specification/event-context",
+          "schema": "https://ucp.dev/{{ ucp_version }}/schemas/shopping/event_context.json"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Schema Composition
+
+The event context extension extends both **cart** and **checkout** objects:
+
+- **Base schemas extended**: `cart.json`, `checkout.json`
+- **Path**: `cart.event_context`, `checkout.event_context`
+- **Schema reference**: `event_context.json`
+
+The `event_context` property is composed onto each object via `allOf`,
+following the same extension pattern as `fulfillment.json` and `discount.json`.
+
+## Schema Definition
+
+### Event Context Payload
+
+The `event_context` object contains referral context from the platform that
+drove the cart or checkout:
+
+| Field         | Type   | Required | Description                                                                                                                                               |
+|---------------|--------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `platform`    | string | Yes      | Referring platform identifier using reverse domain naming (e.g., `com.google`, `com.meta`)                                                                |
+| `dedup_keys`  | object | No       | Deduplication keys for reconciling with the merchant's server-side reporting                                                                              |
+| `utm`         | object | No       | Standard UTM parameters for web analytics compatibility                                                                                                   |
+| `custom`      | object | No       | Platform-specific key-value pairs routed by the merchant based on the `platform` field. Values MUST be string, number, or boolean. Maximum 20 properties. |
+
+### Deduplication Keys
+
+The `dedup_keys` object prevents double-counting when both the referring
+platform and the merchant report the same transaction independently. If
+present, at least one key MUST be provided:
+
+| Field        | Type   | Description                                                                            |
+|--------------|--------|----------------------------------------------------------------------------------------|
+| `event_id`   | string | Shared dedup key for reconciling with the merchant's server-side reporting             |
+| `session_id` | string | Platform session identifier for cross-event correlation (e.g., `fbp`, `ga_session_id`) |
+
+### UTM Parameters
+
+Standard UTM parameters for compatibility with web analytics tools (Google
+Analytics, Northbeam, Triple Whale, etc.):
+
+| Field                  | Type   | Description                                                          |
+|------------------------|--------|----------------------------------------------------------------------|
+| `utm_source`           | string | Traffic source                                                       |
+| `utm_medium`           | string | Marketing medium                                                     |
+| `utm_campaign`         | string | Campaign name                                                        |
+| `utm_content`          | string | Content identifier                                                   |
+| `utm_term`             | string | Search term                                                          |
+| `utm_id`               | string | Campaign ID                                                          |
+| `utm_source_platform`  | string | Advertising platform that served the ad (e.g., Google, Meta, TikTok) |
+
+### Request Behavior
+
+The `event_context` property supports the following operations:
+
+| Operation  | Behavior   | Description                                     |
+|------------|------------|-------------------------------------------------|
+| `create`   | `optional` | Platform MAY include event context on create    |
+| `update`   | `optional` | Platform MAY update event context               |
+| `complete` | `optional` | Platform MAY include event context on complete  |
+
+## Privacy Note
+
+This extension replaces referral context and conversion signals that
+traditionally flow from the referring platform to the business via the
+merchant's website. When a purchase occurs through an agentic flow, the website
+is bypassed and these signals would otherwise be lost. While the fields
+primarily carry marketing and campaign metadata, some values — such as click
+identifiers and session identifiers in `dedup_keys` or `custom` — may be
+considered advertising data subject to user consent under applicable privacy
+regulations.
+
+Implementations **MUST**:
+
+- Only use event context data for the purposes of conversion measurement,
+  reporting, attribution, and analytics
+- **NOT** transmit personally identifiable information (e.g., email addresses,
+  phone numbers, names) through any field in this extension
+- Comply with applicable consent requirements for advertising and marketing
+  data in the jurisdictions where they operate
+
+## Usage Examples
+
+### Google (Google Ads / Gemini)
+
+A user discovers a product through a Google Shopping ad and completes the
+purchase via Gemini's agentic checkout:
+
+```json
+{
+  "event_context": {
+    "platform": "com.google",
+    "dedup_keys": {
+      "event_id": "evt_abc123def456"
+    },
+    "utm": {
+      "utm_source": "google",
+      "utm_medium": "cpc",
+      "utm_campaign": "spring_collection_2026",
+      "utm_content": "60123456789",
+      "utm_id": "18234567890",
+      "utm_source_platform": "Google"
+    },
+    "custom": {
+      "click_id": "EAIaIQobChMI8bXe7...",
+      "ad_group_id": "142345678901",
+      "placement": "Google_Shopping",
+      "gbraid": "WVLA4QjBkaJkZW..."
+    }
+  }
+}
+```
+
+The merchant includes this `event_id` when reporting the conversion via their
+server-side integration to prevent double-counting.
+
+### Meta
+
+A user discovers a product through Meta's platform and their AI agent completes
+the purchase:
+
+```json
+{
+  "event_context": {
+    "platform": "com.meta",
+    "dedup_keys": {
+      "event_id": "evt_abc123def456",
+      "session_id": "fb.1.1710300000000.1234567890"
+    },
+    "utm": {
+      "utm_source": "meta",
+      "utm_medium": "paid_social",
+      "utm_campaign": "spring_sale_2026",
+      "utm_content": "6861203971771",
+      "utm_id": "6861196821371",
+      "utm_source_platform": "Meta"
+    },
+    "custom": {
+      "click_id": "IwY2xjawOR56Fle...",
+      "placement": "Meta_AI"
+    }
+  }
+}
+```
+
+The merchant passes `event_id` and `fbp` (from `session_id`) to their
+Conversions API integration. The shared `event_id` prevents duplicate event
+counting between the platform's first-party event and the merchant's server-side
+event.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
           - AP2 Mandates Extension: specification/ap2-mandates.md
           - Buyer Consent Extension: specification/buyer-consent.md
           - Discounts Extension: specification/discount.md
+          - Event Context Extension: specification/event-context.md
           - Fulfillment Extension: specification/fulfillment.md
       - Cart Capability:
           - Overview: specification/cart.md
@@ -230,6 +231,7 @@ plugins:
           - specification/ap2-mandates.md
           - specification/buyer-consent.md
           - specification/discount.md
+          - specification/event-context.md
           - specification/fulfillment.md
         Cart Capability:
           - specification/cart.md

--- a/source/schemas/shopping/event_context.json
+++ b/source/schemas/shopping/event_context.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/event_context.json",
+  "name": "dev.ucp.shopping.event_context",
+  "title": "Event Context Extension",
+  "description": "Extends Cart and Checkout with event context, enabling referring platforms to pass referral context and deduplication keys through agentic checkout flows.",
+  "$defs": {
+    "event_context_payload": {
+      "type": "object",
+      "required": ["platform"],
+      "properties": {
+        "platform": {
+          "$ref": "types/reverse_domain_name.json",
+          "description": "Referring platform identifier (reverse domain naming). MUST correspond to the domain of the platform's UCP-Agent profile URL.",
+          "examples": ["com.google", "com.meta", "com.tiktok", "com.openai"]
+        },
+        "dedup_keys": {
+          "type": "object",
+          "description": "Deduplication keys for reconciling this event with the merchant's own server-side reporting. Without these, the same transaction may be counted twice in analytics and reporting platforms.",
+          "minProperties": 1,
+          "properties": {
+            "event_id": { "type": "string", "description": "Shared dedup key. The merchant includes this same event_id when reporting the event via their server-side integration (e.g., CAPI, Enhanced Conversions, Events API) to prevent double-counting." },
+            "session_id": { "type": "string", "description": "Platform session identifier for cross-event correlation (e.g., fbp, ga_session_id)." }
+          }
+        },
+        "utm": {
+          "type": "object",
+          "description": "Standard UTM parameters for compatibility with web analytics tools (Google Analytics, Northbeam, Triple Whale, etc.).",
+          "properties": {
+            "utm_source": { "type": "string" },
+            "utm_medium": { "type": "string" },
+            "utm_campaign": { "type": "string" },
+            "utm_content": { "type": "string" },
+            "utm_term": { "type": "string" },
+            "utm_id": { "type": "string" },
+            "utm_source_platform": { "type": "string" }
+          }
+        },
+        "custom": {
+          "type": "object",
+          "description": "Platform-specific key-value pairs not covered by the structured fields above. Merchants pass these through to their analytics integrations based on the platform field.",
+          "additionalProperties": {
+            "type": ["string", "number", "boolean"]
+          },
+          "maxProperties": 20
+        }
+      }
+    },
+    "dev.ucp.shopping.cart": {
+      "title": "Cart with Event Context",
+      "description": "Cart extended with referral event context.",
+      "allOf": [
+        {
+          "$ref": "cart.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_context": {
+              "$ref": "#/$defs/event_context_payload",
+              "description": "Referral event context from the platform that drove the cart.",
+              "ucp_request": {
+                "create": "optional",
+                "update": "optional"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "dev.ucp.shopping.checkout": {
+      "title": "Checkout with Event Context",
+      "description": "Checkout extended with referral event context.",
+      "allOf": [
+        {
+          "$ref": "checkout.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_context": {
+              "$ref": "#/$defs/event_context_payload",
+              "description": "Referral event context from the platform that drove the checkout.",
+              "ucp_request": {
+                "create": "optional",
+                "update": "optional",
+                "complete": "optional"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "dev.ucp.shopping.event_context": {
+      "platform_schema": {
+        "title": "Event Context Capability (Platform)",
+        "description": "Platform-level event context capability. Indicates the platform can provide referral event context on cart and checkout requests.",
+        "allOf": [
+          {
+            "$ref": "../capability.json#/$defs/platform_schema"
+          }
+        ]
+      },
+      "business_schema": {
+        "title": "Event Context Capability (Business)",
+        "description": "Business-level event context capability. Indicates the business accepts and processes referral event context.",
+        "allOf": [
+          {
+            "$ref": "../capability.json#/$defs/business_schema"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Enhancement Proposal: Event Context Extension

## Summary

An optional `event_context` extension for UCP cart and checkout sessions that enables referring platforms to pass referral context and deduplication keys through agentic checkout flows — preserving the merchant's analytics and ROI measurement capabilities that are otherwise lost when the checkout bypasses the merchant's website.

## Motivation

When a user discovers a product through any external channel — a paid ad, an organic recommendation, an influencer link, or an AI agent's suggestion — and completes a purchase via an agentic commerce protocol, the merchant loses the referral context they normally receive. In the traditional web flow, this data arrives via URL parameters on the merchant's landing page (e.g., `utm_source`, `utm_campaign`, platform-specific click IDs like [gclid](https://support.google.com/google-ads/answer/9744275?hl=en), [fbclid](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc/), [ttclid](https://ads.tiktok.com/help/article/tiktok-click-id?lang=en)). With agentic checkout, the user never visits the landing page, so these parameters are never set.

This creates two critical problems for merchants:

1. **Merchants lose channel attribution and ROI visibility** — Without campaign and channel identifiers flowing through to the conversion event, merchants cannot attribute sales to the channels that drove them. This breaks the analytics pipelines that merchants rely on to measure channel performance, optimize budgets, and evaluate return on spend. Tools like Google Analytics, Northbeam, and Triple Whale all depend on UTM parameters and click IDs arriving with the transaction to build attribution models. When these signals are missing, the merchant's analytics show agentic purchases as "direct" or "unattributed" traffic.

2. **Conversion reporting double-counts transactions** — When a purchase completes through an agentic flow, both the referring platform and the merchant's existing server-side integration (e.g., Meta Conversions API, Google Enhanced Conversions, TikTok Events API) may report the same transaction independently. Without a shared deduplication key, the same conversion is counted twice — inflating metrics and corrupting automated bidding data.

This affects every platform that refers users to merchant products through agentic checkout — including Google, Meta, TikTok, Snap, Pinterest, OpenAI/ChatGPT, and others.

## Goals

- Enable referring platforms to pass structured referral context (UTM parameters, platform-specific identifiers) through agentic cart and checkout flows to the merchant
- Provide deduplication keys so merchants can reconcile agentic transactions with their existing server-side reporting
- Preserve compatibility with existing merchant analytics tools (Google Analytics, Northbeam, Triple Whale, etc.)
- Support any referring platform — not limited to a specific platform or channel type
- Supply context that downstream analytics systems consume to perform attribution — without UCP itself performing attribution

## Non-Goals

- Multi-touch attribution modeling — this is the merchant's domain, handled by their analytics tools downstream
- Prescribing how merchants should process or store event context data
- Defining platform-specific deduplication protocols — each platform has its own model (Google uses `gclid` + `order_id`, Meta/TikTok use `event_id`, etc.)
- Content creator attribution (covered by [Issue #185](https://github.com/Universal-Commerce-Protocol/ucp/issues/185))
- Agent discovery telemetry (covered by [Issue #180](https://github.com/Universal-Commerce-Protocol/ucp/issues/180))

## Related Work

| Proposal | Focus | Relationship |
|----------|-------|-------------|
| [Issue #180](https://github.com/Universal-Commerce-Protocol/ucp/issues/180) — Attribution Signals | Agent discovery context (how/why product recommended) | Complementary — #180 is about the agent's reasoning; this is about the referral channel data |
| [Issue #185](https://github.com/Universal-Commerce-Protocol/ucp/issues/185) — Content Citation | Content creator attribution (reviews/guides influence) | Complementary — focuses on content influence tracking |
| [PR #10](https://github.com/Universal-Commerce-Protocol/ucp/pull/10) — Affiliate Attribution | Affiliate tracking (stalled) | Overlapping — this proposal is broader, covering all referral platforms not just affiliates |

Neither #180 nor #185 addresses the use case where the platform that referred a user to a product needs to pass referral context through the checkout flow to the merchant.

## Detailed Design

### Extension Schema

The extension follows the same composition pattern as `fulfillment.json` and `discount.json`: defines the extended cart and checkout in `$defs["dev.ucp.shopping.cart"]` and `$defs["dev.ucp.shopping.checkout"]` using `allOf` to compose onto `cart.json` and `checkout.json`, with `ucp_request` annotations specifying per-operation behavior.

**Event Context Payload:**

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `platform` | string | Yes | Referring platform identifier (reverse domain naming). MUST correspond to the domain of the platform's `UCP-Agent` profile URL. |
| `dedup_keys` | object | No | Deduplication keys for reconciling with the merchant's server-side reporting |
| `utm` | object | No | Standard UTM parameters for web analytics compatibility |
| `custom` | object | No | Platform-specific key-value pairs routed by the merchant based on the `platform` field. Values MUST be string, number, or boolean. Maximum 20 properties. |

**Dedup Keys:**

| Field | Type | Description |
|-------|------|-------------|
| `event_id` | string | Shared dedup key for reconciling with the merchant's server-side reporting |
| `session_id` | string | Platform session identifier for cross-event correlation (e.g., `fbp`, `ga_session_id`) |

**UTM Parameters:** `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `utm_id`, `utm_source_platform`

**Request Behavior (Cart):**

| Operation | Behavior |
|-----------|----------|
| `create` | `optional` |
| `update` | `optional` |

**Request Behavior (Checkout):**

| Operation | Behavior |
|-----------|----------|
| `create` | `optional` |
| `update` | `optional` |
| `complete` | `optional` |

### Usage Examples

**Google (Google Ads / Gemini)** — A user discovers a product through a Google Shopping ad and completes the purchase via agentic checkout:

```json
{
  "event_context": {
    "platform": "com.google",
    "dedup_keys": {
      "session_id": "GA1.2.1234567890.1710300000"
    },
    "utm": {
      "utm_source": "google",
      "utm_medium": "cpc",
      "utm_campaign": "spring_collection_2026",
      "utm_content": "60123456789",
      "utm_id": "18234567890",
      "utm_source_platform": "Google"
    },
    "custom": {
      "click_id": "EAIaIQobChMI8bXe7...",
      "ad_group_id": "142345678901",
      "placement": "Google_Shopping",
      "gbraid": "WVLA4QjBkaJkZW..."
    }
  }
}
```

Google Ads deduplicates conversions using `gclid` + `order_id` + `conversion_date_time`. The `order_id` is available via UCP's Order capability, so no separate `event_id` is required for Google's dedup model.

**Meta** — A user discovers a product through Meta's platform and their AI agent completes the purchase:

```json
{
  "event_context": {
    "platform": "com.meta",
    "dedup_keys": {
      "event_id": "evt_abc123def456",
      "session_id": "fb.1.1710300000000.1234567890"
    },
    "utm": {
      "utm_source": "meta",
      "utm_medium": "paid_social",
      "utm_campaign": "spring_sale_2026",
      "utm_content": "6861203971771",
      "utm_id": "6861196821371",
      "utm_source_platform": "Meta"
    },
    "custom": {
      "click_id": "IwY2xjawOR56Fle...",
      "placement": "Meta_AI"
    }
  }
}
```

The merchant passes `event_id` and `fbp` (from `session_id`) to their Conversions API integration. The shared `event_id` prevents duplicate event counting between the platform's first-party event and the merchant's server-side event.

**TikTok** — A user discovers a product via TikTok and completes the purchase through an agentic flow:

```json
{
  "event_context": {
    "platform": "com.tiktok",
    "dedup_keys": {
      "event_id": "evt_tt_xyz789abc012"
    },
    "utm": {
      "utm_source": "tiktok",
      "utm_medium": "paid_social",
      "utm_campaign": "spring_launch_2026",
      "utm_source_platform": "TikTok"
    },
    "custom": {
      "click_id": "E.C.P.abcdef123456..."
    }
  }
}
```

**OpenAI (ChatGPT Shopping)** — Even without a traditional campaign, the platform provides event context:

```json
{
  "event_context": {
    "platform": "com.openai",
    "dedup_keys": {
      "event_id": "evt_oai_def456ghi789"
    },
    "utm": {
      "utm_source": "chatgpt",
      "utm_medium": "agentic",
      "utm_campaign": "shopping_recommendations"
    }
  }
}
```

### Design Rationale

1. **Follows UCP extension pattern** — uses `allOf` composition onto `cart.json` and `checkout.json` with `ucp_request` annotations, matching `fulfillment.json` and `discount.json`. Capability declarations (`platform_schema`, `business_schema`) follow the same pattern as `fulfillment.json`.
2. **Separate from `signals`** — UCP's `signals` property carries environment data for authorization and abuse prevention. Event context serves a different purpose: referral and marketing analytics context. Mixing them would conflate security/risk data with marketing data.
3. **Single event context object** — Each platform provides one event context payload per cart or checkout. Multi-touch attribution across platforms is the merchant's domain.
4. **UTM as the universal analytics layer** — UTM parameters are the universal language of web analytics that merchants already know how to process.
5. **Dedup keys as first-class concept** — Different platforms use different dedup models. The `dedup_keys` object accommodates all models with optional fields, and different analytics platforms (GA4, Adobe, Northbeam, Meta CAPI, etc.) handle dedup differently.
6. **Platform-namespaced** — Reverse domain naming provides a clean discriminator. The `platform` value MUST correspond to the domain of the platform's `UCP-Agent` profile URL, linking identity to protocol identity without coupling to UCP-specific constructs.
7. **Custom field for platform-specific data** — Platform-specific identifiers go in `custom`, keeping the core schema minimal and universal. Values constrained to string, number, or boolean with a maximum of 20 properties.
8. **Event context, not attribution** — UCP supplies the context that downstream analytics systems consume to perform attribution. UCP itself does not perform attribution or prescribe attribution models.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Privacy concerns about passing tracking data | Event context data flows from the referring platform (which already has it) to the merchant (who would have received it via URL params in the web flow). No new data is created. Privacy note included in specification. |
| Schema bloat from platform-specific fields | Core schema covers only universal fields (UTM, dedup keys). All platform-specific identifiers go in `custom`. |
| Inconsistent dedup models across platforms | `dedup_keys` fields are all optional. Each platform populates only the fields relevant to its dedup model. |
| Overlap with existing proposals (#180, #185, PR #10) | Complementary to #180 and #185 (different data, different use case). PR #10 is stalled and narrower in scope. |

## Test Plan

- JSON Schema validation: validate all usage examples against the schema
- Round-trip test: create checkout with `event_context`, verify it persists through update and complete operations
- Missing fields: verify checkout succeeds when `event_context` is omitted entirely (optional extension)
- Platform routing: verify merchants can discriminate by `platform` field and route to correct analytics integration

## Graduation Criteria

- Schema merged into UCP source
- Specification documentation complete
- 2+ independent implementations (per UCP Enhancement Proposal process)
- TC majority vote for Candidate status

## Code Changes

**New Files:**
- `source/schemas/shopping/event_context.json` — Extension schema with `$defs` containing `event_context_payload`, `dev.ucp.shopping.cart`, and `dev.ucp.shopping.checkout` composition
- `docs/specification/event-context.md` — Extension documentation

**Modified Files:**
- `mkdocs.yml` — Added event context extension to nav and llmstxt sections
- `.cspell/custom-words.txt` — Added related terms

**Note:** No modifications to `checkout.json` or `cart.json` are required. UCP extensions compose onto cart and checkout via `allOf` in the extension schema (same pattern as `fulfillment.json`, `discount.json`).

## References

- [Google Analytics UTM Parameters](https://support.google.com/analytics/answer/1033863)
- [Google Click Identifier (GCLID)](https://support.google.com/google-ads/answer/9744275?hl=en)
- [Google Ads Offline Conversion Deduplication](https://support.google.com/google-ads/answer/7014069)
- [Google Enhanced Conversions](https://developers.google.com/google-ads/api/docs/conversions/enhanced-conversions/web)
- [Meta Conversions API](https://developers.facebook.com/docs/marketing-api/conversions-api)
- [Meta Conversions API Deduplication](https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events)
- [TikTok Events API](https://business-api.tiktok.com/portal/docs?id=1741601162187777)
- [TikTok Click ID](https://ads.tiktok.com/help/article/tiktok-click-id?lang=en)
- [Northbeam](https://www.northbeam.io/) — Multi-touch attribution analytics
- [Triple Whale](https://www.triplewhale.com/) — Ecommerce analytics and attribution
- UCP [Payment Handler Guide](https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/payment-handler-guide.md)
- UCP `checkout.json` — Base checkout schema (extended via `allOf`)
- UCP `cart.json` — Base cart schema (extended via `allOf`)

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings