### PR TITLE
docs: Fix typos and improve formatting in versioning

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Versioning
 
-UCP uses date-based version identifiers following the format YYYY-MM-DD, to
+UCP uses date-based version identifiers following the format `YYYY-MM-DD` to
 indicate the last date backwards incompatible changes were made.
 
 New development occurs on the `main` branch. We will maintain long-lived
@@ -10,14 +10,14 @@ branches for all supported releases of the spec.
   new branch named `release/YYYY-MM-DD` directly from the current state of
   `main`.
     * We will implement a code freeze on the release branch the moment a
-      `release/YYYY-MM-DD branch` is cut. Only critical bug fixes should move
+      `release/YYYY-MM-DD` branch is cut. Only critical bug fixes should move
       during this window.
     * Critical issues discovered after cutting a release branch should be fixed
       in one of two ways:
       1. The fix is made on the release branch and merged to `main`.
       2. The fix is made on `main` and cherry-picked to the release branch.
-* Once finalized, we will merge the release branch into `main` and tag it (e.g.
-  `git tag -a vYYYY-MM-DD`).  We will use a GitHub Action to detect the new Tag
+* Once finalized, we will merge the release branch into `main` and tag it (e.g.,
+  `git tag -a vYYYY-MM-DD`).  We will use a GitHub Action to detect the new tag
   and automatically generate a release notes draft and upload artifacts.
 * Unlike temporary feature branches, release/YYYY-MM-DD branches are long-lived
   and correspond to specific versions of the spec for historical reference and


### PR DESCRIPTION
# Description

minor typo fixes and better formatting. 

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

<!-- Link to any related issues here. e.g., "Fixes #123" -->

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

<!-- If applicable, add screenshots or log output to help explain your changes. -->
