### PR TITLE
docs(checkout): cross-link cart_id from Create Checkout

### DIFF
--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -565,6 +565,11 @@ To be invoked by the platform when the user has expressed purchase intent
 product data (price/title etc.) provided by the business through the feeds
 **SHOULD** match the actual attributes returned in the response.
 
+When the [Cart](cart.md) capability is negotiated, the request payload
+accepts an additional `cart_id` field for cart-to-checkout conversion. See
+[Cart → Cart-to-Checkout Conversion](cart.md#cart-to-checkout-conversion) for
+the field contract.
+
 {{ method_fields('create_checkout', 'rest.openapi.json', 'checkout') }}
 
 ### Get Checkout

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -566,7 +566,7 @@ product data (price/title etc.) provided by the business through the feeds
 **SHOULD** match the actual attributes returned in the response.
 
 When the [Cart](cart.md) capability is negotiated, the request payload
-accepts an additional `cart_id` field for cart-to-checkout conversion. See
+should accept an additional `cart_id` field for cart-to-checkout conversion. See
 [Cart → Cart-to-Checkout Conversion](cart.md#cart-to-checkout-conversion) for
 the field contract.
 


### PR DESCRIPTION
## What

Add a one-line cross-link from the **Create Checkout** section in `checkout.md` to the existing **Cart-to-Checkout Conversion** section in `cart.md`, so a reader on the checkout page can discover `cart_id` and the conversion contract.

## Why

The cart capability extends `create_checkout` with a `cart_id` field (defined in `cart.json#/$defs/checkout` and covered in prose under [Cart → Cart-to-Checkout Conversion](https://ucp.dev/specification/cart/#cart-to-checkout-conversion)). The cart page covers it well, but the **checkout** page has no signpost — a reader on `/specification/checkout/#create-checkout` cannot tell that this field exists or where to find it.

This adds a single discoverability hop. No content duplication.

## Change

```diff
 ### Create Checkout

 ...
 **Recommendation**: To minimize discrepancies and a streamlined user experience,
 product data (price/title etc.) provided by the business through the feeds
 **SHOULD** match the actual attributes returned in the response.

+When the [Cart](cart.md) capability is negotiated, the request payload
+accepts an additional `cart_id` field for cart-to-checkout conversion. See
+[Cart → Cart-to-Checkout Conversion](cart.md#cart-to-checkout-conversion) for
+the field contract.
+
 {{ method_fields('create_checkout', 'rest.openapi.json', 'checkout') }}
```

## Verification

Local `mkdocs build --strict` succeeds with no non-cairosvg warnings. The cross-link resolves to `../cart/#cart-to-checkout-conversion`, which is a stable existing anchor.

---

<img width="1023" height="577" alt="image" src="https://github.com/user-attachments/assets/3a47fe2a-0292-41a9-9378-b3ff2e6e689e" />

