### PR TITLE
feat(schema): add inventory signals to variant availability

### DIFF
--- a/source/schemas/shopping/types/availability.json
+++ b/source/schemas/shopping/types/availability.json
@@ -12,6 +12,52 @@
     "status": {
       "type": "string",
       "description": "Qualifies available with fulfillment state. Well-known values: `in_stock`, `backorder`, `preorder`, `out_of_stock`, `discontinued`."
+    },
+    "quantity": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Current stock quantity. Business MAY omit if inventory tracking is not supported or if exact counts are confidential."
+    },
+    "low_stock_threshold": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Business-defined threshold below which the variant is considered low stock. When quantity is at or below this value, platforms SHOULD surface low-stock messaging to the buyer."
+    },
+    "restock_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Estimated restock date (RFC 3339). Business SHOULD provide when status is `out_of_stock` or `backorder` and a restock date is known."
+    },
+    "locations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "available"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Location identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable location name (e.g., 'Downtown Store', 'Online')."
+          },
+          "available": {
+            "type": "boolean",
+            "description": "Whether the variant is available at this location."
+          },
+          "quantity": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Stock quantity at this location."
+          },
+          "status": {
+            "type": "string",
+            "description": "Location-level availability status. Same well-known values as variant-level status."
+          }
+        }
+      },
+      "description": "Per-location availability for multi-location businesses. Enables agents to guide buyers to locations where the item is in stock."
     }
   }
 }

--- a/source/schemas/shopping/types/variant.json
+++ b/source/schemas/shopping/types/variant.json
@@ -114,6 +114,52 @@
         "status": {
           "type": "string",
           "description": "Qualifies available with fulfillment state. Well-known values: `in_stock`, `backorder`, `preorder`, `out_of_stock`, `discontinued`."
+        },
+        "quantity": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Current stock quantity. Business MAY omit if inventory tracking is not supported or if exact counts are confidential."
+        },
+        "low_stock_threshold": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Business-defined threshold below which the variant is considered low stock. When quantity is at or below this value, platforms SHOULD surface low-stock messaging to the buyer."
+        },
+        "restock_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Estimated restock date (RFC 3339). Business SHOULD provide when status is `out_of_stock` or `backorder` and a restock date is known."
+        },
+        "locations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "available"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Location identifier."
+              },
+              "name": {
+                "type": "string",
+                "description": "Human-readable location name (e.g., 'Downtown Store', 'Online')."
+              },
+              "available": {
+                "type": "boolean",
+                "description": "Whether the variant is available at this location."
+              },
+              "quantity": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Stock quantity at this location."
+              },
+              "status": {
+                "type": "string",
+                "description": "Location-level availability status. Same well-known values as variant-level status."
+              }
+            }
+          },
+          "description": "Per-location availability for multi-location businesses. Enables agents to guide buyers to locations where the item is in stock."
         }
       }
     },


### PR DESCRIPTION
Right now, variant availability is a boolean plus an enum. You know if something is available, and roughly what state it is in (in_stock, backorder, etc). But that is about it.

For agents doing the talking -- especially voice agents where you can not show a grid of alternatives -- "available" vs "unavailable" is not enough. "Only 2 left" changes buying behavior. "Back in stock next Tuesday" changes whether the buyer waits or goes elsewhere.

This PR extends the existing `availability` object on variants with optional inventory fields. Nothing breaks, nothing is required, businesses that do not track inventory just skip the new fields.

Closes #345

## What changed

One file: `source/schemas/shopping/types/variant.json`

The `availability` object gets four new optional properties:

- **`quantity`** (integer) -- current stock count. Some businesses will share this, others will not. Both are fine.
- **`low_stock_threshold`** (integer) -- the business defines what "low stock" means to them. Platforms can use this to show "almost gone" or similar messaging.
- **`restock_at`** (date-time) -- estimated restock date for out-of-stock or backordered items. Useful for "check back on Tuesday" type conversations.
- **`locations`** (array) -- per-location availability for multi-location businesses. Each location has an id, name, available flag, optional quantity, and status.

The existing `available` boolean and `status` enum are untouched.

## What it looks like

```json
{
  "id": "variant_mug_blue",
  "title": "Ceramic Mug - Blue",
  "availability": {
    "available": true,
    "status": "in_stock",
    "quantity": 4,
    "low_stock_threshold": 5,
    "restock_at": "2026-05-10T00:00:00Z",
    "locations": [
      { "id": "loc_downtown", "name": "Downtown", "available": true, "quantity": 3 },
      { "id": "loc_online", "name": "Online", "available": true, "quantity": 1 }
    ]
  }
}
```

A business that does not track inventory still returns what they always returned:

```json
{
  "availability": {
    "available": true,
    "status": "in_stock"
  }
}
```

No change needed on their side.

## Why this matters for agents

A voice agent can not show a product grid. The conversation is linear, so the agent needs to make good recommendations with the information it has. Knowing stock levels lets it say things like:

- "That is running low -- want me to grab one before it is gone?"
- "It is out of stock online but the downtown store has 3 left."
- "They expect more on May 10th. Want me to check back then?"

Without these signals, the agent is stuck with "it is available" or "it is not available." That is a worse experience for the buyer.