### PR TITLE
docs: Remove price and title from checkout request examples

### DIFF
--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -66,11 +66,8 @@ All REST endpoints **MUST** be served over HTTPS with minimum TLS version
       "line_items": [
         {
           "item": {
-            "id": "item_123",
-            "title": "Red T-Shirt",
-            "price": 2500
+            "id": "item_123"
           },
-          "id": "li_1",
           "quantity": 2
         }
       ]
@@ -191,9 +188,7 @@ so clients must include all previously set fields they wish to retain.
       "line_items": [
         {
           "item": {
-            "id": "item_123",
-            "title": "Red T-Shirt",
-            "price": 2500
+            "id": "item_123"
           },
           "id": "li_1",
           "quantity": 2
@@ -319,9 +314,7 @@ type & addresses.
       "line_items": [
         {
           "item": {
-            "id": "item_123",
-            "title": "Red T-Shirt",
-            "price": 2500
+            "id": "item_123"
           },
           "id": "li_1",
           "quantity": 2
@@ -521,9 +514,7 @@ Follow-up calls after initial `fulfillment` data to update selection.
       "line_items": [
         {
           "item": {
-            "id": "item_123",
-            "title": "Red T-Shirt",
-            "price": 2500
+            "id": "item_123"
           },
           "id": "li_1",
           "quantity": 2,


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Aligned request examples with latest UCP schemas. Removed item.price/title and line_item.id from POST (create) and item.price/title from PUT (update) requests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [x] Documentation update

---