### PR TITLE
docs: remove entity wrapper from MCP response examples

### DIFF
--- a/docs/specification/cart-mcp.md
+++ b/docs/specification/cart-mcp.md
@@ -168,49 +168,47 @@ Maps to the [Create Cart](cart.md#create-cart) operation.
       "id": 1,
       "result": {
         "structuredContent": {
-          "cart": {
-            "ucp": {
-              "version": "{{ ucp_version }}",
-              "capabilities": {
-                "dev.ucp.shopping.checkout": [{"version": "{{ ucp_version }}"}],
-                "dev.ucp.shopping.cart": [{"version": "{{ ucp_version }}"}]
-              }
-            },
-            "id": "cart_abc123",
-            "line_items": [
-              {
-                "id": "li_1",
-                "item": {
-                  "id": "item_123",
-                  "title": "Red T-Shirt",
-                  "price": 2500
-                },
-                "quantity": 2,
-                "totals": [
-                  {"type": "subtotal", "amount": 5000},
-                  {"type": "total", "amount": 5000}
-                ]
-              }
-            ],
-            "currency": "USD",
-            "totals": [
-              {
-                "type": "subtotal",
-                "amount": 5000
+          "ucp": {
+            "version": "{{ ucp_version }}",
+            "capabilities": {
+              "dev.ucp.shopping.checkout": [{"version": "{{ ucp_version }}"}],
+              "dev.ucp.shopping.cart": [{"version": "{{ ucp_version }}"}]
+            }
+          },
+          "id": "cart_abc123",
+          "line_items": [
+            {
+              "id": "li_1",
+              "item": {
+                "id": "item_123",
+                "title": "Red T-Shirt",
+                "price": 2500
               },
-              {
-                "type": "total",
-                "amount": 5000
-              }
-            ],
-            "continue_url": "https://business.example.com/checkout?cart=cart_abc123",
-            "expires_at": "2026-01-16T12:00:00Z"
-          }
+              "quantity": 2,
+              "totals": [
+                {"type": "subtotal", "amount": 5000},
+                {"type": "total", "amount": 5000}
+              ]
+            }
+          ],
+          "currency": "USD",
+          "totals": [
+            {
+              "type": "subtotal",
+              "amount": 5000
+            },
+            {
+              "type": "total",
+              "amount": 5000
+            }
+          ],
+          "continue_url": "https://business.example.com/checkout?cart=cart_abc123",
+          "expires_at": "2026-01-16T12:00:00Z"
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"cart\":{\"ucp\":{...},\"id\":\"cart_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"cart_abc123\",...}"
           }
         ]
       }
@@ -288,49 +286,47 @@ Maps to the [Get Cart](cart.md#get-cart) operation.
       "id": 1,
       "result": {
         "structuredContent": {
-          "cart": {
-            "ucp": {
-              "version": "{{ ucp_version }}",
-              "capabilities": {
-                "dev.ucp.shopping.checkout": [{"version": "{{ ucp_version }}"}],
-                "dev.ucp.shopping.cart": [{"version": "{{ ucp_version }}"}]
-              }
-            },
-            "id": "cart_abc123",
-            "line_items": [
-              {
-                "id": "li_1",
-                "item": {
-                  "id": "item_123",
-                  "title": "Red T-Shirt",
-                  "price": 2500
-                },
-                "quantity": 2,
-                "totals": [
-                  {"type": "subtotal", "amount": 5000},
-                  {"type": "total", "amount": 5000}
-                ]
-              }
-            ],
-            "currency": "USD",
-            "totals": [
-              {
-                "type": "subtotal",
-                "amount": 5000
+          "ucp": {
+            "version": "{{ ucp_version }}",
+            "capabilities": {
+              "dev.ucp.shopping.checkout": [{"version": "{{ ucp_version }}"}],
+              "dev.ucp.shopping.cart": [{"version": "{{ ucp_version }}"}]
+            }
+          },
+          "id": "cart_abc123",
+          "line_items": [
+            {
+              "id": "li_1",
+              "item": {
+                "id": "item_123",
+                "title": "Red T-Shirt",
+                "price": 2500
               },
-              {
-                "type": "total",
-                "amount": 5000
-              }
-            ],
-            "continue_url": "https://business.example.com/checkout?cart=cart_abc123",
-            "expires_at": "2026-01-16T12:00:00Z"
-          }
+              "quantity": 2,
+              "totals": [
+                {"type": "subtotal", "amount": 5000},
+                {"type": "total", "amount": 5000}
+              ]
+            }
+          ],
+          "currency": "USD",
+          "totals": [
+            {
+              "type": "subtotal",
+              "amount": 5000
+            },
+            {
+              "type": "total",
+              "amount": 5000
+            }
+          ],
+          "continue_url": "https://business.example.com/checkout?cart=cart_abc123",
+          "expires_at": "2026-01-16T12:00:00Z"
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"cart\":{\"ucp\":{...},\"id\":\"cart_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"cart_abc123\",...}"
           }
         ]
       }
@@ -345,23 +341,21 @@ Maps to the [Get Cart](cart.md#get-cart) operation.
       "id": 1,
       "result": {
         "structuredContent": {
-          "cart": {
-            "ucp": {
-              "version": "{{ ucp_version }}",
-              "capabilities": {
-                "dev.ucp.shopping.cart": [{"version": "{{ ucp_version }}"}]
-              }
-            },
-            "messages": [
-              {
-                "type": "error",
-                "code": "not_found",
-                "content": "Cart not found or has expired",
-                "severity": "unrecoverable"
-              }
-            ],
-            "continue_url": "https://merchant.com/"
-          }
+          "ucp": {
+            "version": "{{ ucp_version }}",
+            "capabilities": {
+              "dev.ucp.shopping.cart": [{"version": "{{ ucp_version }}"}]
+            }
+          },
+          "messages": [
+            {
+              "type": "error",
+              "code": "not_found",
+              "content": "Cart not found or has expired",
+              "severity": "unrecoverable"
+            }
+          ],
+          "continue_url": "https://merchant.com/"
         },
         "content": [
           {
@@ -439,62 +433,60 @@ Maps to the [Update Cart](cart.md#update-cart) operation.
       "id": 2,
       "result": {
         "structuredContent": {
-          "cart": {
-            "ucp": {
-              "version": "{{ ucp_version }}",
-              "capabilities": {
-                "dev.ucp.shopping.checkout": [{"version": "{{ ucp_version }}"}],
-                "dev.ucp.shopping.cart": [{"version": "{{ ucp_version }}"}]
-              }
+          "ucp": {
+            "version": "{{ ucp_version }}",
+            "capabilities": {
+              "dev.ucp.shopping.checkout": [{"version": "{{ ucp_version }}"}],
+              "dev.ucp.shopping.cart": [{"version": "{{ ucp_version }}"}]
+            }
+          },
+          "id": "cart_abc123",
+          "line_items": [
+            {
+              "id": "li_1",
+              "item": {
+                "id": "item_123",
+                "title": "Red T-Shirt",
+                "price": 2500
+              },
+              "quantity": 3,
+              "totals": [
+                {"type": "subtotal", "amount": 7500},
+                {"type": "total", "amount": 7500}
+              ]
             },
-            "id": "cart_abc123",
-            "line_items": [
-              {
-                "id": "li_1",
-                "item": {
-                  "id": "item_123",
-                  "title": "Red T-Shirt",
-                  "price": 2500
-                },
-                "quantity": 3,
-                "totals": [
-                  {"type": "subtotal", "amount": 7500},
-                  {"type": "total", "amount": 7500}
-                ]
+            {
+              "id": "li_2",
+              "item": {
+                "id": "item_456",
+                "title": "Blue Jeans",
+                "price": 7500
               },
-              {
-                "id": "li_2",
-                "item": {
-                  "id": "item_456",
-                  "title": "Blue Jeans",
-                  "price": 7500
-                },
-                "quantity": 1,
-                "totals": [
-                  {"type": "subtotal", "amount": 7500},
-                  {"type": "total", "amount": 7500}
-                ]
-              }
-            ],
-            "currency": "USD",
-            "totals": [
-              {
-                "type": "subtotal",
-                "amount": 15000
-              },
-              {
-                "type": "total",
-                "amount": 15000
-              }
-            ],
-            "continue_url": "https://business.example.com/checkout?cart=cart_abc123",
-            "expires_at": "2026-01-16T12:00:00Z"
-          }
+              "quantity": 1,
+              "totals": [
+                {"type": "subtotal", "amount": 7500},
+                {"type": "total", "amount": 7500}
+              ]
+            }
+          ],
+          "currency": "USD",
+          "totals": [
+            {
+              "type": "subtotal",
+              "amount": 15000
+            },
+            {
+              "type": "total",
+              "amount": 15000
+            }
+          ],
+          "continue_url": "https://business.example.com/checkout?cart=cart_abc123",
+          "expires_at": "2026-01-16T12:00:00Z"
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"cart\":{\"ucp\":{...},\"id\":\"cart_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"cart_abc123\",...}"
           }
         ]
       }
@@ -545,48 +537,46 @@ Maps to the [Cancel Cart](cart.md#cancel-cart) operation.
       "id": 1,
       "result": {
         "structuredContent": {
-          "cart": {
-            "ucp": {
-              "version": "{{ ucp_version }}",
-              "capabilities": {
-                "dev.ucp.shopping.checkout": [{"version": "{{ ucp_version }}"}],
-                "dev.ucp.shopping.cart": [{"version": "{{ ucp_version }}"}]
-              }
-            },
-            "id": "cart_abc123",
-            "line_items": [
-              {
-                "id": "li_1",
-                "item": {
-                  "id": "item_123",
-                  "title": "Red T-Shirt",
-                  "price": 2500
-                },
-                "quantity": 2,
-                "totals": [
-                  {"type": "subtotal", "amount": 5000},
-                  {"type": "total", "amount": 5000}
-                ]
-              }
-            ],
-            "currency": "USD",
-            "totals": [
-              {
-                "type": "subtotal",
-                "amount": 5000
+          "ucp": {
+            "version": "{{ ucp_version }}",
+            "capabilities": {
+              "dev.ucp.shopping.checkout": [{"version": "{{ ucp_version }}"}],
+              "dev.ucp.shopping.cart": [{"version": "{{ ucp_version }}"}]
+            }
+          },
+          "id": "cart_abc123",
+          "line_items": [
+            {
+              "id": "li_1",
+              "item": {
+                "id": "item_123",
+                "title": "Red T-Shirt",
+                "price": 2500
               },
-              {
-                "type": "total",
-                "amount": 5000
-              }
-            ],
-            "continue_url": "https://business.example.com/checkout?cart=cart_abc123"
-          }
+              "quantity": 2,
+              "totals": [
+                {"type": "subtotal", "amount": 5000},
+                {"type": "total", "amount": 5000}
+              ]
+            }
+          ],
+          "currency": "USD",
+          "totals": [
+            {
+              "type": "subtotal",
+              "amount": 5000
+            },
+            {
+              "type": "total",
+              "amount": 5000
+            }
+          ],
+          "continue_url": "https://business.example.com/checkout?cart=cart_abc123"
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"cart\":{\"ucp\":{...},\"id\":\"cart_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"cart_abc123\",...}"
           }
         ]
       }
@@ -617,23 +607,21 @@ JSON-RPC `result` with `structuredContent` containing the UCP envelope and
   "id": 1,
   "result": {
     "structuredContent": {
-      "cart": {
-        "ucp": {
-          "version": "{{ ucp_version }}",
-          "capabilities": {
-            "dev.ucp.shopping.cart": [{"version": "{{ ucp_version }}"}]
-          }
-        },
-        "messages": [
-          {
-            "type": "error",
-            "code": "not_found",
-            "content": "Cart not found or has expired",
-            "severity": "unrecoverable"
-          }
-        ],
-        "continue_url": "https://merchant.com/"
-      }
+      "ucp": {
+        "version": "{{ ucp_version }}",
+        "capabilities": {
+          "dev.ucp.shopping.cart": [{"version": "{{ ucp_version }}"}]
+        }
+      },
+      "messages": [
+        {
+          "type": "error",
+          "code": "not_found",
+          "content": "Cart not found or has expired",
+          "severity": "unrecoverable"
+        }
+      ],
+      "continue_url": "https://merchant.com/"
     },
     "content": [
       {"type": "text", "text": "{\"ucp\":{...},\"messages\":[...]}"}

--- a/docs/specification/checkout-mcp.md
+++ b/docs/specification/checkout-mcp.md
@@ -211,130 +211,128 @@ Maps to the [Create Checkout](checkout.md#create-checkout) operation.
       "id": 1,
       "result": {
         "structuredContent": {
-          "checkout": {
-            "ucp": {
-              "version": "{{ ucp_version }}",
-              "capabilities": {
-                "dev.ucp.shopping.checkout": [
-                  {"version": "{{ ucp_version }}"}
-                ],
-                "dev.ucp.shopping.fulfillment": [
-                  {"version": "{{ ucp_version }}"}
-                ]
-              },
-              "payment_handlers": {
-                "com.example.vendor.delegate_payment": [
-                  {"id": "handler_1", "version": "{{ ucp_version }}", "available_instruments": [{"type": "card"}], "config": {}}
-                ]
-              }
-            },
-            "id": "checkout_abc123",
-            "status": "incomplete",
-            "buyer": {
-              "email": "jane.doe@example.com",
-              "first_name": "Jane",
-              "last_name": "Doe"
-            },
-            "line_items": [
-              {
-                "id": "li_1",
-                "item": {
-                  "id": "item_123",
-                  "title": "Blue Jeans",
-                  "price": 5000
-                },
-                "quantity": 1,
-                "totals": [
-                  {"type": "subtotal", "amount": 5000},
-                  {"type": "total", "amount": 5000}
-                ]
-              }
-            ],
-            "currency": "USD",
-            "totals": [
-              {
-                "type": "subtotal",
-                "amount": 5000
-              },
-              {
-                "type": "fulfillment",
-                "display_text": "Shipping",
-                "amount": 500
-              },
-              {
-                "type": "total",
-                "amount": 5500
-              }
-            ],
-            "fulfillment": {
-              "methods": [
-                {
-                  "id": "shipping_1",
-                  "type": "shipping",
-                  "line_item_ids": ["li_1"],
-                  "selected_destination_id": "dest_home",
-                  "destinations": [
-                    {
-                      "id": "dest_home",
-                      "street_address": "123 Main St",
-                      "address_locality": "Springfield",
-                      "address_region": "IL",
-                      "postal_code": "62701",
-                      "address_country": "US"
-                    }
-                  ],
-                  "groups": [
-                    {
-                      "id": "package_1",
-                      "line_item_ids": ["li_1"],
-                      "selected_option_id": "standard",
-                      "options": [
-                        {
-                          "id": "standard",
-                          "title": "Standard Shipping",
-                          "description": "Arrives in 5-7 business days",
-                          "totals": [
-                            {
-                              "type": "total",
-                              "amount": 500
-                            }
-                          ]
-                        },
-                        {
-                          "id": "express",
-                          "title": "Express Shipping",
-                          "description": "Arrives in 2-3 business days",
-                          "totals": [
-                            {
-                              "type": "total",
-                              "amount": 1000
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
+          "ucp": {
+            "version": "{{ ucp_version }}",
+            "capabilities": {
+              "dev.ucp.shopping.checkout": [
+                {"version": "{{ ucp_version }}"}
+              ],
+              "dev.ucp.shopping.fulfillment": [
+                {"version": "{{ ucp_version }}"}
               ]
             },
-            "links": [
-              {
-                "type": "privacy_policy",
-                "url": "https://business.example.com/privacy"
+            "payment_handlers": {
+              "com.example.vendor.delegate_payment": [
+                {"id": "handler_1", "version": "{{ ucp_version }}", "available_instruments": [{"type": "card"}], "config": {}}
+              ]
+            }
+          },
+          "id": "checkout_abc123",
+          "status": "incomplete",
+          "buyer": {
+            "email": "jane.doe@example.com",
+            "first_name": "Jane",
+            "last_name": "Doe"
+          },
+          "line_items": [
+            {
+              "id": "li_1",
+              "item": {
+                "id": "item_123",
+                "title": "Blue Jeans",
+                "price": 5000
               },
+              "quantity": 1,
+              "totals": [
+                {"type": "subtotal", "amount": 5000},
+                {"type": "total", "amount": 5000}
+              ]
+            }
+          ],
+          "currency": "USD",
+          "totals": [
+            {
+              "type": "subtotal",
+              "amount": 5000
+            },
+            {
+              "type": "fulfillment",
+              "display_text": "Shipping",
+              "amount": 500
+            },
+            {
+              "type": "total",
+              "amount": 5500
+            }
+          ],
+          "fulfillment": {
+            "methods": [
               {
-                "type": "terms_of_service",
-                "url": "https://business.example.com/terms"
+                "id": "shipping_1",
+                "type": "shipping",
+                "line_item_ids": ["li_1"],
+                "selected_destination_id": "dest_home",
+                "destinations": [
+                  {
+                    "id": "dest_home",
+                    "street_address": "123 Main St",
+                    "address_locality": "Springfield",
+                    "address_region": "IL",
+                    "postal_code": "62701",
+                    "address_country": "US"
+                  }
+                ],
+                "groups": [
+                  {
+                    "id": "package_1",
+                    "line_item_ids": ["li_1"],
+                    "selected_option_id": "standard",
+                    "options": [
+                      {
+                        "id": "standard",
+                        "title": "Standard Shipping",
+                        "description": "Arrives in 5-7 business days",
+                        "totals": [
+                          {
+                            "type": "total",
+                            "amount": 500
+                          }
+                        ]
+                      },
+                      {
+                        "id": "express",
+                        "title": "Express Shipping",
+                        "description": "Arrives in 2-3 business days",
+                        "totals": [
+                          {
+                            "type": "total",
+                            "amount": 1000
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
-            ],
-            "continue_url": "https://business.example.com/checkout-sessions/checkout_abc123",
-            "expires_at": "2026-01-11T18:30:00Z"
-          }
+            ]
+          },
+          "links": [
+            {
+              "type": "privacy_policy",
+              "url": "https://business.example.com/privacy"
+            },
+            {
+              "type": "terms_of_service",
+              "url": "https://business.example.com/terms"
+            }
+          ],
+          "continue_url": "https://business.example.com/checkout-sessions/checkout_abc123",
+          "expires_at": "2026-01-11T18:30:00Z"
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"checkout\":{\"ucp\":{...},\"id\":\"checkout_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"checkout_abc123\",...}"
           }
         ]
       }
@@ -462,130 +460,128 @@ Maps to the [Update Checkout](checkout.md#update-checkout) operation.
       "id": 2,
       "result": {
         "structuredContent": {
-          "checkout": {
-            "ucp": {
-              "version": "{{ ucp_version }}",
-              "capabilities": {
-                "dev.ucp.shopping.checkout": [
-                  {"version": "{{ ucp_version }}"}
-                ],
-                "dev.ucp.shopping.fulfillment": [
-                  {"version": "{{ ucp_version }}"}
-                ]
-              },
-              "payment_handlers": {
-                "com.example.vendor.delegate_payment": [
-                  {"id": "handler_1", "version": "{{ ucp_version }}", "available_instruments": [{"type": "card"}], "config": {}}
-                ]
-              }
-            },
-            "id": "checkout_abc123",
-            "status": "incomplete",
-            "buyer": {
-              "email": "jane.doe@example.com",
-              "first_name": "Jane",
-              "last_name": "Doe"
-            },
-            "line_items": [
-              {
-                "id": "li_1",
-                "item": {
-                  "id": "item_123",
-                  "title": "Blue Jeans",
-                  "price": 5000
-                },
-                "quantity": 1,
-                "totals": [
-                  {"type": "subtotal", "amount": 5000},
-                  {"type": "total", "amount": 5000}
-                ]
-              }
-            ],
-            "currency": "USD",
-            "totals": [
-              {
-                "type": "subtotal",
-                "amount": 5000
-              },
-              {
-                "type": "fulfillment",
-                "display_text": "Shipping",
-                "amount": 1000
-              },
-              {
-                "type": "total",
-                "amount": 6000
-              }
-            ],
-            "fulfillment": {
-              "methods": [
-                {
-                  "id": "shipping_1",
-                  "type": "shipping",
-                  "line_item_ids": ["li_1"],
-                  "selected_destination_id": "dest_home",
-                  "destinations": [
-                    {
-                      "id": "dest_home",
-                      "street_address": "123 Main St",
-                      "address_locality": "Springfield",
-                      "address_region": "IL",
-                      "postal_code": "62701",
-                      "address_country": "US"
-                    }
-                  ],
-                  "groups": [
-                    {
-                      "id": "package_1",
-                      "line_item_ids": ["li_1"],
-                      "selected_option_id": "express",
-                      "options": [
-                        {
-                          "id": "standard",
-                          "title": "Standard Shipping",
-                          "description": "Arrives in 5-7 business days",
-                          "totals": [
-                            {
-                              "type": "total",
-                              "amount": 500
-                            }
-                          ]
-                        },
-                        {
-                          "id": "express",
-                          "title": "Express Shipping",
-                          "description": "Arrives in 2-3 business days",
-                          "totals": [
-                            {
-                              "type": "total",
-                              "amount": 1000
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
+          "ucp": {
+            "version": "{{ ucp_version }}",
+            "capabilities": {
+              "dev.ucp.shopping.checkout": [
+                {"version": "{{ ucp_version }}"}
+              ],
+              "dev.ucp.shopping.fulfillment": [
+                {"version": "{{ ucp_version }}"}
               ]
             },
-            "links": [
-              {
-                "type": "privacy_policy",
-                "url": "https://business.example.com/privacy"
+            "payment_handlers": {
+              "com.example.vendor.delegate_payment": [
+                {"id": "handler_1", "version": "{{ ucp_version }}", "available_instruments": [{"type": "card"}], "config": {}}
+              ]
+            }
+          },
+          "id": "checkout_abc123",
+          "status": "incomplete",
+          "buyer": {
+            "email": "jane.doe@example.com",
+            "first_name": "Jane",
+            "last_name": "Doe"
+          },
+          "line_items": [
+            {
+              "id": "li_1",
+              "item": {
+                "id": "item_123",
+                "title": "Blue Jeans",
+                "price": 5000
               },
+              "quantity": 1,
+              "totals": [
+                {"type": "subtotal", "amount": 5000},
+                {"type": "total", "amount": 5000}
+              ]
+            }
+          ],
+          "currency": "USD",
+          "totals": [
+            {
+              "type": "subtotal",
+              "amount": 5000
+            },
+            {
+              "type": "fulfillment",
+              "display_text": "Shipping",
+              "amount": 1000
+            },
+            {
+              "type": "total",
+              "amount": 6000
+            }
+          ],
+          "fulfillment": {
+            "methods": [
               {
-                "type": "terms_of_service",
-                "url": "https://business.example.com/terms"
+                "id": "shipping_1",
+                "type": "shipping",
+                "line_item_ids": ["li_1"],
+                "selected_destination_id": "dest_home",
+                "destinations": [
+                  {
+                    "id": "dest_home",
+                    "street_address": "123 Main St",
+                    "address_locality": "Springfield",
+                    "address_region": "IL",
+                    "postal_code": "62701",
+                    "address_country": "US"
+                  }
+                ],
+                "groups": [
+                  {
+                    "id": "package_1",
+                    "line_item_ids": ["li_1"],
+                    "selected_option_id": "express",
+                    "options": [
+                      {
+                        "id": "standard",
+                        "title": "Standard Shipping",
+                        "description": "Arrives in 5-7 business days",
+                        "totals": [
+                          {
+                            "type": "total",
+                            "amount": 500
+                          }
+                        ]
+                      },
+                      {
+                        "id": "express",
+                        "title": "Express Shipping",
+                        "description": "Arrives in 2-3 business days",
+                        "totals": [
+                          {
+                            "type": "total",
+                            "amount": 1000
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
-            ],
-            "continue_url": "https://business.example.com/checkout-sessions/checkout_abc123",
-            "expires_at": "2026-01-11T18:30:00Z"
-          }
+            ]
+          },
+          "links": [
+            {
+              "type": "privacy_policy",
+              "url": "https://business.example.com/privacy"
+            },
+            {
+              "type": "terms_of_service",
+              "url": "https://business.example.com/terms"
+            }
+          ],
+          "continue_url": "https://business.example.com/checkout-sessions/checkout_abc123",
+          "expires_at": "2026-01-11T18:30:00Z"
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"checkout\":{\"ucp\":{...},\"id\":\"checkout_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"checkout_abc123\",...}"
           }
         ]
       }
@@ -649,35 +645,33 @@ as JSON-RPC `result` with `structuredContent` containing the UCP envelope and
   "id": 1,
   "result": {
     "structuredContent": {
-      "checkout": {
-        "ucp": {
-          "version": "{{ ucp_version }}",
-          "capabilities": {
-            "dev.ucp.shopping.checkout": [{"version": "{{ ucp_version }}"}]
-          }
-        },
-        "id": "checkout_abc123",
-        "status": "incomplete",
-        "line_items": [
-          {
-            "id": "li_1",
-            "quantity": 100,
-            "available_quantity": 12
-          }
-        ],
-        "messages": [
-          {
-            "type": "warning",
-            "code": "quantity_adjusted",
-            "content": "Quantity adjusted, requested 100 units but only 12 available",
-            "path": "$.line_items[0].quantity"
-          }
-        ],
-        "continue_url": "https://merchant.com/checkout/checkout_abc123"
-      }
+      "ucp": {
+        "version": "{{ ucp_version }}",
+        "capabilities": {
+          "dev.ucp.shopping.checkout": [{"version": "{{ ucp_version }}"}]
+        }
+      },
+      "id": "checkout_abc123",
+      "status": "incomplete",
+      "line_items": [
+        {
+          "id": "li_1",
+          "quantity": 100,
+          "available_quantity": 12
+        }
+      ],
+      "messages": [
+        {
+          "type": "warning",
+          "code": "quantity_adjusted",
+          "content": "Quantity adjusted, requested 100 units but only 12 available",
+          "path": "$.line_items[0].quantity"
+        }
+      ],
+      "continue_url": "https://merchant.com/checkout/checkout_abc123"
     },
     "content": [
-      {"type": "text", "text": "{\"checkout\":{\"ucp\":{...},\"id\":\"checkout_abc123\",...}}"}
+      {"type": "text", "text": "{\"ucp\":{...},\"id\":\"checkout_abc123\",...}"}
     ]
   }
 }
@@ -772,7 +766,7 @@ Content-Digest: sha-256=:Y5fK8nLmPqRsT3vWxYzAbCdEfGhIjKlMnO...:
 Signature-Input: sig1=("@status" "content-digest" "content-type");keyid="merchant-2026"
 Signature: sig1=:MFQCIH7kL9nM2oP5qR8sT1uV4wX6yZaB3cD...:
 
-{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"..."}],"structuredContent":{"checkout":{"id":"checkout_abc123","status":"completed"}}}}
+{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"..."}],"structuredContent":{"id":"checkout_abc123","status":"completed"}}}
 ```
 
 See [Message Signatures - REST Response Signing](signatures.md#rest-response-signing)

--- a/docs/specification/order-mcp.md
+++ b/docs/specification/order-mcp.md
@@ -135,70 +135,68 @@ current-state snapshot of an order.
       "id": 1,
       "result": {
         "structuredContent": {
-          "order": {
-            "ucp": {
-              "version": "{{ ucp_version }}",
-              "capabilities": {
-                "dev.ucp.shopping.order": [{"version": "{{ ucp_version }}"}]
-              }
-            },
-            "id": "order_abc123",
-            "checkout_id": "checkout_xyz789",
-            "permalink_url": "https://business.example.com/orders/abc123",
-            "currency": "USD",
-            "line_items": [
+          "ucp": {
+            "version": "{{ ucp_version }}",
+            "capabilities": {
+              "dev.ucp.shopping.order": [{"version": "{{ ucp_version }}"}]
+            }
+          },
+          "id": "order_abc123",
+          "checkout_id": "checkout_xyz789",
+          "permalink_url": "https://business.example.com/orders/abc123",
+          "currency": "USD",
+          "line_items": [
+            {
+              "id": "li_shoes",
+              "item": { "id": "prod_shoes", "title": "Running Shoes", "price": 3000 },
+              "quantity": { "total": 1, "fulfilled": 1 },
+              "totals": [
+                {"type": "subtotal", "amount": 3000},
+                {"type": "total", "amount": 3000}
+              ],
+              "status": "fulfilled"
+            }
+          ],
+          "fulfillment": {
+            "expectations": [
               {
-                "id": "li_shoes",
-                "item": { "id": "prod_shoes", "title": "Running Shoes", "price": 3000 },
-                "quantity": { "total": 1, "fulfilled": 1 },
-                "totals": [
-                  {"type": "subtotal", "amount": 3000},
-                  {"type": "total", "amount": 3000}
-                ],
-                "status": "fulfilled"
+                "id": "exp_1",
+                "line_items": [{ "id": "li_shoes", "quantity": 1 }],
+                "method_type": "shipping",
+                "destination": {
+                  "street_address": "123 Main St",
+                  "address_locality": "Austin",
+                  "address_region": "TX",
+                  "address_country": "US",
+                  "postal_code": "78701"
+                },
+                "description": "Delivered"
               }
             ],
-            "fulfillment": {
-              "expectations": [
-                {
-                  "id": "exp_1",
-                  "line_items": [{ "id": "li_shoes", "quantity": 1 }],
-                  "method_type": "shipping",
-                  "destination": {
-                    "street_address": "123 Main St",
-                    "address_locality": "Austin",
-                    "address_region": "TX",
-                    "address_country": "US",
-                    "postal_code": "78701"
-                  },
-                  "description": "Delivered"
-                }
-              ],
-              "events": [
-                {
-                  "id": "evt_1",
-                  "occurred_at": "2026-01-08T10:30:00Z",
-                  "type": "delivered",
-                  "line_items": [{ "id": "li_shoes", "quantity": 1 }],
-                  "tracking_number": "1Z999AA10123456784",
-                  "tracking_url": "https://ups.com/track/1Z999AA10123456784",
-                  "description": "Delivered to front door"
-                }
-              ]
-            },
-            "adjustments": [],
-            "totals": [
-              { "type": "subtotal", "amount": 3000 },
-              { "type": "fulfillment", "amount": 800 },
-              { "type": "tax", "amount": 304 },
-              { "type": "total", "amount": 4104 }
+            "events": [
+              {
+                "id": "evt_1",
+                "occurred_at": "2026-01-08T10:30:00Z",
+                "type": "delivered",
+                "line_items": [{ "id": "li_shoes", "quantity": 1 }],
+                "tracking_number": "1Z999AA10123456784",
+                "tracking_url": "https://ups.com/track/1Z999AA10123456784",
+                "description": "Delivered to front door"
+              }
             ]
-          }
+          },
+          "adjustments": [],
+          "totals": [
+            { "type": "subtotal", "amount": 3000 },
+            { "type": "fulfillment", "amount": 800 },
+            { "type": "tax", "amount": 304 },
+            { "type": "total", "amount": 4104 }
+          ]
         },
         "content": [
           {
             "type": "text",
-            "text": "{\"order\":{\"ucp\":{...},\"id\":\"order_abc123\",...}}"
+            "text": "{\"ucp\":{...},\"id\":\"order_abc123\",...}"
           }
         ]
       }
@@ -213,23 +211,21 @@ current-state snapshot of an order.
       "id": 1,
       "result": {
         "structuredContent": {
-          "order": {
-            "ucp": {
-              "version": "{{ ucp_version }}",
-              "status": "error",
-              "capabilities": {
-                "dev.ucp.shopping.order": [{"version": "{{ ucp_version }}"}]
-              }
-            },
-            "messages": [
-              {
-                "type": "error",
-                "code": "not_found",
-                "severity": "unrecoverable",
-                "content": "Order not found."
-              }
-            ]
-          }
+          "ucp": {
+            "version": "{{ ucp_version }}",
+            "status": "error",
+            "capabilities": {
+              "dev.ucp.shopping.order": [{"version": "{{ ucp_version }}"}]
+            }
+          },
+          "messages": [
+            {
+              "type": "error",
+              "code": "not_found",
+              "severity": "unrecoverable",
+              "content": "Order not found."
+            }
+          ]
         },
         "content": [
           {
@@ -249,23 +245,21 @@ current-state snapshot of an order.
       "id": 1,
       "result": {
         "structuredContent": {
-          "order": {
-            "ucp": {
-              "version": "{{ ucp_version }}",
-              "status": "error",
-              "capabilities": {
-                "dev.ucp.shopping.order": [{"version": "{{ ucp_version }}"}]
-              }
-            },
-            "messages": [
-              {
-                "type": "error",
-                "code": "unauthorized",
-                "severity": "unrecoverable",
-                "content": "Not authorized to access this order."
-              }
-            ]
-          }
+          "ucp": {
+            "version": "{{ ucp_version }}",
+            "status": "error",
+            "capabilities": {
+              "dev.ucp.shopping.order": [{"version": "{{ ucp_version }}"}]
+            }
+          },
+          "messages": [
+            {
+              "type": "error",
+              "code": "unauthorized",
+              "severity": "unrecoverable",
+              "content": "Not authorized to access this order."
+            }
+          ]
         },
         "content": [
           {

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -1609,15 +1609,13 @@ MCP servers:
   "id": 1,
   "result": {
     "structuredContent": {
-      "checkout": {
-        "ucp": {"version": "{{ ucp_version }}", "capabilities": {...}},
-        "id": "checkout_abc123",
-        "status": "incomplete",
-        ...
-      }
+      "ucp": {"version": "{{ ucp_version }}", "capabilities": {...}},
+      "id": "checkout_abc123",
+      "status": "incomplete",
+      ...
     },
     "content": [
-      {"type": "text", "text": "{\"checkout\":{\"ucp\":{...},\"id\":\"checkout_abc123\",...}}"}
+      {"type": "text", "text": "{\"ucp\":{...},\"id\":\"checkout_abc123\",...}"}
     ]
   }
 }


### PR DESCRIPTION
## Summary

MCP response examples incorrectly nest the UCP payload under a `"checkout"`, `"cart"`, or `"order"` key inside `structuredContent`. Per the [OpenRPC specification](https://spec.open-rpc.org/), the `result.name` field is descriptive metadata for documentation and tooling — it does **not** create a wrapper key in the JSON-RPC wire format. The `name` field only has wire-format significance on `params` (by-name parameter passing), not on `result`.

This creates an inconsistency in the current docs: **error responses** already place the UCP envelope directly in `structuredContent` (no wrapper), while **success responses** incorrectly wrap it.

### Before (success response)

```json
"structuredContent": {
  "checkout": {
    "ucp": { ... },
    "id": "checkout_abc123",
    ...
  }
}
```

### After (success response — consistent with error responses)

```json
"structuredContent": {
  "ucp": { ... },
  "id": "checkout_abc123",
  ...
}
```

### Files changed

- `docs/specification/checkout-mcp.md` — 4 response examples
- `docs/specification/cart-mcp.md` — 6 response examples
- `docs/specification/order-mcp.md` — 3 response examples
- `docs/specification/overview.md` — 1 MCP transport example

### Context

Addresses the same issue as #239, which was closed because #216 was expected to include this fix. #216 corrected error response examples but left success responses wrapped.

## Checklist

- [x] Docs only — no schema changes
- [x] Self-reviewed
- [x] markdownlint passes
- [x] cspell passes
- [x] No new warnings introduced