### PR TITLE
fix!: Cherrypick catalog variant schema fix into 2026-04-08 version

### DIFF
--- a/docs/specification/catalog/mcp.md
+++ b/docs/specification/catalog/mcp.md
@@ -214,7 +214,7 @@ Maps to the [Catalog Search](search.md) capability.
                   "description": { "plain": "Size 10 variant" },
                   "price": { "amount": 12000, "currency": "USD" },
                   "availability": { "available": true },
-                  "selected_options": [
+                  "options": [
                     { "name": "Size", "label": "10" }
                   ],
                   "tags": ["running", "road", "neutral"],
@@ -554,7 +554,7 @@ Maps to the [Catalog Lookup](lookup.md#get-product-get_product) capability. Retu
                 "description": { "plain": "Blue, Size 10" },
                 "price": { "amount": 12000, "currency": "USD" },
                 "availability": { "available": true },
-                "selected_options": [
+                "options": [
                   { "name": "Color", "label": "Blue" },
                   { "name": "Size", "label": "10" }
                 ]
@@ -566,7 +566,7 @@ Maps to the [Catalog Lookup](lookup.md#get-product-get_product) capability. Retu
                 "description": { "plain": "Blue, Size 12" },
                 "price": { "amount": 15000, "currency": "USD" },
                 "availability": { "available": true },
-                "selected_options": [
+                "options": [
                   { "name": "Color", "label": "Blue" },
                   { "name": "Size", "label": "12" }
                 ]

--- a/docs/specification/catalog/rest.md
+++ b/docs/specification/catalog/rest.md
@@ -152,7 +152,7 @@ Maps to the [Catalog Search](search.md) capability.
               "description": { "plain": "Size 10 variant" },
               "price": { "amount": 12000, "currency": "USD" },
               "availability": { "available": true },
-              "selected_options": [
+              "options": [
                 { "name": "Size", "label": "10" }
               ],
               "tags": ["running", "road", "neutral"],
@@ -428,7 +428,7 @@ on option values and returns variants matching the selection.
             "description": { "plain": "Blue, Size 10" },
             "price": { "amount": 12000, "currency": "USD" },
             "availability": { "available": true },
-            "selected_options": [
+            "options": [
               { "name": "Color", "label": "Blue" },
               { "name": "Size", "label": "10" }
             ]
@@ -440,7 +440,7 @@ on option values and returns variants matching the selection.
             "description": { "plain": "Blue, Size 12" },
             "price": { "amount": 15000, "currency": "USD" },
             "availability": { "available": true },
-            "selected_options": [
+            "options": [
               { "name": "Color", "label": "Blue" },
               { "name": "Size", "label": "12" }
             ]

--- a/source/schemas/shopping/types/variant.json
+++ b/source/schemas/shopping/types/variant.json
@@ -117,12 +117,12 @@
         }
       }
     },
-    "selected_options": {
+    "options": {
       "type": "array",
       "items": {
         "$ref": "selected_option.json"
       },
-      "description": "Option selections that define this variant."
+      "description": "Option values that define this variant (e.g., Color: Blue, Size: Large)."
     },
     "media": {
       "type": "array",


### PR DESCRIPTION
# Description

This is a cherrypick request for a breaking schema fix that should've been part of the `2026-04-08` UCP version cut. See https://github.com/Universal-Commerce-Protocol/ucp/pull/353 for more details.

## Type of change

- [x] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [x] Documentation update

---

### Is this a Breaking Change or Removal?

If you checked "Breaking change" above, or if you are removing **any** schema
files or fields:

- [x] **I have added `!` to my PR title** (e.g., `feat!: remove field`).
- [x] **I have added justification below.**

```text
## Breaking Changes / Removal Justification

Schema fix should have been caught and merged prior to version cut on 2026-04-08. This is a CP request to see if it can be patched back into the release.
```

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---