### PR TITLE
fix: add missing ucp_agent parameter to create_cart REST operation

### DIFF
--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -409,6 +409,7 @@
           { "$ref": "#/components/parameters/idempotency_key" },
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
+          { "$ref": "#/components/parameters/ucp_agent" },
           { "$ref": "#/components/parameters/content_type" },
           { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },


### PR DESCRIPTION
## Summary
- `create_cart` (POST `/carts`) is the only REST operation (out of 14) missing the `ucp_agent` parameter reference
- The spec states "All requests MUST include the UCP-Agent header" — this brings `create_cart` into compliance
- MCP transport already requires `ucp-agent` on `create_cart`, so this aligns REST with MCP

## Details
Added `{ "$ref": "#/components/parameters/ucp_agent" }` to the `create_cart` parameters array in `source/services/shopping/rest.openapi.json`, matching the pattern used by all other operations.

| Category | Value |
|----------|-------|
| Category | Capability |
| Type | Bug fix |
| Breaking change | No |

## Test plan
- [x] JSON validity verified (`python -m json.tool`)
- [x] Confirmed all 14 REST operations now include `ucp_agent` parameter reference
- [x] Cross-checked MCP and Embedded transports for consistency