### PR TITLE
feat: add card network token credential and instrument types

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -107,3 +107,10 @@ zapatillas
 yml
 jwks
 keyid
+CAVV
+Cybersource
+MDES
+ntoken
+TAVV
+TRID
+YFAAAAAAAAAAA

--- a/docs/specification/card-network-token.md
+++ b/docs/specification/card-network-token.md
@@ -1,0 +1,173 @@
+<!--
+   Copyright 2026 UCP Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# Card Network Token Credential
+
+## Overview
+
+The card network token credential type enables platforms to present card
+network tokens (Visa VTS, Mastercard MDES, Amex Token Service) directly as
+payment credentials in checkout sessions. Network tokens are opaque
+credentials issued by card networks that replace the primary account number
+(PAN) with a domain-restricted, cryptogram-protected token.
+
+**Key features:**
+
+- Present pre-provisioned network tokens directly at checkout
+- Eliminate CVV collection (cryptogram structurally replaces CVC)
+- Reduce PCI DSS compliance scope compared to handling raw card data
+- Support all major card networks (Visa, Mastercard, Amex, Discover, JCB)
+
+**Dependencies:**
+
+- Checkout Capability
+- Payment Handler Guide
+
+## Credential Schema
+
+### `card_network_token_credential.json`
+
+The credential extends `payment_credential.json` via `allOf`:
+
+| Field                | Type    | Required | Description                                                      |
+|----------------------|---------|----------|------------------------------------------------------------------|
+| `type`               | const   | Yes      | `"card_network_token"`                                           |
+| `token`              | string  | Yes      | Card network token value (DPAN). Omitted from responses.         |
+| `token_expiry_month` | integer | Yes      | Month of the token's expiration date (1-12)                      |
+| `token_expiry_year`  | integer | Yes      | Year of the token's expiration date                              |
+| `cryptogram`         | string  | No       | One-time-use cryptogram (TAVV/CAVV). Omitted from responses.     |
+| `eci_value`          | string  | No       | Electronic Commerce Indicator / Security Level Indicator         |
+| `name`               | string  | No       | Cardholder name. Required by some PSPs (e.g., Adyen).            |
+| `token_requestor_id` | string  | No       | Token Requestor ID (TRID) from the card network                  |
+
+**Required vs optional fields reflect PSP reality:**
+
+- `token` and `token_expiry_*` are universally required by all PSPs
+- `cryptogram` and `eci_value` are conditional: required for customer-initiated
+  transactions (CIT) but may be omitted for merchant-initiated transactions
+  (MIT/recurring)
+- `name` is optional because only some PSPs (e.g., Adyen) require it
+- `token_requestor_id` is optional; relevant when the token presenter differs
+  from the provisioner
+
+**Response omission:** `token` and `cryptogram` use `ucp_response: "omit"` to
+prevent sensitive data leakage in API responses, following the pattern from
+`token_credential.json`.
+
+## Instrument Schema
+
+### `card_network_token_instrument.json`
+
+Network tokens are cards — they share display properties (brand, last digits,
+expiry, card art) with card instruments. The instrument extends
+`card_payment_instrument.json`:
+
+```json
+{
+  "allOf": [
+    { "$ref": "card_payment_instrument.json" },
+    {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "card_network_token" },
+        "credential": {
+          "$ref": "card_network_token_credential.json"
+        }
+      }
+    }
+  ]
+}
+```
+
+The instrument inherits the card display properties (`brand`, `last_digits`,
+`expiry_month`, `expiry_year`, `card_art`) from the card instrument schema.
+
+### Available Instrument Variant
+
+The schema defines `available_card_network_token_instrument` in `$defs`,
+extending `available_card_payment_instrument` to inherit `constraints.brands`:
+
+```json
+{
+  "$defs": {
+    "available_card_network_token_instrument": {
+      "allOf": [
+        { "$ref": "card_payment_instrument.json#/$defs/available_card_payment_instrument" },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "card_network_token" }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## How Network Tokens Fit the Handler Model
+
+Network tokens are **pre-provisioned credentials** that bypass the
+tokenize/detokenize flow:
+
+1. **Negotiation** — The business's handler declares `available_instruments`
+   including `card_network_token`. The platform sees that the handler accepts
+   network token instruments.
+2. **Acquisition** — No tokenizer round-trip is needed. The platform constructs
+   the instrument from a pre-provisioned network token, including a fresh
+   cryptogram from the card network.
+3. **Completion** — The platform submits the `card_network_token` instrument.
+   The business's PSP processes the network token directly.
+
+This is analogous to how wallet handlers (e.g., Google Pay, Shop Pay) work:
+the platform holds a pre-provisioned opaque credential and presents it
+directly.
+
+## Usage Example
+
+A platform presenting a pre-provisioned Visa network token at checkout:
+
+```json
+{
+  "payment": {
+    "instruments": [
+      {
+        "id": "pi_ntoken_001",
+        "handler_id": "handler_merchant_psp",
+        "type": "card_network_token",
+        "credential": {
+          "type": "card_network_token",
+          "token": "4895370012003478",
+          "token_expiry_month": 12,
+          "token_expiry_year": 2028,
+          "name": "Jane Doe",
+          "cryptogram": "AJkBBkhAAAAA0YFAAAAAAAAAAA==",
+          "eci_value": "05",
+          "token_requestor_id": "40012345678"
+        },
+        "display": {
+          "brand": "visa",
+          "last_digits": "3478",
+          "expiry_month": 12,
+          "expiry_year": 2028
+        },
+        "selected": true
+      }
+    ]
+  }
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - Payment Handlers:
           - Guide: specification/payment-handler-guide.md
           - Template: specification/payment-handler-template.md
+          - Card Network Token: specification/card-network-token.md
           - Tokenization Guide: specification/tokenization-guide.md
           - Examples:
               - Processor Tokenizer: specification/examples/processor-tokenizer-payment-handler.md
@@ -236,6 +237,7 @@ plugins:
           - specification/identity-linking.md
           - specification/payment-handler-guide.md
           - specification/payment-handler-template.md
+          - specification/card-network-token.md
           - specification/tokenization-guide.md
           - specification/examples/processor-tokenizer-payment-handler.md
           - specification/examples/platform-tokenizer-payment-handler.md

--- a/source/schemas/shopping/types/card_network_token_credential.json
+++ b/source/schemas/shopping/types/card_network_token_credential.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/types/card_network_token_credential.json",
+  "title": "Card Network Token Credential",
+  "description": "Credential for card network tokens (e.g., Visa VTS, Mastercard MDES). Network tokens are opaque credentials that replace raw PANs, reducing PCI DSS compliance scope.",
+  "allOf": [
+    { "$ref": "payment_credential.json" },
+    {
+      "type": "object",
+      "required": ["type", "token", "token_expiry_month", "token_expiry_year"],
+      "properties": {
+        "type": { "const": "card_network_token" },
+        "token": {
+          "type": "string",
+          "description": "Card network token value (DPAN).",
+          "ucp_response": "omit"
+        },
+        "token_expiry_month": {
+          "type": "integer",
+          "description": "The month of the token's expiration date (1-12)."
+        },
+        "token_expiry_year": {
+          "type": "integer",
+          "description": "The year of the token's expiration date."
+        },
+        "cryptogram": {
+          "type": "string",
+          "description": "One-time-use cryptogram (TAVV/CAVV) for authorization.",
+          "ucp_response": "omit"
+        },
+        "eci_value": {
+          "type": "string",
+          "description": "Electronic Commerce Indicator / Security Level Indicator.",
+          "examples": ["05", "07"]
+        },
+        "name": {
+          "type": "string",
+          "description": "Cardholder name. Required by some PSPs (e.g., Adyen)."
+        },
+        "token_requestor_id": {
+          "type": "string",
+          "description": "Token Requestor ID (TRID) from the card network."
+        }
+      }
+    }
+  ]
+}

