### PR TITLE
docs(messages): rename presentation: "disclosure" to "compliance"

### DIFF
--- a/docs/specification/catalog/index.md
+++ b/docs/specification/catalog/index.md
@@ -165,7 +165,7 @@ Messages communicate business outcomes and provide context:
 | `warning` | Important conditions affecting purchase | `DELAYED_FULFILLMENT`, `FINAL_SALE` |
 | `info` | Additional context without issues | `PROMOTIONAL_PRICING`, `LIMITED_AVAILABILITY` |
 
-Warnings with `presentation: "disclosure"` carry notices (e.g., allergen
+Warnings with `presentation: "compliance"` carry notices (e.g., allergen
 declarations, safety warnings) that platforms must not hide or dismiss. See
 [Warning Presentation](../checkout.md#warning-presentation) for the full
 rendering contract.
@@ -267,7 +267,7 @@ Agents correlate results using the `inputs` array on each variant. See
 #### Product Disclosure
 
 When a product requires a disclosure (e.g., allergen notice, safety warning),
-return it as a warning with `presentation: "disclosure"`. The `path` field targets the
+return it as a warning with `presentation: "compliance"`. The `path` field targets the
 relevant component in the response — when it targets a product, the
 disclosure applies to all of its variants.
 
@@ -301,7 +301,7 @@ disclosure applies to all of its variants.
       "path": "$.products[0]",
       "content": "**Contains: tree nuts.** Produced in a facility that also processes peanuts, milk, and soy.",
       "content_type": "markdown",
-      "presentation": "disclosure",
+      "presentation": "compliance",
       "image_url": "https://merchant.com/allergen-tree-nuts.svg",
       "url": "https://merchant.com/allergen-info"
     }

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -332,7 +332,7 @@ The `presentation` field on warning messages controls the rendering
 contract the platform **MUST** follow. When omitted, it defaults to
 `"notice"`.
 
-| | `notice` (default) | `disclosure` |
+| | `notice` (default) | `compliance` |
 | :--- | :--- | :--- |
 | Display content | **MUST** | **MUST** |
 | Proximity to `path` | **MAY** | **MUST** |
@@ -347,9 +347,9 @@ The default rendering contract for warnings. Platforms **MUST** display
 the warning content to the buyer. Platforms **MAY** render notices in a
 banner, tray, or toast, and **MAY** allow the buyer to dismiss them.
 
-#### `disclosure`
+#### `compliance`
 
-Warnings with `presentation: "disclosure"` carry notices — safety
+Warnings with `presentation: "compliance"` carry notices — safety
 warnings, allergen declarations, compliance content, etc. — that
 **MUST** follow the prescribed rendering contract below.
 
@@ -365,7 +365,7 @@ warnings, allergen declarations, compliance content, etc. — that
   energy class label).
 * **SHOULD** render `url` as a navigable reference link when present.
 
-Warnings with `presentation: "disclosure"` **SHOULD** be given rendering
+Warnings with `presentation: "compliance"` **SHOULD** be given rendering
 priority over notices.
 
 Platforms that cannot honor the disclosure rendering contract **MUST**
@@ -374,7 +374,7 @@ downgrading to a notice.
 
 **Business requirements:**
 
-* **MUST** set `presentation: "disclosure"` when the warning content must
+* **MUST** set `presentation: "compliance"` when the warning content must
   be displayed alongside a specific component and must not be hidden or
   auto-dismissed.
 * **SHOULD** use the `path` field to associate disclosures with the
@@ -438,7 +438,7 @@ warning on a line item:
       "path": "$.line_items[0]",
       "content": "**Contains: tree nuts.** Produced in a facility that also processes peanuts, milk, and soy.",
       "content_type": "markdown",
-      "presentation": "disclosure",
+      "presentation": "compliance",
       "image_url": "https://merchant.com/allergen-tree-nuts.svg",
       "url": "https://merchant.com/allergen-info"
     }

--- a/source/schemas/shopping/types/message_warning.json
+++ b/source/schemas/shopping/types/message_warning.json
@@ -37,7 +37,7 @@
     "presentation": {
       "type": "string",
       "default": "notice",
-      "description": "Rendering contract for this warning. 'notice' (default): platform MUST display, MAY dismiss. 'disclosure': platform MUST display in proximity to the path-referenced component, MUST NOT hide or auto-dismiss. See specification for full contract."
+      "description": "Rendering contract for this warning. 'notice' (default): platform MUST display, MAY dismiss. 'compliance': platform MUST display in proximity to the path-referenced component, MUST NOT hide or auto-dismiss. See specification for full contract."
     },
     "image_url": {
       "type": "string",


### PR DESCRIPTION
## Summary

Rename the `presentation` enum value `"disclosure"` to `"compliance"` so the mode name describes the category of message (regulatory compliance) rather than the rendering verb (disclosing). Reads more naturally alongside the default `"notice"` mode for general advisories.

Follow-up to #267, which introduced the strict-display `"disclosure"` mode. Rendering contract is unchanged — only the value name.

## Why

`disclosure` reads as a verb / general concept; almost every warning is technically "disclosing" something. The mode is specifically for messages that exist to satisfy a regulatory display requirement (Prop 65, GPSR responsible-person, allergen declarations, energy labels). `compliance` names that intent directly.

## What changes

- `source/schemas/shopping/types/message_warning.json` — description text on the `presentation` field
- `docs/specification/checkout.md` — table column header, the `#### \`compliance\`` section heading, prose references to the value, JSON example
- `docs/specification/catalog/index.md` — prose references to the value, JSON example

## What is intentionally NOT changed

- `message_warning` type itself stays — `presentation: "compliance"` is a mode of the warning slot, not a replacement for it. The message-type axis (error/info/warning) is severity-based and remains orthogonal to category.
- References to "disclosure" as a real-world concept (e.g. "allergen disclosure", "the disclosure rendering contract", "Disclosure and Acknowledgment") are preserved. Only the literal enum value is renamed.

## Migration

`presentation` has no enum constraint in the schema (free-form string with documented values), so this is a documentation-level change. Implementations currently emitting `presentation: "disclosure"` should update to `"compliance"`. There is no value-coexistence story; the rename is a clean replacement.

Opening as draft for discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)