### PR TITLE
fix!: Pull out dangling webhook fields into headers so transport reference only base schemas

### DIFF
--- a/docs/specification/order.md
+++ b/docs/specification/order.md
@@ -402,7 +402,7 @@ during partner onboarding. The URL format is platform-specific.
 | Header               | Description                                 |
 | :------------------- | :------------------------------------------ |
 | `Webhook-Timestamp`  | Event creation timestamp (RFC 3339)         |
-| `Request-Id`         | Unique event identifier                     |
+| `Webhook-Event-Id`   | Unique event identifier                     |
 
 {{ method_fields('order_event_webhook', 'rest.openapi.json', 'order') }}
 

--- a/docs/specification/order.md
+++ b/docs/specification/order.md
@@ -397,12 +397,16 @@ payload is the same **current-state snapshot** described in
 Businesses POST order events to a webhook URL provided by the platform
 during partner onboarding. The URL format is platform-specific.
 
+Headers follow **[Standard Webhooks](https://www.standardwebhooks.com/){ target="_blank" }**;
+except for request signing, which follows [RFC 9421](https://www.rfc-editor.org/rfc/rfc9421).
+See [Message Signatures](signatures.md) for more details.
+
 **Required Headers:**
 
 | Header               | Description                                 |
 | :------------------- | :------------------------------------------ |
-| `Webhook-Timestamp`  | Event creation timestamp (RFC 3339)         |
-| `Webhook-Event-Id`   | Unique event identifier                     |
+| `Webhook-Timestamp`  | Event occurrence timestamp (unix)           |
+| `Webhook-Id`         | Unique event identifier                     |
 
 {{ method_fields('order_event_webhook', 'rest.openapi.json', 'order') }}
 

--- a/docs/specification/order.md
+++ b/docs/specification/order.md
@@ -397,6 +397,13 @@ payload is the same **current-state snapshot** described in
 Businesses POST order events to a webhook URL provided by the platform
 during partner onboarding. The URL format is platform-specific.
 
+**Required Headers:**
+
+| Header               | Description                                 |
+| :------------------- | :------------------------------------------ |
+| `Webhook-Timestamp`  | Event creation timestamp (RFC 3339)         |
+| `Request-Id`         | Unique event identifier                     |
+
 {{ method_fields('order_event_webhook', 'rest.openapi.json', 'order') }}
 
 ### Webhook URL Configuration

--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -739,7 +739,7 @@
           { "$ref": "#/components/parameters/ucp_agent" },
           { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/webhook_timestamp" },
-          { "$ref": "#/components/parameters/webhook_event_id" }
+          { "$ref": "#/components/parameters/webhook_id" }
         ],
         "requestBody": {
           "required": true,
@@ -923,13 +923,12 @@
         "in": "header",
         "required": true,
         "schema": {
-          "type": "string",
-          "format": "date-time"
+          "type": "integer"
         },
-        "description": "Webhook event creation timestamp (RFC 3339)."
+        "description": "Webhook event occurrence unix timestamp (seconds since epoch)."
       },
-      "webhook_event_id": {
-        "name": "Webhook-Event-Id",
+      "webhook_id": {
+        "name": "Webhook-Id",
         "in": "header",
         "required": true,
         "schema": {

--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -739,7 +739,7 @@
           { "$ref": "#/components/parameters/ucp_agent" },
           { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/webhook_timestamp" },
-          { "$ref": "#/components/parameters/request_id" }
+          { "$ref": "#/components/parameters/webhook_event_id" }
         ],
         "requestBody": {
           "required": true,
@@ -927,6 +927,16 @@
           "format": "date-time"
         },
         "description": "Webhook event creation timestamp (RFC 3339)."
+      },
+      "webhook_event_id": {
+        "name": "Webhook-Event-Id",
+        "in": "header",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "description": "The unique identifier of a webhook event."
       }
     },
     "headers": {

--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -737,32 +737,15 @@
           { "$ref": "#/components/parameters/signature_input" },
           { "$ref": "#/components/parameters/content_digest" },
           { "$ref": "#/components/parameters/ucp_agent" },
-          { "$ref": "#/components/parameters/x_api_key" }
+          { "$ref": "#/components/parameters/x_api_key" },
+          { "$ref": "#/components/parameters/webhook_timestamp" },
+          { "$ref": "#/components/parameters/request_id" }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "allOf": [
-                  { "$ref": "#/components/schemas/order" },
-                  {
-                    "type": "object",
-                    "required": ["event_id", "created_time"],
-                    "properties": {
-                      "event_id": {
-                        "type": "string",
-                        "description": "Unique event identifier."
-                      },
-                      "created_time": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Event creation timestamp in RFC 3339 format."
-                      }
-                    }
-                  }
-                ]
-              }
+              "schema": { "$ref": "#/components/schemas/order" }
             }
           }
         },
@@ -933,7 +916,17 @@
         "schema": {
           "type": "string"
         },
-        "description": "Compression. The client tells the server which content-codings it supports, usually for compression"
+        "description": "Compression. The client tells the server which content-codings it supports, usually for compression."
+      },
+      "webhook_timestamp": {
+        "name": "Webhook-Timestamp",
+        "in": "header",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "description": "Webhook event creation timestamp (RFC 3339)."
       }
     },
     "headers": {


### PR DESCRIPTION
# Description

There is a [requirement](https://ucp.dev/draft/specification/overview/#requirements) in UCP transport definition:
> Transport definitions (OpenAPI/OpenRPC) MUST reference base schemas only. They MUST NOT enumerate fields or define payload shapes inline.

This requirement is complied for all operations with the exception of `Order Webhook` today (https://github.com/Universal-Commerce-Protocol/ucp/blob/main/source/services/shopping/rest.openapi.json#L749), where the payload actually attempts to build additional fields (`event_id`, `created_time`) on top of the core Order capability.

To make sure we are fully compliant with the requirement, proposing to pull out the 2 webhook-specific fields into required headers.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [ ] Documentation update

---

### Is this a Breaking Change or Removal?

If you checked "Breaking change" above, or if you are removing **any** schema
files or fields:

- [x] **I have added `!` to my PR title** (e.g., `feat!: remove field`).
- [x] **I have added justification below.**

```text
## Breaking Changes / Removal Justification

Bug fix on schema to make sure we are complying with UCP transport requirement.
```

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---