### PR TITLE
feat(schema): add buyer_notes field to line items

### DIFF
--- a/source/schemas/shopping/types/line_item.json
+++ b/source/schemas/shopping/types/line_item.json
@@ -41,6 +41,15 @@
         "create": "omit",
         "update": "optional"
       }
+    },
+    "buyer_notes": {
+      "type": "string",
+      "maxLength": 500,
+      "description": "Free-text buyer instructions for this line item (e.g., customization requests, gift messages, dietary notes). Business MAY act on, echo back, or ignore.",
+      "ucp_request": {
+        "create": "optional",
+        "update": "optional"
+      }
     }
   }
 }

--- a/source/schemas/shopping/types/order_line_item.json
+++ b/source/schemas/shopping/types/order_line_item.json
@@ -61,6 +61,11 @@
     "parent_id": {
       "type": "string",
       "description": "Parent line item identifier for any nested structures."
+    },
+    "buyer_notes": {
+      "type": "string",
+      "maxLength": 500,
+      "description": "Buyer instructions for this line item, preserved from checkout. Business SHOULD surface these in fulfillment workflows."
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds an optional `buyer_notes` string field to both `line_item` and `order_line_item` schemas, enabling per-item buyer instructions.

Closes #349

## Motivation

Line items currently have no field for buyer-specific instructions. This is a gap for common commerce scenarios:

- **Food ordering**: "no onions", "extra sauce on the side"
- **Gift purchases**: "gift wrap, include card: Happy Birthday!"
- **Custom products**: "engrave: J.D. 2026"
- **Delivery instructions**: "leave at back door" (per-item, not per-order)

Voice and chat agents especially need this — they naturally collect customization preferences during conversation, but have no structured field to pass them through.

## Changes

### `source/schemas/shopping/types/line_item.json`
- Added `buyer_notes` (string, maxLength 500)
- `ucp_request`: optional on `create` and `update`
- Business MAY act on, echo back, or ignore

### `source/schemas/shopping/types/order_line_item.json`
- Added `buyer_notes` (string, maxLength 500, read-only)
- Preserved from checkout into the order record
- Business SHOULD surface in fulfillment workflows

## Design decisions

| Decision | Rationale |
|----------|-----------|
| Single `string` vs structured object | Keeps it simple. Structured customization (modifiers, add-ons) belongs in the catalog/item model, not in free-text notes. |
| `maxLength: 500` | Enough for meaningful instructions, prevents abuse. Businesses MAY enforce shorter limits. |
| Optional, not required | Zero breaking changes. Businesses that do not support buyer notes simply ignore the field. |
| On `line_item` (not `checkout`) | Notes are per-item, not per-order. A buyer might want different instructions for different items. |
| Preserved on `order_line_item` | Fulfillment teams need to see buyer instructions. Dropping them at order creation would defeat the purpose. |

## Example

```json
{
  "line_items": [
    {
      "item": { "id": "variant_latte_lg", "title": "Large Oat Latte" },
      "quantity": 1,
      "buyer_notes": "Extra hot, oat milk, no foam"
    },
    {
      "item": { "id": "variant_croissant", "title": "Butter Croissant" },
      "quantity": 2,
      "buyer_notes": "Warm please"
    }
  ]
}
```

## Backward compatibility

Fully backward-compatible. The field is optional on all operations. Existing implementations that do not send or handle `buyer_notes` are unaffected.