### PR TITLE
fix: render Total and Totals fields on schema reference page

### DIFF
--- a/main.py
+++ b/main.py
@@ -600,9 +600,9 @@ def define_env(env):
 
     if (
       not properties
-      and "allOf" not in schema_data
       and "oneOf" not in schema_data
       and "$ref" not in schema_data
+      and ("allOf" not in schema_data or schema_data.get("type") == "array")
     ):
       # Fallback for scalar schemas (Enums, Strings with patterns, etc.)
       s_type = schema_data.get("type")
@@ -634,7 +634,7 @@ def define_env(env):
           context,
         )
       )
-    elif "allOf" in schema_data:
+    elif "allOf" in schema_data and not properties:
       md.append(
         _render_embedded_table(
           schema_data.get("allOf", []),


### PR DESCRIPTION
The Total and Totals sections on the specification reference page rendered empty tables because `_render_table_from_schema` entered the `allOf` branch for schemas that have both `properties` and `allOf` validation constraints (if/then, contains). The allOf items contained no renderable content, so no table rows were emitted.

Two fixes in `_render_table_from_schema`:

1. Only enter the `allOf` rendering branch when `properties` is empty (`and not properties`). This lets Total's three fields (type, display_text, amount) render through the normal property iteration path.

2. Treat array-typed schemas (like Totals) the same as scalar types in the description fallback, since their top-level `allOf` only carries `contains` constraints, not composition. Totals now renders its description text, consistent with Amount and Signed Amount.

Before:

<img width="765" height="390" alt="image" src="https://github.com/user-attachments/assets/29921e55-dcc4-49db-9ff6-12e1c64c45ff" />

After:
<img width="762" height="446" alt="image" src="https://github.com/user-attachments/assets/4dd4df20-81ea-42fa-a94e-a615336199cf" />

<img width="616" height="209" alt="image" src="https://github.com/user-attachments/assets/b0abd5d1-a3be-4cfc-b577-9fc528826080" />
