### PR TITLE
fix: Harden signing_key to only allowing properties related to public keys

### DIFF
--- a/source/discovery/profile_schema.json
+++ b/source/discovery/profile_schema.json
@@ -51,9 +51,9 @@
         "alg": {
           "type": "string",
           "description": "Algorithm (e.g., 'ES256', 'RS256')."
-        },
-        "additionalProperties": false
-      }
+        }
+      },
+      "additionalProperties": false
     },
 
     "base": {

--- a/source/discovery/profile_schema.json
+++ b/source/discovery/profile_schema.json
@@ -51,7 +51,8 @@
         "alg": {
           "type": "string",
           "description": "Algorithm (e.g., 'ES256', 'RS256')."
-        }
+        },
+        "additionalProperties": false
       }
     },
 


### PR DESCRIPTION
# Description

The `signing_key` schema in discovery profiles defines public key fields (x, y, n, e) but does not set `"additionalProperties": false`, potentially allowing private key fields (e.g. `d`, `p`, `q`) to be published in discovery profiles without warning.

This changes fixes that.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [X] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [X] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation (if applicable).
- [ ] My changes pass all local linting and formatting checks.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A
