### PR TITLE
fix: allow "draft" as declared protocol version in UCP responses

### DIFF
--- a/source/schemas/ucp.json
+++ b/source/schemas/ucp.json
@@ -11,6 +11,14 @@
       "description": "UCP version in YYYY-MM-DD format."
     },
 
+    "declared_version": {
+      "oneOf": [
+        { "$ref": "#/$defs/version" },
+        { "const": "draft", "description": "In-development version, not yet assigned a date." }
+      ],
+      "description": "A UCP version as declared in a response — either a dated release (YYYY-MM-DD) or \"draft\" for the pre-release working version."
+    },
+
     "version_constraint": {
       "type": "object",
       "description": "Version range requirement with minimum and optional maximum.",
@@ -52,8 +60,8 @@
       "required": ["version"],
       "properties": {
         "version": {
-          "$ref": "#/$defs/version",
-          "description": "Entity version in YYYY-MM-DD format."
+          "$ref": "#/$defs/declared_version",
+          "description": "Entity version — a dated release (YYYY-MM-DD) or \"draft\" for entities in pre-release. Entities developed outside of UCP (e.g. payment handlers) may use \"draft\" to signal a pre-release implementation."
         },
         "spec": {
           "type": "string",
@@ -82,7 +90,7 @@
       "type": "object",
       "required": ["version"],
       "properties": {
-        "version": { "$ref": "#/$defs/version" },
+        "version": { "$ref": "#/$defs/declared_version" },
         "status": {
           "type": "string",
           "enum": ["success", "error"],


### PR DESCRIPTION
# Description

The `$defs/version` pattern in `ucp.json` restricts protocol version strings to YYYY-MM-DD format. However, implementations running the pre-release protocol should be able to return `"version": "draft"` in their UCP responses — a value consistent with the established "draft" concept in the spec (draft branch, draft profile URLs) but one that fails schema validation.

This fix introduces `$defs/declared_version`, a new type that accepts either a dated release (YYYY-MM-DD) or `"draft"` for the pre-release working version. It is applied to two fields:

1. **`$defs/base.version`** — the protocol version declared in every UCP response. A server running the draft protocol returns `"version": "draft"` here.

2. **`$defs/entity.version`** — the version carried by capabilities, services, and payment handlers. Entities have independent release lifecycles: a payment handler could be developed entirely outside of UCP (e.g. by a third-party payment provider). Without this change, there is no way for a platform to distinguish a merchant that supports draft for all capabilities from one where only some capabilities have been extended to draft — the schema gave no per-entity signal.

It is worthy to note `$defs/version` remains date-only and continues to be used for version constraints (`min`/`max`), and `supported_versions` property names — all contexts where a real date is semantically required for ordering and comparison.

**Before:** Any implementation responding to draft profile requests produces invalid response per `ucp.version` schema. Per-entity draft status is inexpressible.

**After:** `"version": "draft"` is valid in both protocol-level response metadata and individual entity declarations. Version constraints and backward-compatibility mappings are unchanged and remain date-only.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] `ucp-schema lint source` passes with no new errors introduced (`schemas/ucp.json` ✓)
- [x] Any dependent changes have been merged and published in downstream modules