### PR TITLE
feat: attribution field for platform referral context

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -110,3 +110,6 @@ keyid
 reauth
 reprepare
 sandboxing
+fbclid
+gclid
+ttclid

--- a/docs/documentation/schema-authoring.md
+++ b/docs/documentation/schema-authoring.md
@@ -367,6 +367,19 @@ typos in core metadata like the `ucp` block).
 }
 ```
 
+### Property-Count Constraints (`minProperties` / `maxProperties`)
+
+By default, UCP schemas do not set `minProperties` or `maxProperties` on
+object fields:
+
+- **`maxProperties`** — Limits are deferred to implementers. The protocol
+  does not define caps because any specific limit requires judgment calls
+  that inevitably run into exceptions. Implementers are encouraged to
+  impose their own constraints and surface clear error feedback to support
+  debugging and good behavior.
+- **`minProperties`** — Empty objects (`{}`) are well-formed and harmless.
+  Implementers should accept and process them as a no-op.
+
 ## Complete Example: Capability Schema
 
 A capability schema defines both payload structure and declaration variants:

--- a/docs/specification/cart.md
+++ b/docs/specification/cart.md
@@ -220,6 +220,15 @@ requirements.
 
 {{ schema_fields('types/signals', 'checkout') }}
 
+### Attribution
+
+Platform-provided referral and conversion-event context — campaign IDs,
+click identifiers, and source/medium markers communicated by the platform.
+See [Attribution](overview.md#attribution) for details and consent
+requirements.
+
+{{ schema_fields('types/attribution', 'checkout') }}
+
 ### Total
 
 The same totals contract applies to cart and checkout. See

--- a/docs/specification/catalog/index.md
+++ b/docs/specification/catalog/index.md
@@ -89,6 +89,15 @@ and abuse prevention. Signal values MUST NOT be buyer-asserted claims. See
 
 {{ schema_fields('types/signals', 'catalog') }}
 
+### Attribution
+
+Platform-provided referral and conversion-event context — campaign IDs,
+click identifiers, and source/medium markers communicated by the platform.
+See [Attribution](../overview.md#attribution) for details and consent
+requirements.
+
+{{ schema_fields('types/attribution', 'catalog') }}
+
 ### Product
 
 A catalog item representing a sellable item with one or more purchasable variants.

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -642,6 +642,15 @@ requirements.
 
 {{ schema_fields('types/signals', 'checkout') }}
 
+### Attribution
+
+Platform-provided referral and conversion-event context — campaign IDs,
+click identifiers, and source/medium markers communicated by the platform.
+See [Attribution](overview.md#attribution) for details and consent
+requirements.
+
+{{ schema_fields('types/attribution', 'checkout') }}
+
 ### Fulfillment Option
 
 {{ extension_schema_fields('fulfillment.json#/$defs/fulfillment_option', 'checkout') }}

--- a/docs/specification/order.md
+++ b/docs/specification/order.md
@@ -87,6 +87,13 @@ Expectations can be split, merged, or adjusted post-order. For example:
   (common examples: `processing`, `shipped`, `in_transit`, `delivered`,
   `failed_attempt`, `canceled`, `undeliverable`, `returned_to_sender`)
 
+### Attribution
+
+Businesses MAY surface a snapshot of the originating checkout's
+`attribution` on the order. Read-only on the order — agents do not write
+`order.attribution`. See [Attribution](overview.md#attribution) for the
+underlying contract.
+
 ### Adjustments
 
 **Adjustments** are post-order events that exist independently of

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -1722,6 +1722,48 @@ signal is provided; an `info` is advisory and non-blocking.
 }
 ```
 
+### Attribution
+
+Platforms refer users to businesses through many channels — paid ads,
+organic recommendations, influencer links, AI agents. In a browser-based
+flow, the referral context (campaigns, click identifiers, source/medium
+markers) flows through URL query parameters. The `attribution` field
+enables platforms to communicate the same parameters to businesses.
+
+UCP does **NOT** prescribe attribution models, windows, or assignment
+logic. Platforms use their existing conventions (GA4 campaign parameters,
+click identifiers like `gclid` / `fbclid` / `ttclid`, etc.); businesses
+receive and process them according to their own analytics needs.
+
+```json
+{
+  "attribution": {
+    "campaign_id": "18234567890",
+    "campaign_source": "google",
+    "campaign_medium": "cpc",
+    "campaign_name": "spring_2026",
+    "gclid": "EAIaIQobChMI..."
+  }
+}
+```
+
+Attribution is informational and optionally provided by the platform.
+Businesses do not negotiate or advertise support; the field's presence or
+absence MUST NOT affect the response or negotiation.
+
+The data can carry pseudonymous identifiers (click IDs, session keys)
+treated as personal data under applicable data protection laws. Platforms
+and businesses are each responsible for compliance in their respective
+jurisdictions: platforms determine what to emit and disclose; businesses
+apply their own data handling, retention, and consent policies. The
+`buyer_consent` extension provides a structured channel for buyers to
+communicate consent state. Direct identifiers (email, phone,
+name, postal address) belong on `buyer`, not `attribution`.
+
+Attribution appears on cart, checkout, and catalog requests as
+platform-provided attribution context; on order it appears as a
+business-emitted snapshot of the originating checkout's attribution.
+
 ### Transaction Integrity and Non-Repudiation
 
 For scenarios requiring cryptographic proof of authorization (e.g., autonomous

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -1757,8 +1757,7 @@ and businesses are each responsible for compliance in their respective
 jurisdictions: platforms determine what to emit and disclose; businesses
 apply their own data handling, retention, and consent policies. The
 `buyer_consent` extension provides a structured channel for buyers to
-communicate consent state. Direct identifiers (email, phone,
-name, postal address) belong on `buyer`, not `attribution`.
+communicate consent state.
 
 Attribution appears on cart, checkout, and catalog requests as
 platform-provided attribution context; on order it appears as a

--- a/source/schemas/shopping/cart.json
+++ b/source/schemas/shopping/cart.json
@@ -76,6 +76,13 @@
         "update": "optional"
       }
     },
