### PR TITLE
ci: extract Configure Site URL step into composite action

### DIFF
--- a/.github/actions/configure-site-url/action.yml
+++ b/.github/actions/configure-site-url/action.yml
@@ -1,0 +1,27 @@
+name: 'Configure Site URL'
+description: >-
+  Resolves the GitHub Pages URL for the current repository and exports it as
+  SITE_URL and SPEC_URL environment variables for subsequent steps.
+inputs:
+  github-token:
+    description: >-
+      Token used to query the GitHub Pages API. Defaults to the workflow token.
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve and export site URLs
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        PAGES_URL=$(gh api "repos/${{ github.repository }}/pages" --jq '.html_url' 2>/dev/null || true)
+        if [ -z "$PAGES_URL" ] || [ "$PAGES_URL" = "null" ]; then
+          PAGES_URL="https://${{ github.repository_owner }}.github.io/${GITHUB_REPOSITORY#*/}"
+        fi
+        if [[ "$PAGES_URL" != */ ]]; then
+          PAGES_URL="${PAGES_URL}/"
+        fi
+        echo "SITE_URL=$PAGES_URL" >> "$GITHUB_ENV"
+        echo "SPEC_URL=${PAGES_URL}latest/specification/overview/" >> "$GITHUB_ENV"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,15 +85,7 @@ jobs:
 
       - uses: ./.github/actions/setup-build-env
 
-      - name: Configure Site URL
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PAGES_URL=$(gh api "repos/${{ github.repository }}/pages" --jq '.html_url' 2>/dev/null || true)
-          if [ -z "$PAGES_URL" ] || [ "$PAGES_URL" = "null" ]; then PAGES_URL="https://${{ github.repository_owner }}.github.io/${GITHUB_REPOSITORY#*/}"; fi
-          if [[ "$PAGES_URL" != */ ]]; then PAGES_URL="${PAGES_URL}/"; fi
-          echo "SITE_URL=$PAGES_URL" >> $GITHUB_ENV
-          echo "SPEC_URL=${PAGES_URL}latest/specification/overview/" >> $GITHUB_ENV
+      - uses: ./.github/actions/configure-site-url
 
       - name: Build and Verify Documentation Site (Main/PR)
         run: |
@@ -122,15 +114,7 @@ jobs:
 
       - uses: ./.github/actions/setup-build-env
 
-      - name: Configure Site URL
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PAGES_URL=$(gh api "repos/${{ github.repository }}/pages" --jq '.html_url' 2>/dev/null || true)
-          if [ -z "$PAGES_URL" ] || [ "$PAGES_URL" = "null" ]; then PAGES_URL="https://${{ github.repository_owner }}.github.io/${GITHUB_REPOSITORY#*/}"; fi
-          if [[ "$PAGES_URL" != */ ]]; then PAGES_URL="${PAGES_URL}/"; fi
-          echo "SITE_URL=$PAGES_URL" >> $GITHUB_ENV
-          echo "SPEC_URL=${PAGES_URL}latest/specification/overview/" >> $GITHUB_ENV
+      - uses: ./.github/actions/configure-site-url
 
       - name: Build and Verify Specification Docs (Release Branches)
         run: |
@@ -159,15 +143,7 @@ jobs:
 
       - uses: ./.github/actions/setup-build-env
 
-      - name: Configure Site URL
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PAGES_URL=$(gh api "repos/${{ github.repository }}/pages" --jq '.html_url' 2>/dev/null || true)
-          if [ -z "$PAGES_URL" ] || [ "$PAGES_URL" = "null" ]; then PAGES_URL="https://${{ github.repository_owner }}.github.io/${GITHUB_REPOSITORY#*/}"; fi
-          if [[ "$PAGES_URL" != */ ]]; then PAGES_URL="${PAGES_URL}/"; fi
-          echo "SITE_URL=$PAGES_URL" >> $GITHUB_ENV
-          echo "SPEC_URL=${PAGES_URL}latest/specification/overview/" >> $GITHUB_ENV
+      - uses: ./.github/actions/configure-site-url
 
       - name: Deploy development version from main branch
         run: |
@@ -220,15 +196,7 @@ jobs:
 
       - uses: ./.github/actions/setup-build-env
 
-      - name: Configure Site URL
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PAGES_URL=$(gh api "repos/${{ github.repository }}/pages" --jq '.html_url' 2>/dev/null || true)
-          if [ -z "$PAGES_URL" ] || [ "$PAGES_URL" = "null" ]; then PAGES_URL="https://${{ github.repository_owner }}.github.io/${GITHUB_REPOSITORY#*/}"; fi
-          if [[ "$PAGES_URL" != */ ]]; then PAGES_URL="${PAGES_URL}/"; fi
-          echo "SITE_URL=$PAGES_URL" >> $GITHUB_ENV
-          echo "SPEC_URL=${PAGES_URL}latest/specification/overview/" >> $GITHUB_ENV
+      - uses: ./.github/actions/configure-site-url
 
       - name: Deploy release version
         run: |


### PR DESCRIPTION
## Summary

Four jobs in [`.github/workflows/docs.yml`](.github/workflows/docs.yml) = `build_and_verify_main`, `build_and_verify_release`, `deploy_main`, and `deploy_release` & each contained an identical nine-line inline shell block that queries the GitHub Pages API, falls back to a constructed URL when the API returns nothing, normalises the trailing slash, and exports `SITE_URL` / `SPEC_URL` to `\$GITHUB_ENV`. Any change to the URL-resolution logic (e.g. a new suffix, a fallback tweak, a token-scope change) required editing all four places in lockstep.

This PR factors that block into a new composite action at [`.github/actions/configure-site-url/action.yml`](.github/actions/configure-site-url/action.yml), matching the pattern already established by [`.github/actions/setup-build-env/action.yml`](.github/actions/setup-build-env/action.yml).

## Changes

- **New:** `.github/actions/configure-site-url/action.yml` - composite action that wraps the existing logic. Takes an optional `github-token` input (defaulting to `github.token`) and exports `SITE_URL` + `SPEC_URL` to `\$GITHUB_ENV`, preserving the exact contract downstream steps rely on.
- **Edit:** `.github/workflows/docs.yml` - each of the four duplicated blocks is replaced with `- uses: ./.github/actions/configure-site-url`.

Net: 36 LOC of duplication removed, replaced with a single 25-line action plus four single-line invocations. No runtime behaviour change.

## Test plan

- [ ] `lint` job passes (yamllint)
- [ ] `build_and_verify_main` passes - exercises the composite action and consumes `\$SITE_URL` / `\$SPEC_URL` in `build_local.sh` + `check_links.py`
- [ ] Confirm the composite action writes the same two env vars (diff the resolved `\$GITHUB_ENV` vs. the previous inline block)

## Notes for reviewers

- The action uses `github.token` as the default for `github-token`, which is functionally equivalent to the prior `\${{ secrets.GITHUB_TOKEN }}` - both resolve to the automatically-minted workflow token with the same scope. Kept it overridable so a caller could supply a broader token if needed.
- All four call sites are in jobs that already run `./.github/actions/setup-build-env` immediately before the inlined block, so ordering is preserved.
- No change to the `Configure Git Credentials` blocks, which are also duplicated but differ slightly in context (one job configures git for pushing to `gh-pages`, others don't). Happy to extract those in a follow-up if desired.