### PR TITLE
feat: add optional specs array to product and variant

### DIFF
--- a/docs/specification/catalog/index.md
+++ b/docs/specification/catalog/index.md
@@ -113,6 +113,64 @@ as the first element. Platforms SHOULD treat the first element as featured.
 
 {{ schema_fields('types/variant', 'catalog') }}
 
+### Specs
+
+`specs` is an optional structured array on `Product` and `Variant` for
+measurable attributes — battery life, display size, weight, storage
+capacity. Each entry is a small object with a required `label` and `value`
+plus optional `unit`, `numeric_value`, and `key`.
+
+Specs are for measurable facts that an agent might want to compare across
+products. Use `tags` for categorical labels and `metadata` for
+business-specific data that doesn't fit elsewhere.
+
+Place specs that are constant across all variants on the product (e.g.,
+display size, screen resolution). Place specs that vary by variant (e.g.,
+storage capacity, weight by size) on the variant. Clients read whichever
+level is populated.
+
+`numeric_value` is the machine-comparable form of `value`. Populate it
+when the attribute is a single measurement so agents can filter without
+parsing display strings. Omit it for ranges (`"20-22"`) or non-numeric
+values; clients fall back to parsing `value`.
+
+```json
+{
+  "id": "prod_aurora_phone",
+  "title": "Aurora Phone",
+  "description": { "plain": "Flagship phone with all-day battery and a 6.1-inch display." },
+  "price_range": {
+    "min": { "amount": 79900, "currency": "USD" },
+    "max": { "amount": 89900, "currency": "USD" }
+  },
+  "specs": [
+    { "key": "display_size", "label": "Display", "value": "6.1", "numeric_value": 6.1, "unit": "inches" },
+    { "key": "battery_video_playback", "label": "Battery video playback", "value": "22", "numeric_value": 22, "unit": "hours" },
+    { "key": "weight", "label": "Weight", "value": "1.2", "numeric_value": 1.2, "unit": "kg" }
+  ],
+  "variants": [
+    {
+      "id": "var_aurora_128",
+      "title": "128 GB",
+      "description": { "plain": "Aurora Phone, 128 GB storage." },
+      "price": { "amount": 79900, "currency": "USD" },
+      "specs": [
+        { "key": "storage", "label": "Storage", "value": "128", "numeric_value": 128, "unit": "GB" }
+      ]
+    },
+    {
+      "id": "var_aurora_256",
+      "title": "256 GB",
+      "description": { "plain": "Aurora Phone, 256 GB storage." },
+      "price": { "amount": 89900, "currency": "USD" },
+      "specs": [
+        { "key": "storage", "label": "Storage", "value": "256", "numeric_value": 256, "unit": "GB" }
+      ]
+    }
+  ]
+}
+```
+
 ### Price
 
 {{ schema_fields('types/price', 'catalog') }}

--- a/source/schemas/shopping/types/product.json
+++ b/source/schemas/shopping/types/product.json
@@ -81,6 +81,36 @@
       },
       "description": "Product tags for categorization and search."
     },
+    "specs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["label", "value"],
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Optional stable machine-readable identifier (e.g., `battery_life_hours`, `display_size_inches`, `weight_kg`). Open vocabulary; clients MUST tolerate unknown keys."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable attribute name (e.g., `Battery life`, `Display`, `Weight`)."
+          },
+          "value": {
+            "type": "string",
+            "description": "Display value. MAY be a number (`22`), a range (`20-22`), or domain notation (`5x114.3`). For agent-comparable single values, populate `numeric_value` as well."
+          },
+          "numeric_value": {
+            "type": "number",
+            "description": "Optional machine-comparable numeric form of `value`. Populate when the attribute is a single measurement. Omit for ranges or non-numeric values; clients fall back to parsing `value`."
+          },
+          "unit": {
+            "type": "string",
+            "description": "Unit of measurement. Open vocabulary; clients MUST tolerate unknown values. Well-known values: `hours`, `inches`, `mm`, `cm`, `kg`, `g`, `lb`, `ml`, `l`, `W`, `mAh`, `GB`, `MP`."
+          }
+        }
+      },
+      "description": "Structured product attributes — measurable facts beyond title and description (e.g., battery life, display size). Place specs that are constant across variants here; specs that vary by variant belong on the variant."
+    },
     "metadata": {
       "type": "object",
       "description": "Business-defined custom data extending the standard product model."

--- a/source/schemas/shopping/types/variant.json
+++ b/source/schemas/shopping/types/variant.json
@@ -142,6 +142,36 @@
       },
       "description": "Variant tags for categorization and search."
     },