+    "attribution": {
+      "$ref": "types/attribution.json",
+      "ucp_request": {
+        "create": "optional",
+        "update": "optional"
+      }
+    },
     "buyer": {
       "$ref": "types/buyer.json",
       "description": "Optional buyer information for personalized estimates.",

--- a/source/schemas/shopping/catalog_lookup.json
+++ b/source/schemas/shopping/catalog_lookup.json
@@ -43,6 +43,9 @@
         },
         "signals": {
           "$ref": "types/signals.json"
+        },
+        "attribution": {
+          "$ref": "types/attribution.json"
         }
       }
     },
@@ -113,6 +116,9 @@
         },
         "signals": {
           "$ref": "types/signals.json"
+        },
+        "attribution": {
+          "$ref": "types/attribution.json"
         }
       }
     },

--- a/source/schemas/shopping/catalog_search.json
+++ b/source/schemas/shopping/catalog_search.json
@@ -19,6 +19,9 @@
         "signals": {
           "$ref": "types/signals.json"
         },
+        "attribution": {
+          "$ref": "types/attribution.json"
+        },
         "filters": {
           "$ref": "types/search_filters.json"
         },

--- a/source/schemas/shopping/checkout.json
+++ b/source/schemas/shopping/checkout.json
@@ -58,6 +58,10 @@
       "$ref": "types/signals.json",
       "ucp_request": "optional"
     },
+    "attribution": {
+      "$ref": "types/attribution.json",
+      "ucp_request": "optional"
+    },
     "status": {
       "type": "string",
       "enum": [

--- a/source/schemas/shopping/order.json
+++ b/source/schemas/shopping/order.json
@@ -102,6 +102,11 @@
         "$ref": "types/message.json"
       },
       "description": "Business outcome messages (errors, warnings, informational). Present when the business needs to communicate status or issues to the platform."
+    },
+    "attribution": {
+      "$ref": "types/attribution.json",
+      "description": "Snapshot of the attribution associated with the originating checkout. Read-only on the order.",
+      "ucp_request": "omit"
     }
   }
 }

--- a/source/schemas/shopping/types/attribution.json
+++ b/source/schemas/shopping/types/attribution.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/types/attribution.json",
+  "title": "Attribution",
+  "description": "Platform-emitted referral and conversion-event context — campaign identifiers, click IDs, source/medium markers, etc. The same parameters platforms communicate via URL query parameters in browser-based flows.",
+  "type": "object",
+  "additionalProperties": {
+    "type": "string",
+    "description": "URL-style parameter value, encoded as a string. Numeric or boolean values MUST be string-encoded as they would be in a URL query string."
+  }
+}


### PR DESCRIPTION
Alternative proposal to [#295](https://github.com/Universal-Commerce-Protocol/ucp/pull/295). cc @jamesandersen 

Adds a top-level `attribution` field to UCP carrying platform-emitted referral and conversion-event context. It carries the same parameters platforms communicate via URL query parameters in browser-based flows, in the same flat key-value form.

```json
{
  "attribution": {
    "campaign_id": "18234567890",
    "campaign_source": "google",
    "campaign_medium": "cpc",
    "campaign_name": "spring_2026",
    "gclid": "EAIaIQobChMI..."
  }
}
```

Available on `cart`, `checkout`, and catalog requests as platform-provided input. Appears on `order` as a business-emitted snapshot of the originating checkout's attribution.

## Design decisions

- **Core field, not extension or capability.** Attribution is informational; its presence or absence does not affect protocol behavior. Capability negotiation earns nothing: there's no merchant decision to gate. The field lives in core schema alongside `signals` and `context` (the three platform/buyer-asserted session-metadata fields).
- **Open string-keyed map.** UCP does NOT prescribe attribution models, windows, or assignment logic. Platforms use their existing conventions (GA4 campaign parameters, click identifiers like `gclid` / `fbclid` / `ttclid`); businesses receive and process per their own analytics needs. No UCP-imposed vocabulary, existing event/analytics pipelines work transparently by piping contents of attribution into their existing event processing logic; attribution is equivalent to URL-parsed fields on browser-based flow.
- **Separate from `signals`.** `signals` carries authorization and abuse-prevention data with a specific trust posture. `attribution` carries marketing/referral context with different consent and routing expectations. Distinct fields keep these tiers clean and let each evolve independently.
- **Spans the journey.** Lives on every operation where referral context might matter — catalog discovery, cart assembly, checkout, and order — rather than scoped to a single capability.


---
## Checklist

- [x] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors.
- [x] **Capability**: New schemas (Discovery, Cart, etc.) or extensions.
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. 
- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] (For Core/Capability) I have included/updated the relevant JSON schemas.