### PR TITLE
fix!: rename variant.selected_options → options

### DIFF
--- a/docs/specification/catalog/mcp.md
+++ b/docs/specification/catalog/mcp.md
@@ -214,7 +214,7 @@ Maps to the [Catalog Search](search.md) capability.
                   "description": { "plain": "Size 10 variant" },
                   "price": { "amount": 12000, "currency": "USD" },
                   "availability": { "available": true },
-                  "selected_options": [
+                  "options": [
                     { "name": "Size", "label": "10" }
                   ],
                   "tags": ["running", "road", "neutral"],
@@ -554,7 +554,7 @@ Maps to the [Catalog Lookup](lookup.md#get-product-get_product) capability. Retu
                 "description": { "plain": "Blue, Size 10" },
                 "price": { "amount": 12000, "currency": "USD" },
                 "availability": { "available": true },
-                "selected_options": [
+                "options": [
                   { "name": "Color", "label": "Blue" },
                   { "name": "Size", "label": "10" }
                 ]
@@ -566,7 +566,7 @@ Maps to the [Catalog Lookup](lookup.md#get-product-get_product) capability. Retu
                 "description": { "plain": "Blue, Size 12" },
                 "price": { "amount": 15000, "currency": "USD" },
                 "availability": { "available": true },
-                "selected_options": [
+                "options": [
                   { "name": "Color", "label": "Blue" },
                   { "name": "Size", "label": "12" }
                 ]

--- a/docs/specification/catalog/rest.md
+++ b/docs/specification/catalog/rest.md
@@ -152,7 +152,7 @@ Maps to the [Catalog Search](search.md) capability.
               "description": { "plain": "Size 10 variant" },
               "price": { "amount": 12000, "currency": "USD" },
               "availability": { "available": true },
-              "selected_options": [
+              "options": [
                 { "name": "Size", "label": "10" }
               ],
               "tags": ["running", "road", "neutral"],
@@ -428,7 +428,7 @@ on option values and returns variants matching the selection.
             "description": { "plain": "Blue, Size 10" },
             "price": { "amount": 12000, "currency": "USD" },
             "availability": { "available": true },
-            "selected_options": [
+            "options": [
               { "name": "Color", "label": "Blue" },
               { "name": "Size", "label": "10" }
             ]
@@ -440,7 +440,7 @@ on option values and returns variants matching the selection.
             "description": { "plain": "Blue, Size 12" },
             "price": { "amount": 15000, "currency": "USD" },
             "availability": { "available": true },
-            "selected_options": [
+            "options": [
               { "name": "Color", "label": "Blue" },
               { "name": "Size", "label": "12" }
             ]

--- a/source/schemas/shopping/types/variant.json
+++ b/source/schemas/shopping/types/variant.json
@@ -117,12 +117,12 @@
         }
       }
     },
-    "selected_options": {
+    "options": {
       "type": "array",
       "items": {
         "$ref": "selected_option.json"
       },
-      "description": "Option selections that define this variant."
+      "description": "Option values that define this variant (e.g., Color: Blue, Size: Large)."
     },
     "media": {
       "type": "array",


### PR DESCRIPTION

<img width="936" height="122" alt="image" src="https://github.com/user-attachments/assets/f55581e3-3b4c-454f-8e2e-baff30d74e3e" />


PR #195 described the change and intent but commit got lost between working and merged branch (doh!). This PR lands the change described in 195. This is a breaking change relative to current schema: `variant.selected_options` → `variant.options`. With this change in place, we have:

* `request.selected` — what the user chose (input parameter)
* `product.selected` — what the server resolved (response, post-relaxation)
* `variant.options`  — what the variant IS (intrinsic, immutable)


## Checklist
- [x] **Breaking change**
- [x] Documentation update
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
