### PR TITLE
fix: Fix inconsistent schema on documentation examples & discounts extension schema

### DIFF
--- a/docs/specification/checkout-mcp.md
+++ b/docs/specification/checkout-mcp.md
@@ -656,10 +656,16 @@ as JSON-RPC `result` with `structuredContent` containing the UCP envelope and
       "line_items": [
         {
           "id": "li_1",
-          "quantity": 100,
-          "available_quantity": 12
+           "item": {
+              "id": "item_123",
+              "title": "Blue Jeans",
+              "price": 5000
+            },
+          "quantity": 12,
+          "totals": [...]
         }
       ],
+      "totals": [...],
       "messages": [
         {
           "type": "warning",

--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -1291,11 +1291,17 @@ with HTTP 200 and the UCP envelope containing `messages`:
   "status": "incomplete",
   "line_items": [
     {
-      "id": "item_456",
-      "quantity": 100,
-      "available_quantity": 12
+      "id": "li_1",
+        "item": {
+          "id": "item_123",
+          "title": "Blue Jeans",
+          "price": 5000
+        },
+      "quantity": 12,
+      "totals": [...]
     }
   ],
+  "totals": [...],
   "messages": [
     {
       "type": "warning",

--- a/docs/specification/discount.md
+++ b/docs/specification/discount.md
@@ -246,10 +246,9 @@ stacking and allocation details:
       "line_items": [
         {
           "item": {
-            "id": "prod_shirt",
-            "quantity": 2,
-            "price": 2500
-          }
+            "id": "prod_shirt"
+          },
+          "quantity": 2
         }
       ]
     }
@@ -331,10 +330,8 @@ proceeding to checkout.
         {
           "item": {
             "id": "prod_1",
-            "quantity": 2,
-            "title": "T-Shirt",
-            "price": 2000
-          }
+          },
+          "quantity": 2
         }
       ],
       "discounts": {
@@ -353,10 +350,10 @@ proceeding to checkout.
           "id": "li_1",
           "item": {
             "id": "prod_1",
-            "quantity": 2,
             "title": "T-Shirt",
             "price": 2000
           },
+          "quantity": 2,
           "totals": [
             {"type": "subtotal", "amount": 4000},
             {"type": "items_discount", "amount": -800},
@@ -448,10 +445,10 @@ to line items, and an automatic shipping discount at the order level.
           "id": "li_1",
           "item": {
             "id": "prod_1",
-            "quantity": 2,
             "title": "T-Shirt",
             "price": 2000
           },
+          "quantity": 2,
           "totals": [
             {"type": "subtotal", "amount": 4000},
             {"type": "items_discount", "amount": -800},
@@ -545,9 +542,11 @@ Multiple discounts applied with full allocation breakdown:
         {
           "id": "li_1",
           "item": {
+            "id": "prod_1",
             "title": "T-Shirt",
             "price": 6000
           },
+          "quantity": 1,
           "totals": [
             {"type": "subtotal", "amount": 6000},
             {"type": "items_discount", "amount": -1500},
@@ -557,9 +556,11 @@ Multiple discounts applied with full allocation breakdown:
         {
           "id": "li_2",
           "item": {
+            "id": "prod_2",
             "title": "Socks",
             "price": 4000
           },
+          "quantity": 1,
           "totals": [
             {"type": "subtotal", "amount": 4000},
             {"type": "items_discount", "amount": -1000},

--- a/source/schemas/shopping/discount.json
+++ b/source/schemas/shopping/discount.json
@@ -92,11 +92,11 @@
         },
         "applied": {
           "type": "array",
-          "readOnly": true,
           "items": {
             "$ref": "#/$defs/applied_discount"
           },
-          "description": "Discounts successfully applied (code-based and automatic)."
+          "description": "Discounts successfully applied (code-based and automatic).",
+          "ucp_request": "omit"
         }
       }
     },


### PR DESCRIPTION
# Description

This PR aims to address some minor schema inconsistencies that are present in the current UCP spec:
1) In `discount.md`: Update all the examples to follow the correct UCP schema - `item.id` is the only field populated in requests, `quantity` pulled out to the `line_item` level, etc.
2) In `checkout-rest.md` and `checkout-mcp.md`: Remove unsupported `available_quantity` field and add in other required fields like `item` in business error example.
3) Fix incorrect usage of `readOnly` annotation in `discount.json`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
