### PR TITLE
ci: extract Configure Site URL step into composite action

### DIFF
--- a/.github/actions/configure-site-url/action.yml
+++ b/.github/actions/configure-site-url/action.yml
@@ -1,0 +1,27 @@
+name: 'Configure Site URL'
+description: >-
+  Resolves the GitHub Pages URL for the current repository and exports it as
+  SITE_URL and SPEC_URL environment variables for subsequent steps.
+inputs:
+  github-token:
+    description: >-
+      Token used to query the GitHub Pages API. Defaults to the workflow token.
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve and export site URLs
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        PAGES_URL=$(gh api "repos/${{ github.repository }}/pages" --jq '.html_url' 2>/dev/null || true)
+        if [ -z "$PAGES_URL" ] || [ "$PAGES_URL" = "null" ]; then
+          PAGES_URL="https://${{ github.repository_owner }}.github.io/${GITHUB_REPOSITORY#*/}"
+        fi
+        if [[ "$PAGES_URL" != */ ]]; then
+          PAGES_URL="${PAGES_URL}/"
+        fi
+        echo "SITE_URL=$PAGES_URL" >> "$GITHUB_ENV"
+        echo "SPEC_URL=${PAGES_URL}latest/specification/overview/" >> "$GITHUB_ENV"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,15 +85,7 @@ jobs:
 
       - uses: ./.github/actions/setup-build-env
 
-      - name: Configure Site URL
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PAGES_URL=$(gh api "repos/${{ github.repository }}/pages" --jq '.html_url' 2>/dev/null || true)
-          if [ -z "$PAGES_URL" ] || [ "$PAGES_URL" = "null" ]; then PAGES_URL="https://${{ github.repository_owner }}.github.io/${GITHUB_REPOSITORY#*/}"; fi
-          if [[ "$PAGES_URL" != */ ]]; then PAGES_URL="${PAGES_URL}/"; fi
-          echo "SITE_URL=$PAGES_URL" >> $GITHUB_ENV
-          echo "SPEC_URL=${PAGES_URL}latest/specification/overview/" >> $GITHUB_ENV
+      - uses: ./.github/actions/configure-site-url
 
       - name: Build and Verify Documentation Site (Main/PR)
         run: |
@@ -122,15 +114,7 @@ jobs:
 
       - uses: ./.github/actions/setup-build-env
 
-      - name: Configure Site URL
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PAGES_URL=$(gh api "repos/${{ github.repository }}/pages" --jq '.html_url' 2>/dev/null || true)
-          if [ -z "$PAGES_URL" ] || [ "$PAGES_URL" = "null" ]; then PAGES_URL="https://${{ github.repository_owner }}.github.io/${GITHUB_REPOSITORY#*/}"; fi
-          if [[ "$PAGES_URL" != */ ]]; then PAGES_URL="${PAGES_URL}/"; fi
-          echo "SITE_URL=$PAGES_URL" >> $GITHUB_ENV
-          echo "SPEC_URL=${PAGES_URL}latest/specification/overview/" >> $GITHUB_ENV
+      - uses: ./.github/actions/configure-site-url
 
       - name: Build and Verify Specification Docs (Release Branches)
         run: |
@@ -159,15 +143,7 @@ jobs:
 
       - uses: ./.github/actions/setup-build-env
 
-      - name: Configure Site URL
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PAGES_URL=$(gh api "repos/${{ github.repository }}/pages" --jq '.html_url' 2>/dev/null || true)
-          if [ -z "$PAGES_URL" ] || [ "$PAGES_URL" = "null" ]; then PAGES_URL="https://${{ github.repository_owner }}.github.io/${GITHUB_REPOSITORY#*/}"; fi
-          if [[ "$PAGES_URL" != */ ]]; then PAGES_URL="${PAGES_URL}/"; fi
-          echo "SITE_URL=$PAGES_URL" >> $GITHUB_ENV
-          echo "SPEC_URL=${PAGES_URL}latest/specification/overview/" >> $GITHUB_ENV
+      - uses: ./.github/actions/configure-site-url
 
       - name: Deploy development version from main branch
         run: |
@@ -220,15 +196,7 @@ jobs:
 
       - uses: ./.github/actions/setup-build-env
 
-      - name: Configure Site URL
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PAGES_URL=$(gh api "repos/${{ github.repository }}/pages" --jq '.html_url' 2>/dev/null || true)
-          if [ -z "$PAGES_URL" ] || [ "$PAGES_URL" = "null" ]; then PAGES_URL="https://${{ github.repository_owner }}.github.io/${GITHUB_REPOSITORY#*/}"; fi
-          if [[ "$PAGES_URL" != */ ]]; then PAGES_URL="${PAGES_URL}/"; fi
-          echo "SITE_URL=$PAGES_URL" >> $GITHUB_ENV
-          echo "SPEC_URL=${PAGES_URL}latest/specification/overview/" >> $GITHUB_ENV
+      - uses: ./.github/actions/configure-site-url
 
       - name: Deploy release version
         run: |


### PR DESCRIPTION
# Description

Four jobs in `.github/workflows/docs.yml` (`build_and_verify_main`, `build_and_verify_release`, `deploy_main`, `deploy_release`) had the same 9-line inline block for resolving the GitHub Pages URL and exporting `SITE_URL` / `SPEC_URL` to `$GITHUB_ENV`. Any change to that logic meant editing all four places in lockstep.

Moved it into a composite action at `.github/actions/configure-site-url/action.yml`, matching the pattern already used by `setup-build-env`. Each call site is now a single `uses:` line.

Removes 36 lines of duplication. No behavior change, the action exports the same two env vars as before. The `github-token` input defaults to `github.token`, which is the same token the inline block used via `secrets.GITHUB_TOKEN`.

I didn't touch the `Configure Git Credentials` blocks (also duplicated, but the context differs slightly across jobs). Happy to do those in a follow-up if wanted.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A