### PR TITLE
fix(openapi): add missing signature headers to get_order 200 response

### DIFF
--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -673,6 +673,11 @@
         "responses": {
           "200": {
             "description": "Order retrieved or business outcome message",
+            "headers": {
+              "Signature": { "$ref": "#/components/headers/signature" },
+              "Signature-Input": { "$ref": "#/components/headers/signature_input" },
+              "Content-Digest": { "$ref": "#/components/headers/content_digest" }
+            },
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/order_response" }


### PR DESCRIPTION
Fixes #364
The `get_order` operation (`GET /orders/{id}`) was the only endpoint missing the standard signature response headers present in all other operations.
**Added to the `get_order` 200 response:**
- `Signature` → `#/components/headers/signature`
- `Signature-Input` → `#/components/headers/signature_input`
- `Content-Digest` → `#/components/headers/content_digest`
No new components introduced — these $refs already exist and are used by every other operation. JSON remains valid.