--- a/source/schemas/shopping/types/card_network_token_instrument.json
+++ b/source/schemas/shopping/types/card_network_token_instrument.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/types/card_network_token_instrument.json",
+  "title": "Card Network Token Payment Instrument",
+  "description": "A card network token payment instrument. Extends card_payment_instrument with network token credential.",
+  "$defs": {
+    "available_card_network_token_instrument": {
+      "title": "Available Card Network Token Instrument",
+      "description": "Declares card network token instrument availability with card-specific constraints.",
+      "allOf": [
+        { "$ref": "card_payment_instrument.json#/$defs/available_card_payment_instrument" },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "card_network_token" }
+          }
+        }
+      ]
+    }
+  },
+  "allOf": [
+    { "$ref": "card_payment_instrument.json" },
+    {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "const": "card_network_token",
+          "description": "Indicates this is a card network token payment instrument."
+        },
+        "credential": {
+          "$ref": "card_network_token_credential.json"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Enhancement Proposal: Card Network Token Credential Type

## Summary

A new `card_network_token` credential type for UCP that enables platforms to present card network tokens (Visa VTS, Mastercard MDES, Amex Token Service) directly as payment credentials in checkout sessions — without requiring re-tokenization through a handler or falling back to raw PANs.

## Motivation

UCP currently supports payment tokenization through handler-specific tokens and a delegated payment model. However, there is no support for card network tokens — tokenized card credentials issued by card networks that replace the primary account number (PAN) with a network-level token.

Card network tokens are an industry-standard payment security mechanism with broad PSP acceptance. Every major processor supports directly processing network tokens with the same core fields (token/DPAN, cryptogram, ECI):

| PSP | Always Required | Conditional / Optional | Documentation |
|-----|----------------|----------------------|---------------|
| Adyen | DPAN, expiry, cardholder name, cryptogram, ECI | Brand (co-badged cards), CVC | [Network Tokenization](https://docs.adyen.com/online-payments/network-tokenization#existing-network-tokens) |
| Chase | Token, expiry | Cryptogram + ECI (may be omitted for MIT/recurring) | [Online Payments](https://developer.payments.jpmorgan.com/docs/commerce/online-payments/capabilities/online-payments/payment-enhancements/tokenization) |
| Braintree | DPAN, expiry, cryptogram (for CIT) | ECI, token requestor ID, transaction source (for MIT) | [Bring Your Own Token](https://developer.paypal.com/braintree/docs/guides/network-tokens/bring-your-own-token/java/) |
| Stripe | Card data, cryptogram + ECI | Network, 3DS version | PCI required for API docs |
| Cybersource | Token, cryptogram, ECI, expiry | — | [Auth with NT](https://developer.cybersource.com/docs/barclays/en-us/payments/developer/all/rest/payments/CreatingOnlineAuth/CreatingAuthReqPNT.html) |

UCP's own specification explicitly identifies network tokens as a mechanism for platforms to avoid PCI-DSS scope:

> *"Platforms can avoid PCI-DSS scope by using handlers providing opaque credentials, never accessing raw payment data."*
> — [UCP Specification Overview: Credential Flow & PCI Scope](https://ucp.dev/latest/specification/overview/#credential-flow-pci-scope)

Yet despite this design intent, UCP currently has no dedicated credential type for network tokens. Platforms that already hold card network tokens cannot use them directly.

### Token Provisioning

Platforms can obtain card network tokens through several standard provisioning channels:

- **Direct network integration** — Platform enrolls as a Token Requestor with Visa VTS, Mastercard MDES, or Amex Token Service
- **PSP-managed tokenization** — Platform's PSP manages token lifecycle on behalf of the platform
- **Secure Remote Commerce (SRC)** — EMVCo's [SRC specification](https://www.emvco.com/emv-technologies/src/) ("Click to Pay") maintains a directory of tokenized cards across participating networks

## Goals

- Enable platforms holding card network tokens to present them directly as UCP payment credentials
- Support all major card networks (Visa, Mastercard, Amex, Discover, JCB)
- Reflect PSP field requirements accurately (required vs. conditional vs. optional)
- Follow UCP's existing credential and instrument composition patterns (`allOf` with base schemas)
- Prevent sensitive data leakage in API responses via `ucp_response: "omit"`

## Non-Goals

- Replacing or modifying the existing `card_credential.json` schema
- Token provisioning or lifecycle management (out of scope — handled by the card network)
- Defining how merchants/PSPs should process network tokens (PSP-specific)
- Defining a new tokenization handler — network tokens are pre-provisioned credentials, not produced by the tokenize/detokenize flow

## Related Work

- The current `card_credential.json` includes partial network token support via `card_number_type: "network_token"` with `cryptogram` and `eci_value` fields. See "Discussion Points" below for why a separate credential type is proposed.
- `card_payment_instrument.json` — defines the card instrument with display properties and the `available_card_payment_instrument` variant with `constraints.brands`.
- `token_credential.json` — base token credential with `ucp_response: "omit"` pattern on `token` field.
- [Tokenization Guide](https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/tokenization-guide.md) — defines the tokenize/detokenize flow for handler-produced tokens. Network tokens bypass this flow.
- [Payment Handler Guide](https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/payment-handler-guide.md) — defines handler declaration, instrument acquisition, and processing patterns.
- [PR #187](https://github.com/Universal-Commerce-Protocol/ucp/pull/187) (merged): Added `available_instruments` with constraints.
- [PR #214](https://github.com/Universal-Commerce-Protocol/ucp/pull/214) (merged): Added payment instrument qualifiers.

## Detailed Design

### Credential Schema: card_network_token_credential.json

The credential extends `payment_credential.json` via `allOf`:

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `type` | const | Yes | `"card_network_token"` |
| `token` | string | Yes | Card network token value (DPAN). Omitted from responses. |
| `token_expiry_month` | integer | Yes | Month of the token's expiration date (1-12) |
| `token_expiry_year` | integer | Yes | Year of the token's expiration date |
| `cryptogram` | string | No | One-time-use cryptogram (TAVV/CAVV). Omitted from responses. |
| `eci_value` | string | No | Electronic Commerce Indicator / Security Level Indicator |
| `name` | string | No | Cardholder name. Required by some PSPs (e.g., Adyen). |
| `token_requestor_id` | string | No | Token Requestor ID (TRID) from the card network |

### Instrument Schema: card_network_token_instrument.json

Network tokens are cards — they share display properties (brand, last digits, expiry, card art) with card instruments. The instrument extends `card_payment_instrument.json` and includes an `available_*` variant following the established pattern:

- Inherits card display properties (`brand`, `last_digits`, `expiry_month`, `expiry_year`, `card_art`)
- Defines `available_card_network_token_instrument` extending `available_card_payment_instrument` to inherit `constraints.brands`
- Pairs with `card_network_token_credential.json` via the `credential` property

### How Network Tokens Fit the Handler Model

Network tokens are **pre-provisioned credentials** that bypass the tokenize/detokenize flow:

1. **Negotiation** — The business's handler declares `available_instruments` including `card_network_token`.
2. **Acquisition** — No tokenizer round-trip is needed. The platform constructs the instrument from a pre-provisioned network token, including a fresh cryptogram from the card network.
3. **Completion** — The platform submits the `card_network_token` instrument. The business's PSP processes the network token directly.

This is analogous to how wallet handlers (e.g., Google Pay, Shop Pay) work: the platform holds a pre-provisioned opaque credential and presents it directly.

### Relationship to Existing card_credential.json

The current `card_credential.json` includes partial network token support via `card_number_type: "network_token"`. However, that schema carries PCI restrictions that apply to the entire schema:

- *"This credential type MUST NOT be used for checkout, only with payment handlers that tokenize or encrypt credentials."*
- *"Both parties handling CardCredential MUST be PCI DSS compliant."*

A separate credential type is proposed because:

1. **PCI scope** — The blanket PCI requirement exists because the schema handles raw PANs. Network tokens reduce PCI DSS compliance scope compared to handling raw card data.
2. **Missing fields** — `card_credential.json` lacks `token_requestor_id` and has no way to distinguish token expiry from card expiry (network tokens have independent expiry dates).
3. **No instrument schema** — there is no instrument type for network tokens paired with a reduced-PCI-scope credential.
4. **Semantic clarity** — presenting a network token as a `card_credential` implies the platform holds PCI-scoped card data when it does not.

**Alternative approach**: The community could choose to enhance `card_credential.json` with the missing fields and relax the PCI restriction when `card_number_type` is `"network_token"`. Either approach achieves the same functional goal. This is an explicit discussion point.

### Usage Example

A platform presenting a pre-provisioned Visa network token at checkout:

```json
{
  "payment": {
    "instruments": [
      {
        "id": "pi_ntoken_001",
        "handler_id": "handler_merchant_psp",
        "type": "card_network_token",
        "credential": {
          "type": "card_network_token",
          "token": "4895370012003478",
          "token_expiry_month": 12,
          "token_expiry_year": 2028,
          "name": "Jane Doe",
          "cryptogram": "AJkBBkhAAAAA0YFAAAAAAAAAAA==",
          "eci_value": "05",
          "token_requestor_id": "40012345678"
        },
        "display": {
          "brand": "visa",
          "last_digits": "3478",
          "expiry_month": 12,
          "expiry_year": 2028
        },
        "selected": true
      }
    ]
  }
}
```

### Design Rationale

1. **Follows UCP's composition patterns** — credential extends `payment_credential.json` via `allOf`; instrument extends `card_payment_instrument.json` to inherit display properties and `available_*` variant pattern.
2. **Required vs optional fields reflect PSP reality** — token and token_expiry are universally required by all PSPs. Network/brand is inherited from `card_payment_instrument.json`. Cryptogram and eci_value are optional because they are conditional (CIT vs MIT). Name is optional (only Adyen requires it).
3. **Cryptogram and token use `ucp_response: omit`** — prevents leaking sensitive data in API responses, following the pattern from `token_credential.json`.
4. **Token Requestor ID** — optional; important in agentic flows where the token presenter differs from the provisioner.
5. **Pre-provisioned credential model** — network tokens bypass the tokenize/detokenize flow, analogous to wallet handlers.
6. **Eliminates CVV collection** — the cryptogram structurally replaces CVC, removing the need for platforms to collect CVV.
7. **Aligns with UCP's stated PCI design** — the specification overview identifies network tokens as opaque credentials that reduce compliance scope. A dedicated credential type realizes this design intent.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Overlap with existing `card_credential.json` network token support | Proposal explicitly acknowledges the alternative of enhancing `card_credential.json` and presents this as a discussion point for the TC. |
| PCI scope confusion | Network tokens reduce PCI DSS compliance scope compared to handling raw card data. UCP's own specification states that platforms working with network tokens can reduce compliance overhead. |
| PSP-specific field variations | Schema uses required fields only where universally needed; optional fields cover PSP-specific requirements. |
| Sensitive data in responses | `ucp_response: "omit"` on `token` and `cryptogram` fields prevents leakage. |

## Test Plan

- JSON Schema validation: validate usage example against the schema
- Composition test: verify `allOf` with `payment_credential.json` produces valid combined schema
- Required field enforcement: verify rejection when `token` or expiry fields are missing
- Response omission: verify `token` and `cryptogram` are omitted from API responses
- PSP compatibility: verify schema accommodates all five documented PSP field sets

## Graduation Criteria

- Schema merged into UCP source
- Specification documentation complete
- 2+ independent implementations
- TC majority vote for Candidate status

## Code Changes

**New Files:**
- `source/schemas/shopping/types/card_network_token_credential.json` — credential schema
- `source/schemas/shopping/types/card_network_token_instrument.json` — instrument schema with `available_card_network_token_instrument` variant
- `docs/specification/card-network-token.md` — documentation

**Modified Files:**
- `mkdocs.yml` — Added card network token to nav and llmstxt sections
- `.cspell/custom-words.txt` — Added network token-related terms

**Note:** No modifications to existing schemas required. Base `payment_credential.json` uses `additionalProperties: true`; `card_payment_instrument.json` is extended via `allOf`, not modified.

## Discussion Points

- New credential type vs. enhancing `card_credential.json` with conditional PCI relaxation?
- Should `available_card_network_token_instrument` extend `available_card_payment_instrument` (inheriting `constraints.brands`) or define its own constraints?

## References

- [EMVCo Token Framework](https://www.emvco.com/emv-technologies/payment-tokenisation/)
- [EMVCo Secure Remote Commerce (SRC)](https://www.emvco.com/emv-technologies/src/)
- [Visa Token Service](https://developer.visa.com/capabilities/visa-token-service)
- [Mastercard MDES](https://developer.mastercard.com/mdes-digital-enablement/documentation/)
- [Adyen Network Tokens](https://docs.adyen.com/online-payments/network-tokenization#existing-network-tokens)
- [Braintree Bring Your Own Token](https://developer.paypal.com/braintree/docs/guides/network-tokens/bring-your-own-token/java/)
- [Chase Online Payments Tokenization](https://developer.payments.jpmorgan.com/docs/commerce/online-payments/capabilities/online-payments/payment-enhancements/tokenization)
- UCP [Specification Overview: Credential Flow & PCI Scope](https://ucp.dev/latest/specification/overview/#credential-flow-pci-scope)
- UCP [Payment Handler Guide](https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/payment-handler-guide.md)
- UCP [Tokenization Guide](https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/tokenization-guide.md)
- UCP `payment_credential.json` — base credential schema
- UCP `card_credential.json` — existing card credential with partial network token support
- UCP `card_payment_instrument.json` — card instrument with display properties and `available_card_payment_instrument` variant

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings