### PR TITLE
fix!: Fix generic "object" references in docs

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,16 +135,6 @@ def _resolve_schema(
     raise RuntimeError(f"ucp-schema execution error: result = {result}")
 
 
-# Backward compatibility alias
-def _resolve_schema_bundled(
-  schema_path: str | Path,
-  direction: str = "response",
-  operation: str = "read",
-) -> dict[str, Any] | None:
-  """Resolve a schema with bundling (backward compat)."""
-  return _resolve_schema(schema_path, direction, operation, bundle=True)
-
-
 def define_env(env):
   """Injects custom macros into the MkDocs environment.
 

--- a/main.py
+++ b/main.py
@@ -724,6 +724,32 @@ def define_env(env):
           # Array of Primitives
           inner_type = items.get("type", "any")
           f_type = f"Array[{inner_type}]"
+        elif f_type == "object" and ("propertyNames" in details or isinstance(details.get("additionalProperties"), dict)):
+          # Map/Registry
+          key_type = "string"
+          val_type = "any"
+          
+          prop_names = details.get("propertyNames", {})
+          if "$ref" in prop_names:
+            key_type = create_link(prop_names["$ref"], spec_file_name, context)
+          elif "type" in prop_names:
+            key_type = prop_names["type"]
+            
+          add_props = details.get("additionalProperties")
+          if isinstance(add_props, dict):
+            if "$ref" in add_props:
+              val_type = create_link(add_props["$ref"], spec_file_name, context)
+            elif "type" in add_props:
+              if add_props["type"] == "array" and "items" in add_props:
+                items_schema = add_props["items"]
+                if isinstance(items_schema, dict) and "$ref" in items_schema:
+                  val_type = f"Array[{create_link(items_schema['$ref'], spec_file_name, context)}]"
+                else:
+                  val_type = f"Array[{items_schema.get('type', 'any')}]"
+              else:
+                val_type = add_props["type"]
+                
+          f_type = f"Map[{key_type}, {val_type}]"
 
         # --- Handle Description ---
         desc = ""
@@ -790,19 +816,19 @@ def define_env(env):
       full_path = Path(schemas_dir) / core_entity_name
       if not full_path.exists():
         continue
-      # Use ucp-schema to resolve the full file with bundling
-      bundled = _resolve_schema_bundled(full_path)
-      if bundled:
-        # Extract the $def from the bundled result
-        embedded_schema_data = _resolve_json_pointer(def_path, bundled)
+      # Resolve WITHOUT bundling to preserve $refs for hyperlinks
+      resolved_schema = _resolve_schema(full_path, bundle=False)
+      if resolved_schema:
+        # Extract the $def from the resolved result
+        embedded_schema_data = _resolve_json_pointer(def_path, resolved_schema)
         if embedded_schema_data is not None:
-          # Resolve internal refs (like #/$defs/base) against the bundled root
+          # Resolve internal refs (like #/$defs/base) against the resolved root
           if "allOf" in embedded_schema_data:
             new_all_of = []
             for item in embedded_schema_data["allOf"]:
               if "$ref" in item and item["$ref"].startswith("#"):
-                resolved = _resolve_json_pointer(item["$ref"], bundled)
-                new_all_of.append(resolved if resolved else item)
+                resolved_def = _resolve_json_pointer(item["$ref"], resolved_schema)
+                new_all_of.append(resolved_def if resolved_def else item)
               else:
                 new_all_of.append(item)
             embedded_schema_data = embedded_schema_data.copy()
@@ -1008,14 +1034,30 @@ def define_env(env):
             output.pop()  # remove title
             continue
         else:
+          defs = schema_data.get("$defs", {})
           rendered_table = _render_table_from_schema(
             schema_data, spec_file_name
           )
-          if rendered_table == "_No properties defined._":
-            continue
-          output.append(f"### {schema_title}\n")
-          output.append(rendered_table)
-          output.append("\n---\n")
+          
+          if rendered_table != "_No properties defined._" or defs:
+            output.append(f"### {schema_title}\n")
+            
+            if rendered_table != "_No properties defined._":
+              output.append(rendered_table)
+              output.append("\n")
+
+            for def_name, def_schema in defs.items():
+              def_title = def_schema.get(
+                "title", def_name.replace("_", " ").title()
+              )
+              output.append(f"#### {def_title}\n")
+              rendered_table = _read_schema_from_defs(
+                f"{entity_name}.json#/$defs/{def_name}", spec_file_name
+              )
+              output.append(rendered_table)
+              output.append("\n")
+
+            output.append("\n---\n")
       else:
         output.append(f"### {entity_name_base}\n")
         output.append(

--- a/source/schemas/shopping/ap2_mandate.json
+++ b/source/schemas/shopping/ap2_mandate.json
@@ -43,6 +43,18 @@
         }
       }
     },
+    "ap2_data": {
+      "title": "AP2 Data",
+      "description": "AP2 extension data.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/ap2_with_merchant_authorization"
+        },
+        {
+          "$ref": "#/$defs/ap2_with_checkout_mandate"
+        }
+      ]
+    },
     "dev.ucp.shopping.checkout": {
       "title": "Checkout with AP2 Mandate",
       "description": "Checkout extended with AP2 mandate support.",
@@ -54,14 +66,7 @@
           "type": "object",
           "properties": {
             "ap2": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/ap2_with_merchant_authorization"
-                },
-                {
-                  "$ref": "#/$defs/ap2_with_checkout_mandate"
-                }
-              ],
+              "$ref": "#/$defs/ap2_data",
               "ucp_request": {
                 "create": "omit",
                 "update": "omit",

--- a/source/schemas/shopping/catalog_lookup.json
+++ b/source/schemas/shopping/catalog_lookup.json
@@ -23,6 +23,32 @@
         }
       ]
     },
+    "lookup_product": {
+      "description": "Product with required correlation metadata for lookup responses.",
+      "allOf": [
+        { "$ref": "types/product.json" },
+        {
+          "properties": {
+            "variants": {
+              "items": { "$ref": "#/$defs/lookup_variant" }
+            }
+          }
+        }
+      ]
+    },
+    "detail_product_option": {
+      "type": "object",
+      "title": "Detail Product Option",
+      "required": ["name", "values"],
+      "properties": {
+        "name": { "type": "string" },
+        "values": {
+          "type": "array",
+          "items": { "$ref": "types/detail_option_value.json" },
+          "minItems": 1
+        }
+      }
+    },
     "lookup_request": {
       "type": "object",
       "description": "Request body for catalog lookup.",
@@ -59,16 +85,7 @@
         "products": {
           "type": "array",
           "items": {
-            "allOf": [
-              { "$ref": "types/product.json" },
-              {
-                "properties": {
-                  "variants": {
-                    "items": { "$ref": "#/$defs/lookup_variant" }
-                  }
-                }
-              }
-            ]
+            "$ref": "#/$defs/lookup_product"
           },
           "description": "Products matching the requested identifiers. May contain fewer items if some identifiers not found, or more if identifiers match multiple products."
         },
@@ -129,16 +146,7 @@
         "options": {
           "type": "array",
           "items": {
-            "type": "object",
-            "required": ["name", "values"],
-            "properties": {
-              "name": { "type": "string" },
-              "values": {
-                "type": "array",
-                "items": { "$ref": "types/detail_option_value.json" },
-                "minItems": 1
-              }
-            }
+            "$ref": "#/$defs/detail_product_option"
           },
           "description": "Product options with availability signals relative to the effective selections."
         }

--- a/source/schemas/shopping/order.json
+++ b/source/schemas/shopping/order.json
@@ -19,6 +19,27 @@
           "description": "URL where merchant sends order lifecycle events (webhooks)."
         }
       }
+    },
+    "order_fulfillment": {
+      "type": "object",
+      "title": "Order Fulfillment",
+      "description": "Fulfillment data: buyer expectations and what actually happened.",
+      "properties": {
+        "expectations": {
+          "type": "array",
+          "items": {
+            "$ref": "types/expectation.json"
+          },
+          "description": "Buyer-facing groups representing when/how items will be delivered. Can be split, merged, or adjusted post-order."
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "types/fulfillment_event.json"
+          },
+          "description": "Append-only event log of actual shipments. Each event references line items by ID."
+        }
+      }
     }
   },
   "type": "object",
@@ -61,24 +82,7 @@
       "description": "Line items representing what was purchased — can change post-order via edits or exchanges."
     },
     "fulfillment": {
-      "type": "object",
-      "properties": {
-        "expectations": {
-          "type": "array",
-          "items": {
-            "$ref": "types/expectation.json"
-          },
-          "description": "Buyer-facing groups representing when/how items will be delivered. Can be split, merged, or adjusted post-order."
-        },
-        "events": {
-          "type": "array",
-          "items": {
-            "$ref": "types/fulfillment_event.json"
-          },
-          "description": "Append-only event log of actual shipments. Each event references line items by ID."
-        }
-      },
-      "description": "Fulfillment data: buyer expectations and what actually happened."
+      "$ref": "#/$defs/order_fulfillment"
     },
     "adjustments": {
       "type": "array",

--- a/source/schemas/shopping/types/adjustment.json
+++ b/source/schemas/shopping/types/adjustment.json
@@ -3,6 +3,23 @@
   "$id": "https://ucp.dev/schemas/shopping/types/adjustment.json",
   "title": "Adjustment",
   "description": "Post-order event that exists independently of fulfillment. Typically represents money movements but can be any post-order change. Polymorphic type that can optionally reference line items.",
+  "$defs": {
+    "adjustment_line_item": {
+      "type": "object",
+      "title": "Adjustment Line Item",
+      "required": ["id", "quantity"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Line item ID reference."
+        },
+        "quantity": {
+          "type": "integer",
+          "description": "Signed quantity affected by this adjustment. Negative values represent reductions (e.g. returns); positive values represent additions (e.g. exchanges)."
+        }
+      }
+    }
+  },
   "type": "object",
   "required": [
     "id",
@@ -36,18 +53,7 @@
     "line_items": {
       "type": "array",
       "items": {
-        "type": "object",
-        "required": ["id", "quantity"],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Line item ID reference."
-          },
-          "quantity": {
-            "type": "integer",
-            "description": "Signed quantity affected by this adjustment. Negative values represent reductions (e.g. returns); positive values represent additions (e.g. exchanges)."
-          }
-        }
+        "$ref": "#/$defs/adjustment_line_item"
       },
       "description": "Which line items and quantities are affected (optional)."
     },

--- a/source/schemas/shopping/types/expectation.json
+++ b/source/schemas/shopping/types/expectation.json
@@ -3,6 +3,24 @@
   "$id": "https://ucp.dev/schemas/shopping/types/expectation.json",
   "title": "Expectation",
   "description": "Buyer-facing fulfillment expectation representing logical groupings of items (e.g., 'package'). Can be split, merged, or adjusted post-order to set buyer expectations for when/how items arrive.",
+  "$defs": {
+    "expectation_line_item": {
+      "type": "object",
+      "title": "Expectation Line Item",
+      "required": ["id", "quantity"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Line item ID reference."
+        },
+        "quantity": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Quantity of this item in this expectation."
+        }
+      }
+    }
+  },
   "type": "object",
   "required": [
     "id",
@@ -18,19 +36,7 @@
     "line_items": {
       "type": "array",
       "items": {
-        "type": "object",
-        "required": ["id", "quantity"],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Line item ID reference."
-          },
-          "quantity": {
-            "type": "integer",
-            "minimum": 1,
-            "description": "Quantity of this item in this expectation."
-          }
-        }
+        "$ref": "#/$defs/expectation_line_item"
       },
       "description": "Which line items and quantities are in this expectation."
     },

--- a/source/schemas/shopping/types/variant.json
+++ b/source/schemas/shopping/types/variant.json
@@ -3,6 +3,23 @@
   "$id": "https://ucp.dev/schemas/shopping/types/variant.json",
   "title": "Variant",
   "description": "A purchasable variant of a product with specific option selections.",
+  "$defs": {
+    "barcode": {
+      "type": "object",
+      "title": "Barcode",
+      "required": ["type", "value"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Barcode standard. Well-known values: UPC, EAN, ISBN, GTIN, JAN."
+        },
+        "value": {
+          "type": "string",
+          "description": "Barcode value."
+        }
+      }
+    }
+  },
   "type": "object",
   "required": [
     "id",
@@ -22,18 +39,7 @@
     "barcodes": {
       "type": "array",
       "items": {
-        "type": "object",
-        "required": ["type", "value"],
-        "properties": {
-          "type": {
-            "type": "string",
-            "description": "Barcode standard. Well-known values: UPC, EAN, ISBN, GTIN, JAN."
-          },
-          "value": {
-            "type": "string",
-            "description": "Barcode value."
-          }
-        }
+        "$ref": "#/$defs/barcode"
       },
       "description": "Industry-standard product identifiers for cross-reference and correlation."
     },


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

The current version of the [Reference](https://ucp.dev/latest/specification/reference/) page has > 50 "broken" references (i.e. references to generic "object" rather than a link to the actual schema). Check [Order.fulfillment](https://ucp.dev/latest/specification/reference/#order) or [Adjustment.line_items](https://ucp.dev/latest/specification/reference/#adjustment) for example.

This PR adds the missing $refs/$defs to the relevant schemas + some logic to better render entities like the [Discovery Profiles](https://ucp.dev/latest/specification/reference/#platform-discovery-profile)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [x] Documentation update

---

### Is this a Breaking Change or Removal?

If you checked "Breaking change" above, or if you are removing **any** schema
files or fields:

- [x] **I have added `!` to my PR title** (e.g., `feat!: remove field`).
- [x] **I have added justification below.**

## Breaking Changes / Removal Justification

Modified the schemas by adding missing $refs/$defs

---