### PR TITLE
style!: Clean up transition & deprecated schema in preparation of a version cut

### DIFF
--- a/source/schemas/shopping/checkout.json
+++ b/source/schemas/shopping/checkout.json
@@ -23,11 +23,7 @@
     "id": {
       "type": "string",
       "description": "Unique identifier of the checkout session.",
-      "ucp_request": {
-        "create": "omit",
-        "update": {"transition": {"from": "required", "to": "omit", "description": "ID is provided as argument on the request, this ID is redundant."}},
-        "complete": "omit"
-      }
+      "ucp_request": "omit"
     },
     "line_items": {
       "type": "array",
@@ -60,27 +56,7 @@
     },
     "signals": {
       "$ref": "types/signals.json",
-      "ucp_request": {
-        "create": "optional",
-        "update": "optional",
-        "complete": "optional"
-      }
-    },
-    "risk_signals": {
-      "type": "object",
-      "description": "Deprecated. Use signals instead. Will be removed in the next version.",
-      "deprecated": true,
-      "additionalProperties": true,
-      "ucp_request": {
-        "complete": {
-          "transition": {
-            "from": "optional",
-            "to": "omit",
-            "description": "Replaced by signals. Will be removed in the next version."
-          }
-        }
-      },
-      "ucp_response": "omit"
+      "ucp_request": "optional"
     },
     "status": {
       "type": "string",
@@ -98,11 +74,7 @@
     "currency": {
       "type": "string",
       "description": "ISO 4217 currency code reflecting the merchant's market determination. Derived from address, context, and geo IP—buyers provide signals, merchants determine currency.",
-      "ucp_request": {
-        "create": "omit",
-        "update": "omit",
-        "complete": "omit"
-      }
+      "ucp_request": "omit"
     },
     "totals": {
       "$ref": "types/totals.json",

--- a/source/schemas/shopping/order.json
+++ b/source/schemas/shopping/order.json
@@ -90,14 +90,7 @@
     "currency": {
       "type": "string",
       "description": "ISO 4217 currency code. MUST match the currency from the originating checkout session.",
-      "ucp_request": "omit", 
-      "ucp_response": {
-        "transition": {
-          "from": "optional",
-          "to": "required",
-          "description": "Global requirement for currency in all Order responses."
-        }
-      } 
+      "ucp_request": "omit"
     },
     "totals": {
       "$ref": "types/totals.json",

--- a/source/schemas/shopping/types/fulfillment_method.json
+++ b/source/schemas/shopping/types/fulfillment_method.json
@@ -10,7 +10,7 @@
     "id": {
       "type": "string",
       "description": "Unique fulfillment method identifier.",
-      "ucp_request": {"create": "omit", "update": {"transition": {"from": "required", "to": "optional", "description": "Id is becoming optional to support platforms signalling a change of fulfillment method type without knowing the specific id ahead of the transition."}}}
+      "ucp_request": {"create": "omit", "update": "optional"}
     },
     "type": {
       "type": "string",


### PR DESCRIPTION
# Description

Prior to the new UCP version cut, we need to clean up schema fields that are transitioning to a different state & drop any deprecated fields.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [ ] Documentation update

---

### Is this a Breaking Change or Removal?

If you checked "Breaking change" above, or if you are removing **any** schema
files or fields:

- [x] **I have added `!` to my PR title** (e.g., `feat!: remove field`).
- [x] **I have added justification below.**

```text
## Breaking Changes / Removal Justification

The breaking schema changes are already forecasted via other PRs. This PR is simply to clean up annotations prior to the formal version cut.
```

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
