### PR TITLE
docs: fix accuracy issues in documentation pages

### DIFF
--- a/docs/documentation/core-concepts.md
+++ b/docs/documentation/core-concepts.md
@@ -121,4 +121,4 @@ interact.
     UCP is transport-agnostic but defines specific bindings for
     interoperability.
     * *Examples:* REST API (primary), MCP (Model Context Protocol), A2A
-        (Agent2Agent).
+        (Agent2Agent), EP (Embedded Protocol).

--- a/docs/documentation/roadmap.md
+++ b/docs/documentation/roadmap.md
@@ -34,14 +34,9 @@ community feedback.
 To move beyond isolated transactions, we are expanding the protocol's scope to
 tackle key user journeys such as multi-item checkout, loyalty, and lifecycle
 management, while ensuring the business's brand and logic remain central to all
-shopping experiences. Key upcoming initiatives include:
+shopping experiences. With product discovery, cart building, and post-order
+management now part of the specification, key upcoming initiatives include:
 
-* **Product discovery and post-order management:** By facilitating the entire
-    journey, we help businesses maximize lifetime and average order value rather
-    than just processing a single item for checkout.
-* **Cart and basket building:** Support for multi-item checkout from a
-    business, complex basket rules (e.g., promotions, tax, shipping), and varied
-    fulfillment logic that reflects how people actually shop.
 * **Loyalty & Member benefits:** Capabilities to enable loyalty and member
     benefits to help users find the best value and businesses achieve a deeper
     connection with their consumers through account linking.

--- a/docs/specification/playground.md
+++ b/docs/specification/playground.md
@@ -405,7 +405,7 @@ Accept: application/json</pre>
  * ------------------------------------------------------------------
  */
 const UcpData = {
-  version: "2026-01-11",
+  version: "{{ ucp_version }}",
 
   inventory: {
     "sku_stickers": { title: "UCP Demo Sticker Pack", price: 599, image_url: "https://example.com/images/stickers.jpg" },
@@ -416,7 +416,7 @@ const UcpData = {
     "com.shopify.shop_pay": [
       {
         id: "shop_pay",
-        version: "2026-01-11",
+        version: "{{ ucp_version }}",
         spec: "https://shopify.dev/docs/agents/checkout/shop-pay-handler",
         config_schema: "https://shopify.dev/ucp/shop-pay-handler/2026-01-11/config.json",
         instrument_schemas: ["https://shopify.dev/ucp/shop-pay-handler/2026-01-11/instrument.json"],
@@ -426,7 +426,7 @@ const UcpData = {
     "com.google.pay": [
       {
         id: "gpay",
-        version: "2026-01-11",
+        version: "{{ ucp_version }}",
         spec: "https://pay.google.com/gp/p/ucp/2026-01-11/",
         config_schema: "https://pay.google.com/gp/p/ucp/2026-01-11/schemas/config.json",
         instrument_schemas: [


### PR DESCRIPTION
## Summary

Fixes three documentation accuracy issues where pages had drifted from the current state of the specification.

### Fixes

| # | File | Fix |
|---|------|-----|
| 1 | `docs/specification/playground.md` | Replace 3 hardcoded `"2026-01-11"` UCP version fields with `{{ ucp_version }}` template variable. Third-party mock URLs (shopify.dev, pay.google.com) left unchanged. |
| 2 | `docs/documentation/core-concepts.md` | Add EP (Embedded Protocol) to transport examples list — it was the only defined transport binding missing from the list. |
| 3 | `docs/documentation/roadmap.md` | Update "upcoming initiatives" to reflect that product discovery, cart, and post-order management are now part of the specification. Loyalty and cross-sell/upsell remain as upcoming. |

All changes are docs-only. No schema or code changes.

## Test plan

- [x] `mkdocs build --strict` passes
- [x] All `{{ ucp_version }}` template variables render correctly
- [x] Roadmap prose reads naturally after edit