### PR TITLE
fix!: repair profile schemas to pass validation & endpoint contract

### DIFF
--- a/docs/documentation/schema-authoring.md
+++ b/docs/documentation/schema-authoring.md
@@ -101,10 +101,9 @@ Define transport bindings that appear in `ucp.services{}` registries. Each trans
 
 - **Top-level fields**: `$schema`, `$id`, `title`, `description`, `name`, `version`
 - **Variants**: `platform_schema`, `business_schema`
-- **Transport requirements**:
-    - REST/MCP: `endpoint`, `schema` (OpenAPI/OpenRPC URL)
-    - A2A: `endpoint` (Agent Card URL)
-    - Embedded: `schema` (OpenRPC URL)
+- **Transport requirements** (additional beyond the common base):
+    - Platform profile (`platform_schema`): REST/MCP/Embedded require `schema` (OpenAPI/OpenRPC URL). A2A has no additional requirements.
+    - Business profile (`business_schema`): REST/MCP/A2A require `endpoint` (Agent Card URL for A2A). Embedded has no additional requirements.
 
 ### Payment Handler Schemas
 

--- a/source/discovery/profile_schema.json
+++ b/source/discovery/profile_schema.json
@@ -4,7 +4,7 @@
   "title": "UCP Discovery Profile",
   "description": "Schema for UCP discovery profiles. Business profiles are hosted at /.well-known/ucp; platform profiles are hosted at URIs advertised in request headers.",
 
-  "oneOf": [
+  "anyOf": [
     { "$ref": "#/$defs/platform_profile" },
     { "$ref": "#/$defs/business_profile" }
   ],

--- a/source/schemas/service.json
+++ b/source/schemas/service.json
@@ -29,7 +29,7 @@
 
     "platform_schema": {
       "title": "Service (Platform Schema)",
-      "description": "Full service declaration for platform-level discovery. All transports require `version`, `spec`, and `transport`. REST and MCP additionally require `schema` and `endpoint`; A2A requires `endpoint`; embedded requires `schema`.",
+      "description": "Full service declaration for platform-level discovery. All transports require `version`, `spec`, and `transport`. REST, MCP, and embedded additionally require `schema`.",
       "allOf": [
         { "$ref": "#/$defs/base" },
         { "required": ["spec"] },

--- a/source/schemas/service.json
+++ b/source/schemas/service.json
@@ -37,15 +37,14 @@
           "anyOf": [
             {
               "properties": { "transport": { "const": "rest" } },
-              "required": ["schema", "endpoint"]
+              "required": ["schema"]
             },
             {
               "properties": { "transport": { "const": "mcp" } },
-              "required": ["schema", "endpoint"]
+              "required": ["schema"]
             },
             {
-              "properties": { "transport": { "const": "a2a" } },
-              "required": ["endpoint"]
+              "properties": { "transport": { "const": "a2a" } }
             },
             {
               "properties": { "transport": { "const": "embedded" } },

--- a/source/services/shopping/mcp.openrpc.json
+++ b/source/services/shopping/mcp.openrpc.json
@@ -65,10 +65,6 @@
             "type": "string",
             "format": "uuid",
             "description": "Unique key for retry safety. Maps to HTTP Idempotency-Key header."
-          },
-          "signature": {
-            "type": "string",
-            "description": "Detached JWS signature (RFC 7515 Appendix F) in format `<base64url-header>..<base64url-signature>`. See Message Signatures specification."
           }
         }
       }


### PR DESCRIPTION
Our schema validation and lint infrastructure exercises the **services / payload** surface — request roundtrips, codegen, fixture validation. The **profile / discovery** schemas and the MCP openrpc meta block have no equivalent validation pass:

- The prose examples in `docs/specification/` are not validated against their corresponding schemas.
- No fixture roundtrips a real profile document through the top-level discovery schema.
- The openrpc meta block is not cross-checked against the canonical Message Signatures spec.

As a result, a few schema issues snuck in undetected. Worse, our published profiles schemas are effectively broken / can't be validated due to broken `oneOf` and misplaced `requires`. See individual commits for specifics

- https://github.com/Universal-Commerce-Protocol/ucp/commit/c5fa47cefc4927c008789e73c621b8f574381dae: `service.json` platform_schema: drop over-strict `endpoint` requirement
- [`0100ed4`](https://github.com/Universal-Commerce-Protocol/ucp/commit/0100ed4119b930ef384222beb81ecea16620dd2b): `profile_schema.json`: top-level `oneOf` → `anyOf` (was unsatisfiable)
- https://github.com/Universal-Commerce-Protocol/ucp/commit/78ea9b3eacdeb36cc1c57eef6c07836d6cfcbbba: `mcp.openrpc.json`: remove stale RFC 7515 signature field

Technically, both oneOf and requires are breaking changes to the profile schemas, but they are un-breaking the current broken state, and so I propose we land and backport this to both 04-08 and previous releases.

---

## Checklist

- [x] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors.
- [x] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.