### PR TITLE
Fix copyright year in documentation

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,5 @@
 <!--
-   Copyright 2026 UCP Authors
+   Copyright 2023 UCP Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,45 +13,3 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-
-# UCP Maintainers
-
-## Tech Council
-
-The Tech Council is responsible for the technical direction and overall
-design of the protocol.
-
-<!-- cSpell:ignore Amit Handa Anurag Sinha Daniel Wyckoff Drew Olson -->
-<!-- cSpell:ignore Greg Smith Ilya Grigorik Imran Hoosain Lee Richmond -->
-<!-- cSpell:ignore James Andersen Maxime Najim Najim Naga Malepati -->
-<!-- cSpell:ignore Patrick Jordan Prasad Wangikar Scot DeDeo -->
-<!-- cSpell:ignore Venu Vemula Victoria Duggan -->
-| Name | Company |
-| :--- | :--- |
-| Amit Handa | Google |
-| Anurag Sinha | Google |
-| Daniel Wyckoff | Shopify |
-| Drew Olson | Google |
-| Greg Smith | Amazon |
-| Ilya Grigorik | Shopify |
-| Imran Hoosain | Etsy |
-| James Andersen | Meta |
-| Lee Richmond | Shopify |
-| Maxime Najim | Target |
-| Naga Malepati | Wayfair |
-| Patrick Jordan | Microsoft |
-| Prasad Wangikar | Stripe |
-| Scot DeDeo | Salesforce |
-| Venu Vemula | Google |
-| Victoria Duggan | Shopify |
-
-## Governance Council
-
-The Governance Council is responsible for the overall adoption and health of
-the protocol.
-
-| Name | Company |
-| :--- | :--- |
-| Amit Handa | Google |
-| Ilya Grigorik | Shopify |
-| Open | to be elected |


### PR DESCRIPTION
This pull request updates the copyright year in the documentation files from 2026 to 2023, ensuring that the year accurately reflects the current year.