### PR TITLE
docs: add message.path field conventions to Error Handling

### DIFF
--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -119,8 +119,10 @@ platform receives messages indicating what's needed to progress.
 The `messages` array contains errors, warnings, and informational messages
 about the checkout state. `ucp.status` is the shape discriminator —
 `"success"` means the response carries the expected payload, `"error"`
-means it carries error information instead. The `severity` field on each
-error message prescribes the recommended action:
+means it carries error information instead. Each message carries a `type`,
+`code`, `severity`, `content`, and an optional `path` that identifies the
+specific field or line item the message refers to (see [The `path` Field](#the-path-field) below).
+The `severity` field prescribes the recommended platform action:
 
 | Severity                | Meaning                                          | Platform Action                                                   |
 | :---------------------- | :----------------------------------------------- | :---------------------------------------------------------------- |
@@ -182,6 +184,7 @@ Businesses **SHOULD** surface such messages as early as possible, and platforms
       "type": "error",
       "code": "invalid_phone",
       "severity": "recoverable",
+      "path": "$.buyer.phone_number",
       "content": "Phone number format is invalid"
     },
     {
@@ -219,7 +222,11 @@ IF unrecoverable is not empty
 
 IF recoverable is not empty
   FOR EACH error IN recoverable
-    ATTEMPT to fix error (e.g., reformat phone number)
+    IF error.path is present
+      IDENTIFY the field at error.path in the request payload
+      ATTEMPT to fix that field (e.g., reformat phone at $.buyer.phone_number)
+    ELSE
+      ATTEMPT generic fix based on error.code
   CALL Update Checkout
   RETURN and re-evaluate response
 
@@ -249,6 +256,54 @@ messages or deferring to checkout completion.
 
 Example: `out_of_stock` requires specific upfront UX, whereas
 `payment_required` can be handled generically at submission.
+
+#### The `path` Field
+
+The optional `path` field on a message anchors the error to a specific
+component of the response payload. Platforms use it to associate error
+messages with the input field or line item that caused them - for example,
+highlighting a specific buyer field in a form or flagging a specific
+cart line.
+
+`path` **MUST** be an [RFC 9535](https://www.rfc-editor.org/rfc/rfc9535)
+JSONPath expression relative to the root of the UCP response object.
+Property names **MUST** use snake_case matching the request schema.
+When `path` is omitted, the message applies to the response as a whole.
+
+**Simple field reference:**
+
+```json
+{ "path": "$.buyer.email" }
+```
+
+**Indexed array element:**
+
+```json
+{ "path": "$.line_items[0].quantity" }
+```
+
+**Filter expression (optional, when referencing a specific item by ID):**
+
+```json
+{ "path": "$.line_items[?(@.id=='line-item-uuid')].quantity" }
+```
+
+Filter expressions are valid RFC 9535 syntax and **MAY** be used when
+referencing a specific line item by `id` is clearer than its index.
+Index-based paths are equally valid; the business returns indices that
+are unambiguous within the response.
+
+**Specificity rule:** A path to a specific field (e.g.,
+`$.line_items[0].quantity`) takes precedence over a path to its parent
+(e.g., `$.line_items[0]`). When multiple errors apply to the same field,
+each message **SHOULD** carry the most specific path applicable.
+
+**Create vs. Update keying:** On `create_checkout`, line item filter
+expressions key on `item.id` (the catalog item identifier). On
+`update_checkout`, they key on the line item's own `id` (the
+session-scoped line item identifier assigned in the create response).
+
+When `path` is omitted, the message applies to the response as a whole.
 
 #### Eligibility Verification at Completion
 

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -119,7 +119,7 @@ platform receives messages indicating what's needed to progress.
 The `messages` array contains errors, warnings, and informational messages
 about the checkout state. `ucp.status` is the shape discriminator —
 `"success"` means the response carries the expected payload, `"error"`
-means it carries error information instead. Each message carries a `type`,
+means it carries error information instead. Each error message carries a `type`,
 `code`, `severity`, `content`, and an optional `path` that identifies the
 specific field or line item the message refers to (see [The `path` Field](#the-path-field) below).
 The `severity` field prescribes the recommended platform action:
@@ -296,13 +296,6 @@ are unambiguous within the response.
 `$.line_items[0].quantity`) takes precedence over a path to its parent
 (e.g., `$.line_items[0]`). When multiple errors apply to the same field,
 each message **SHOULD** carry the most specific path applicable.
-
-**Create vs. Update keying:** On `create_checkout`, line item filter
-expressions key on `item.id` (the catalog item identifier). On
-`update_checkout`, they key on the line item's own `id` (the
-session-scoped line item identifier assigned in the create response).
-
-When `path` is omitted, the message applies to the response as a whole.
 
 #### Eligibility Verification at Completion
 

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -271,18 +271,21 @@ When `path` is omitted, the message applies to the response as a whole.
 
 **Simple field reference:**
 
+<!-- ucp:example skip reason="path schema example" -->
 ```json
 { "path": "$.buyer.email" }
 ```
 
 **Indexed array element:**
 
+<!-- ucp:example skip reason="path schema example" -->
 ```json
 { "path": "$.line_items[0].quantity" }
 ```
 
 **Filter expression (optional, when referencing a specific item by ID):**
 
+<!-- ucp:example skip reason="path schema example" -->
 ```json
 { "path": "$.line_items[?(@.id=='line-item-uuid')].quantity" }
 ```

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -119,8 +119,10 @@ platform receives messages indicating what's needed to progress.
 The `messages` array contains errors, warnings, and informational messages
 about the checkout state. `ucp.status` is the shape discriminator —
 `"success"` means the response carries the expected payload, `"error"`
-means it carries error information instead. The `severity` field on each
-error message prescribes the recommended action:
+means it carries error information instead. Each message carries a `type`,
+`code`, `severity`, `content`, and an optional `path` that identifies the
+specific field or line item the message refers to (see [The `path` Field](#the-path-field) below).
+The `severity` field prescribes the recommended platform action:
 
 | Severity                | Meaning                                          | Platform Action                                                   |
 | :---------------------- | :----------------------------------------------- | :---------------------------------------------------------------- |
@@ -182,6 +184,7 @@ Businesses **SHOULD** surface such messages as early as possible, and platforms
     "type": "error",
     "code": "invalid_phone",
     "severity": "recoverable",
+    "path": "$.buyer.phone_number",
     "content": "Phone number format is invalid"
   },
   {
@@ -218,7 +221,11 @@ IF unrecoverable is not empty
 
 IF recoverable is not empty
   FOR EACH error IN recoverable
-    ATTEMPT to fix error (e.g., reformat phone number)
+    IF error.path is present
+      IDENTIFY the field at error.path in the request payload
+      ATTEMPT to fix that field (e.g., reformat phone at $.buyer.phone_number)
+    ELSE
+      ATTEMPT generic fix based on error.code
   CALL Update Checkout
   RETURN and re-evaluate response
 
@@ -248,6 +255,54 @@ messages or deferring to checkout completion.
 
 Example: `out_of_stock` requires specific upfront UX, whereas
 `payment_required` can be handled generically at submission.
+
+#### The `path` Field
+
+The optional `path` field on a message anchors the error to a specific
+component of the response payload. Platforms use it to associate error
+messages with the input field or line item that caused them - for example,
+highlighting a specific buyer field in a form or flagging a specific
+cart line.
+
+`path` **MUST** be an [RFC 9535](https://www.rfc-editor.org/rfc/rfc9535)
+JSONPath expression relative to the root of the UCP response object.
+Property names **MUST** use snake_case matching the request schema.
+When `path` is omitted, the message applies to the response as a whole.
+
+**Simple field reference:**
+
+```json
+{ "path": "$.buyer.email" }
+```
+
+**Indexed array element:**
+
+```json
+{ "path": "$.line_items[0].quantity" }
+```
+
+**Filter expression (optional, when referencing a specific item by ID):**
+
+```json
+{ "path": "$.line_items[?(@.id=='line-item-uuid')].quantity" }
+```
+
+Filter expressions are valid RFC 9535 syntax and **MAY** be used when
+referencing a specific line item by `id` is clearer than its index.
+Index-based paths are equally valid; the business returns indices that
+are unambiguous within the response.
+
+**Specificity rule:** A path to a specific field (e.g.,
+`$.line_items[0].quantity`) takes precedence over a path to its parent
+(e.g., `$.line_items[0]`). When multiple errors apply to the same field,
+each message **SHOULD** carry the most specific path applicable.
+
+**Create vs. Update keying:** On `create_checkout`, line item filter
+expressions key on `item.id` (the catalog item identifier). On
+`update_checkout`, they key on the line item's own `id` (the
+session-scoped line item identifier assigned in the create response).
+
+When `path` is omitted, the message applies to the response as a whole.
 
 #### Eligibility Verification at Completion
 


### PR DESCRIPTION
The `path` field on error/warning/info messages is used in examples
throughout the spec but has no prose explaining how to construct it.

Changes to `checkout.md`:

- Introduces `path` in the Error Handling opening paragraph so readers
  know it exists before hitting the severity table, with an anchor link
  to the new subsection.
- Adds `#### The path Field` subsection covering RFC 9535 JSONPath,
  snake_case convention, filter expressions, specificity rule, and
  create-vs-update keying differences.
- Adds `path` to the `invalid_phone` entry in the error processing
  example (`$.buyer.contact.phone`).
- Updates the error processing algorithm to show how to use `path` to
  identify the specific field to fix, with fallback to `error.code`
  when `path` is absent.

Complements #380 (which fixes the schema descriptions on the
message_* types) with implementation guidance in the spec prose.