### PR TITLE
feat: add return_url for post-handoff buyer return

### DIFF
--- a/docs/specification/checkout-mcp.md
+++ b/docs/specification/checkout-mcp.md
@@ -181,6 +181,7 @@ Maps to the [Create Checkout](checkout.md#create-checkout) operation.
               }
             ],
             "currency": "USD",
+            "return_url": "https://platform.example.com/checkout/return",
             "fulfillment": {
               "methods": [
                 {
@@ -587,6 +588,24 @@ Maps to the [Update Checkout](checkout.md#update-checkout) operation.
       }
     }
     ```
+
+#### Handoff and Return Flow
+
+When a business responds with `continue_url`, the platform directs the buyer to
+that URL to complete the hosted checkout UI. If the platform provided a
+`return_url` in the `create_checkout` request, the business **SHOULD** redirect
+the buyer back to the platform when the hosted UI exits:
+
+```text
+# Buyer completes hosted checkout
+GET https://platform.example.com/checkout/return?status=completed
+
+# Buyer cancels or checkout cannot complete
+GET https://platform.example.com/checkout/return?status=canceled
+```
+
+Platforms **SHOULD** verify the actual checkout session state via `get_checkout`
+after receiving the buyer back — `status` is a routing hint only.
 
 ### `complete_checkout`
 

--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -70,7 +70,8 @@ All REST endpoints **MUST** be served over HTTPS with minimum TLS version
           },
           "quantity": 2
         }
-      ]
+      ],
+      "return_url": "https://platform.example.com/checkout/return"
     }
     ```
 
@@ -187,6 +188,25 @@ All REST endpoints **MUST** be served over HTTPS with minimum TLS version
       "continue_url": "https://merchant.com/"
     }
     ```
+
+#### Handoff and Return Flow
+
+When a business responds with `continue_url`, the platform directs the buyer to
+that URL to complete the hosted checkout UI. If the platform provided a
+`return_url` in the request, the business **SHOULD** redirect the buyer back
+when the hosted UI exits:
+
+```text
+# Buyer completes hosted checkout
+GET https://platform.example.com/checkout/return?status=completed
+
+# Buyer cancels or checkout cannot complete
+GET https://platform.example.com/checkout/return?status=canceled
+```
+
+Platforms **SHOULD** verify actual checkout session state via `GET
+/checkout-sessions/{id}` after receiving the buyer back — `status` is a routing
+hint only.
 
 ### Update Checkout
 

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -493,6 +493,59 @@ platform can prefill checkout state when initiating a buy-now flow.
 > [REST transport binding](checkout-rest.md). Accessing a permalink returns a
 > redirect to the checkout UI or renders the checkout page directly.
 
+## Return URL
+
+The `return_url` field is the counterpart to `continue_url`. Where `continue_url`
+is provided by the business to hand off the buyer to a hosted UI, `return_url` is
+provided by the platform to receive the buyer back after the hosted experience ends.
+
+This mechanism applies to both checkout session handoff and payment handler redirect
+flows (e.g. hosted payment pages, bank redirects).
+
+### Availability
+
+Platforms **MAY** provide `return_url` in `create_checkout` or `update_checkout`
+requests. Businesses and payment handlers **SHOULD** redirect the buyer to
+`return_url` when the hosted UI exits for any reason.
+
+### Status Hint
+
+The redirecting party **MUST** append a `status` query parameter to `return_url`
+when redirecting:
+
+| `status` | Meaning |
+|---|---|
+| `completed` | The hosted flow completed successfully |
+| `canceled` | The hosted flow did not complete — covers buyer cancellation, unresolvable escalation, timeout, or any other non-completion exit |
+
+Example redirect:
+
+```text
+https://platform.example.com/return?status=completed
+https://platform.example.com/return?status=canceled
+```
+
+> **Note:** Platforms **SHOULD** treat `status` as a routing hint only.
+> Actual session state **MUST** be verified by fetching the checkout or payment
+> handler session — `status` is not authoritative.
+
+### Format
+
+The `return_url` **MUST** be an absolute HTTPS URL. If the URL already contains
+query parameters, the redirecting party **MUST** append `status` as an
+additional parameter.
+
+### Security
+
+Redirecting to a caller-supplied URL is an open redirect risk. Businesses and
+payment handlers **SHOULD** validate `return_url` against known URLs or origins
+for the platform before redirecting a buyer to it.
+
+> **Note:** The authenticated API relationship between platform and business
+> provides accountability, but businesses should be aware that blindly
+> redirecting buyers to any caller-supplied URL may expose them to open redirect
+> attacks.
+
 ## Guidelines
 
 (In addition to the overarching guidelines)

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -725,6 +725,21 @@ Businesses **SHOULD** provide the most contextually relevant URL:
 This enables graceful degradation—agents can redirect buyers to complete their
 task through the standard web interface.
 
+##### The `return_url` Field
+
+`return_url` is the counterpart to `continue_url`. Where `continue_url` is
+provided by the business to hand the buyer off to a hosted UI, `return_url` is
+provided by the platform in the checkout session request to receive the buyer
+back after the hosted experience ends.
+
+When redirecting back to `return_url`, the redirecting party **MUST** append a
+`status` query parameter with value `completed` or `canceled` as a routing hint.
+Platforms **SHOULD** verify actual session state independently rather than
+relying solely on this hint.
+
+See the [Checkout specification](checkout.md#return-url) for the full
+`return_url` specification, including status values and security considerations.
+
 ##### Transport Bindings
 
 === "REST"

--- a/source/schemas/shopping/checkout.json
+++ b/source/schemas/shopping/checkout.json
@@ -109,6 +109,16 @@
       "description": "URL for checkout handoff and session recovery. MUST be provided when status is requires_escalation. See specification for format and availability requirements.",
       "ucp_request": "omit"
     },
+    "return_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Platform-provided URL for buyer return after hosted checkout handoff. See specification for status hint and security requirements.",
+      "ucp_request": {
+        "create": "optional",
+        "update": "optional",
+        "complete": "omit"
+      }
+    },
     "payment": {
       "$ref": "payment.json",
       "ucp_request": {


### PR DESCRIPTION
Ref #486 

## Summary

- Adds `return_url` as an optional request field (`create`/`update`) on checkout sessions
- Provides a platform-specified destination for the buyer after completing or exiting a hosted checkout UI reached via `continue_url`
- The redirecting party appends `?status=completed` or `?status=canceled` as a routing hint; platforms should verify actual session state independently via the checkout session API
- Includes open redirect security guidance recommending businesses validate `return_url` against known platform origins before redirecting

## Motivation

`continue_url` handles the outbound handoff — business sends buyer to hosted UI. `return_url` closes the loop — business sends buyer back to the platform after the hosted experience ends. Without it, there is no standard mechanism for a platform to receive the buyer back after a hosted checkout or payment handler redirect.

## Category

- [x] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [x] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] (For Core/Capability) I have included/updated the relevant JSON schemas.