### PR TITLE
docs: omit deprecated checkout id from playground payload

### DIFF
--- a/docs/specification/playground.md
+++ b/docs/specification/playground.md
@@ -990,7 +990,7 @@ class UcpApp {
   }
 
   prepareUpdatePayload(checkoutResponse) {
-    const patch = { id: checkoutResponse.id }; // deprecated: id is provided in URL path
+    const patch = {}; // id is provided in URL path
     const errors = checkoutResponse.messages || [];
 
     if (errors.some(e => e.path === "$.buyer.email")) {


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

While reviewing the interactive playground script in `docs/specification/playground.md`, I noticed that the `id` property was still being passed inside the `patch` object for update requests. Since this field was recently marked as `deprecated_required_to_omit` (as it is provided via the URL path), the playground was inadvertently generating non-compliant payloads. This PR fixes the playground payload creation by properly initializing an empty patch object.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

---

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

---

### Pull Request Title

docs: omit deprecated checkout id from playground payload