+    "specs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["label", "value"],
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Optional stable machine-readable identifier (e.g., `storage_gb`, `weight_kg`). Open vocabulary; clients MUST tolerate unknown keys."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable attribute name (e.g., `Storage`, `Weight`)."
+          },
+          "value": {
+            "type": "string",
+            "description": "Display value. MAY be a number (`512`), a range (`20-22`), or domain notation (`5x114.3`). For agent-comparable single values, populate `numeric_value` as well."
+          },
+          "numeric_value": {
+            "type": "number",
+            "description": "Optional machine-comparable numeric form of `value`. Populate when the attribute is a single measurement. Omit for ranges or non-numeric values; clients fall back to parsing `value`."
+          },
+          "unit": {
+            "type": "string",
+            "description": "Unit of measurement. Open vocabulary; clients MUST tolerate unknown values. Well-known values: `hours`, `inches`, `mm`, `cm`, `kg`, `g`, `lb`, `ml`, `l`, `W`, `mAh`, `GB`, `MP`."
+          }
+        }
+      },
+      "description": "Structured variant attributes — measurable facts that vary by variant (e.g., storage capacity, weight by size). Specs constant across variants belong on the product."
+    },
     "metadata": {
       "type": "object",
       "description": "Business-defined custom data extending the standard variant model."


### PR DESCRIPTION
# Description

Adds an optional `specs` array to `Product` and `Variant` for measurable attributes (battery life, display size, weight, storage). Each entry has a `label`, a `value`, and optional `unit`, `numeric_value`, and `key`. Inline shape, modeled on the existing `Variant.barcodes`. No new schema files, capabilities, transports, or query parameters. Additive: existing clients ignore unknown fields and existing merchants don't need to publish anything.

## Why

A buyer asks an agent: "phone with at least 20 hours of battery, under $800."

The answer is usually in the catalog response, but it's buried in prose ("all-day battery", "lightweight at 1.2 kg"). Tags can't carry units cleanly — `22h-battery` is awkward and not comparable. Metadata works, but every merchant picks their own shape, so agents can't read it portably.

`specs` gives merchants a shared place to put measurable facts. `tags`, `description`, and `metadata` keep working the way they do today.

## Shape

```json
"specs": [
  { "key": "battery_video_playback", "label": "Battery video playback", "value": "22", "numeric_value": 22, "unit": "hours" },
  { "key": "display_size", "label": "Display", "value": "6.1", "numeric_value": 6.1, "unit": "inches" }
]
```

Required: `label`, `value`. Optional: `key`, `numeric_value`, `unit`.

**`value` is a string. `numeric_value` is separate.** Strings let one field carry exact values, ranges (`"20-22"`), and domain notation (`"5x114.3"`). `numeric_value` is the comparable form for single measurements, so agents can filter without re-parsing display strings. A multi-type `value` would have worked, but the Schema Authoring guide flags multi-types as awkward for codegen.

**`key` is open vocabulary**, like `unit`. A closed enum of attribute keys would be incomplete on day one or never stop growing. v1 cross-merchant filtering should lean on `numeric_value` + `unit` rather than `key`. Common keys can be documented in the catalog spec as conventions settle.

**Product vs variant.** Constant across variants (display size, chipset) → product. Varies (storage, weight by size) → variant. Clients read whichever level is populated.

The catalog spec doc gains a `Specs` section with placement guidance and a worked example.

## Category (Required)

- [x] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)

## Related Issues

N/A.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

  Python SDK lives in a separate repo (`python_sdk`); a follow-up PR there will regenerate models against the merged schema.

## Screenshots / Logs (if applicable)

N/A - simply schema and doc change.
