### PR TITLE
feat!: buyer consent with per-segment extensibility

### DIFF
--- a/docs/documentation/core-concepts.md
+++ b/docs/documentation/core-concepts.md
@@ -185,7 +185,7 @@ up-to-date list.
 | `dev.ucp.shopping.discount` | checkout, cart | Discount codes and promotions |
 | `dev.ucp.shopping.fulfillment` | checkout | Shipping and delivery options |
 | `dev.ucp.shopping.ap2_mandate` | checkout | Non-repudiable authorization for autonomous commerce |
-| `dev.ucp.shopping.buyer_consent` | checkout | Explicit consent capture |
+| `dev.ucp.shopping.buyer_consent` | checkout, cart | Explicit consent capture |
 
 ### Services
 

--- a/docs/specification/buyer-consent.md
+++ b/docs/specification/buyer-consent.md
@@ -27,15 +27,21 @@ Consent is modeled as a two-level structure:
 
 - **Purpose** — what the consent is for. Keyed at the top level by a
     reverse-DNS identifier (e.g., `dev.ucp.consent.marketing`). Each purpose
-    carries an `allowed` state, a human-readable `description`, and optional
-    `links`.
+    carries a `checked` state, a `source` identifying who asserted that state,
+    a human-readable `description`, and optional `links`.
 - **Segment** — an optional refinement scoping the parent purpose to a
     specific channel (e.g., email, SMS), vendor (e.g., a measurement provider),
-    or program. Each segment has the same shape (`allowed`, `description`,
-    optional `links`) and overrides the parent purpose for its specific scope.
+    or program. Each segment has the same shape (`checked`, `source`,
+    `description`, optional `links`) and overrides the parent purpose for its
+    specific scope.
 
 The structure is bounded to one level of nesting: purposes have segments;
 segments do not nest further.
+
+The protocol carries only the binary state and its source attribution.
+The operational meaning of `checked: true` vs `false` (granted, denied,
+enabled, subscribed) is defined by the consent context — not by the field
+name or by the protocol.
 
 ## Scope
 
@@ -47,13 +53,11 @@ displaying current subscription state with an unsubscribe affordance) are
 governed by business policy and applicable regulation, not by this
 specification.
 
-Businesses are responsible for selecting the initial `allowed` value according
-to applicable policy and regulation before advertising consent options. In
-contexts that require affirmative opt-in, the business SHOULD advertise
-`allowed: false` until the buyer chooses otherwise. In contexts that allow
-opt-out, the business MAY advertise `allowed: true` as a default the buyer can
-override. The protocol carries the precomputed `allowed` value; policy and
-regulatory reasoning remain the business's responsibility.
+Businesses are responsible for selecting the initial `checked` value according
+to their applicable policy before advertising consent options. The advertised
+value with `source: "business"` is the business's authoritative default;
+buyers may override it through the platform. Policy reasoning remains the
+business's responsibility.
 
 ## Discovery
 
@@ -137,15 +141,27 @@ channel segment identifiers:
 
 The same map shape carries two complementary directions of information:
 
-| Direction                | Who populates | Fields populated                                               |
-| ------------------------ | ------------- | -------------------------------------------------------------- |
-| **Advertise** (response) | Business      | `description`, `links`, current `allowed`, optional `segments` |
-| **Confirm** (request)    | Platform      | captured `allowed`, optional `segments`                        |
+| Direction                | Who populates | Fields populated                                                          |
+| ------------------------ | ------------- | ------------------------------------------------------------------------- |
+| **Advertise** (response) | Business      | `checked`, `source`, `description`; `links` and `segments` when present   |
+| **Confirm** (request)    | Platform      | `checked`, `source`; `segments` when present                              |
 
 `description` and `links` are response-only; the platform does not echo them on
-confirm. `allowed` is required in both directions: businesses send the current
-or default state when advertising; platforms send the captured decision when
-confirming.
+confirm. `checked` and `source` are required in both directions: businesses
+send the current state and its source when advertising; platforms send the
+current state and its source when confirming.
+
+The `source` field carries the authorship of the current `checked` value:
+
+- `source: "business"` means the value reflects the business's default; no
+  buyer preference applies.
+- `source: "platform"` means the value reflects the buyer's stated
+  preference, captured by the platform.
+
+The source signals how to treat the current value: `source: "business"`
+invites the platform to surface the choice for buyer engagement;
+`source: "platform"` indicates a recorded buyer preference the platform
+SHOULD respect unless the buyer initiates a change.
 
 ### Advertise example
 
@@ -163,42 +179,50 @@ state (either the buyer's prior decision or the business default):
   "buyer": {
     "consent": {
       "dev.ucp.consent.marketing": {
-        "allowed": false,
+        "checked": false,
+        "source": "business",
         "description": "Promotional communications across all channels",
         "links": [{ "type": "privacy_policy", "url": "https://example.com/privacy" }],
         "segments": {
           "dev.ucp.consent.marketing.email": {
-            "allowed": false,
+            "checked": true,
+            "source": "platform",
             "description": "Promotional emails and exclusive offers"
           },
           "dev.ucp.consent.marketing.sms": {
-            "allowed": false,
+            "checked": false,
+            "source": "business",
             "description": "Marketing text messages",
             "links": [{ "type": "terms_of_service", "url": "https://example.com/sms-terms" }]
           },
           "com.example.channel.marketing": {
-            "allowed": false,
+            "checked": false,
+            "source": "business",
             "description": "Marketing messages via a third-party channel"
           }
         }
       },
       "dev.ucp.consent.analytics": {
-        "allowed": true,
+        "checked": true,
+        "source": "business",
         "description": "Site analytics and performance measurement",
         "segments": {
           "com.example.analytics": {
-            "allowed": false,
+            "checked": false,
+            "source": "business",
             "description": "Third-party analytics measurement",
             "links": [{ "type": "privacy_policy", "url": "https://example.com/analytics-privacy" }]
           }
         }
       },
       "dev.ucp.consent.preferences": {
-        "allowed": true,
+        "checked": true,
+        "source": "business",
         "description": "Remember preferences and personalize the shopping experience"
       },
       "dev.ucp.consent.sale_or_sharing": {
-        "allowed": false,
+        "checked": false,
+        "source": "platform",
         "description": "Sale or sharing of personal data with third parties",
         "links": [{ "type": "privacy_policy", "url": "https://example.com/privacy" }]
       }
@@ -207,11 +231,19 @@ state (either the buyer's prior decision or the business default):
 }
 ```
 
+In this example, the buyer has previously opted in to promotional email
+(`marketing.email` shows `source: "platform"`) and previously opted out of
+data sale (`sale_or_sharing` shows `source: "platform"`). Every other choice
+remains at its business-asserted default and is a candidate for the platform
+to surface for explicit capture.
+
 ### Confirm example
 
-Platforms submit current consent decisions in a subsequent `update_checkout` or
-`complete_checkout` request, with buyer changes applied to the advertised
-settings:
+Platforms submit the current state of every advertised purpose and segment in a
+subsequent `update_checkout` or `complete_checkout` request. For each choice,
+the platform echoes the advertised `checked` and `source` when no buyer
+preference applies, or sets `source: "platform"` with the buyer's stated
+`checked` value when one does.
 
 <!-- ucp:example schema=shopping/buyer_consent def=consent op=complete direction=request extract=$.buyer.consent -->
 
@@ -220,34 +252,45 @@ settings:
   "buyer": {
     "consent": {
       "dev.ucp.consent.marketing": {
-        "allowed": false,
+        "checked": true,
+        "source": "platform",
         "segments": {
-          "dev.ucp.consent.marketing.email": { "allowed": true },
-          "dev.ucp.consent.marketing.sms": { "allowed": false },
-          "com.example.channel.marketing": { "allowed": false }
+          "dev.ucp.consent.marketing.email": { "checked": true,  "source": "platform" },
+          "dev.ucp.consent.marketing.sms":   { "checked": true,  "source": "platform" },
+          "com.example.channel.marketing":   { "checked": false, "source": "business" }
         }
       },
       "dev.ucp.consent.analytics": {
-        "allowed": true,
+        "checked": true,
+        "source": "business",
         "segments": {
-          "com.example.analytics": { "allowed": false }
+          "com.example.analytics": { "checked": false, "source": "business" }
         }
       },
-      "dev.ucp.consent.preferences": { "allowed": true },
-      "dev.ucp.consent.sale_or_sharing": { "allowed": false }
+      "dev.ucp.consent.preferences":     { "checked": true,  "source": "business" },
+      "dev.ucp.consent.sale_or_sharing": { "checked": false, "source": "platform" }
     }
   }
 }
 ```
 
+Here, the buyer opted in to marketing on email and SMS; other choices are
+echoed at their advertised values, including `sale_or_sharing` which retains
+a prior platform-captured choice.
+
 ## Data dependencies
 
 Some consent states depend on additional buyer or checkout data. For example,
-SMS marketing consent may require a buyer phone number. When required data is
-missing, the business SHOULD use standard `messages[]` warnings or errors to
-inform the platform or buyer.
+SMS marketing consent requires a buyer phone number. When the
+platform confirms a consent value whose required dependency is missing,
+businesses surface the gap through the standard [Checkout Status
+Lifecycle](checkout.md#checkout-status-lifecycle) and [Error
+Handling](checkout.md#error-handling) mechanisms.
 
-For example:
+On `create_cart`, `update_cart`, `create_checkout`, and `update_checkout`,
+businesses SHOULD surface missing dependencies as `warning` messages so the
+platform can collect the data on a subsequent operation. The advertised
+consent decisions remain valid; the warning is informational.
 
 <!-- ucp:example schema=shopping/checkout target=$.messages op=read -->
 
@@ -262,16 +305,25 @@ For example:
 ]
 ```
 
+On `complete_checkout`, businesses MUST NOT transition the checkout to
+`completed` while a confirmed consent decision has unmet data dependencies.
+Missing dependencies MUST be surfaced via the standard [Error
+Handling](checkout.md#error-handling) flow.
+
 ## Normative requirements
 
 1. **Use the advertised settings.** Platforms MUST initialize and present
-   consent using the advertised `description`, `links`, provided `allowed`
-   values, and purpose/segment grouping. Identifiers are opaque handles; agents
-   MUST NOT infer semantics from identifier paths alone.
+   consent using the advertised `description`, `links`, provided `checked`
+   values, `source` attribution, and purpose/segment grouping. Identifiers are
+   opaque handles; platforms MUST NOT infer semantics from identifier paths
+   alone.
 
-2. **Complete confirm.** When submitting consent, platforms MUST include every
-   advertised purpose and segment key, carrying either the advertised `allowed`
-   value or the buyer's captured change.
+2. **Confirm semantics.** The `consent` field is optional on requests;
+   omitting it provides no consent update and the business retains its prior
+   position. When submitting `consent`, platforms MUST include every advertised
+   purpose and segment key, carrying both `checked` and `source` for each.
+   Omitting an advertised key within a submitted `consent` map MUST NOT be
+   used to signal any value.
 
 3. **Advertised set is authoritative.** Businesses MUST ignore purposes and
    segments in a request that were not advertised in a prior response. Platforms
@@ -279,4 +331,18 @@ For example:
    advertise.
 
 4. **More-specific values win.** For an advertised segment, the segment's
-   `allowed` value overrides the parent purpose's `allowed` for that segment.
+   `checked` value overrides the parent purpose's `checked` for that segment.
+
+5. **Source attribution requires a buyer-stated preference.** Platforms MUST
+   set `source: "platform"` only when the `checked` value reflects the buyer's
+   stated preference. For choices to which no buyer preference applies,
+   platforms MUST echo the advertised `source` unchanged. The protocol does
+   not prescribe what counts as a buyer-stated preference; that determination
+   is made by the platform under applicable policy.
+
+6. **Per-business attribution.** A consent decision captured with a specific
+   business is attributable only to that business; platforms MUST NOT
+   propagate it as the basis for `source: "platform"` in a different business's
+   request. Broader buyer preferences that are not tied to a specific business
+   are independent of per-business decisions and may be applied to each
+   business's advertised choices on their own basis.

--- a/docs/specification/buyer-consent.md
+++ b/docs/specification/buyer-consent.md
@@ -18,30 +18,60 @@
 
 ## Overview
 
-The Buyer Consent extension enables platforms to transmit buyer consent choices
-to businesses regarding data usage and communication preferences. It allows
-buyers to communicate their consent status for various categories, such as
-analytics, marketing, and data sales, helping businesses comply with privacy
-regulations like CCPA and GDPR.
+The Buyer Consent extension lets businesses communicate the consent options they
+offer and lets platforms transmit buyers' consent decisions for data usage and
+communication preferences — purposes like marketing, analytics, preferences, and
+sale or sharing of data.
 
-When this extension is supported, the `buyer` object in checkout is extended
-with a `consent` field containing boolean consent states.
+Consent is modeled as a two-level structure:
 
-This extension can be included in `create_checkout` and `update_checkout`
-operations.
+- **Purpose** — what the consent is for. Keyed at the top level by a
+    reverse-DNS identifier (e.g., `dev.ucp.consent.marketing`). Each purpose
+    carries an `allowed` state, a human-readable `description`, and optional
+    `links`.
+- **Segment** — an optional refinement scoping the parent purpose to a
+    specific channel (e.g., email, SMS), vendor (e.g., a measurement provider),
+    or program. Each segment has the same shape (`allowed`, `description`,
+    optional `links`) and overrides the parent purpose for its specific scope.
+
+The structure is bounded to one level of nesting: purposes have segments;
+segments do not nest further.
+
+## Scope
+
+This extension defines the mechanism by which businesses and platforms establish
+and communicate buyer consent state. It does not dictate either party's behavior
+in response to that state — how a business acts on it (e.g., sending emails,
+sharing data) and how a platform surfaces existing decisions to the buyer (e.g.,
+displaying current subscription state with an unsubscribe affordance) are
+governed by business policy and applicable regulation, not by this
+specification.
+
+Businesses are responsible for selecting the initial `allowed` value according
+to applicable policy and regulation before advertising consent options. In
+contexts that require affirmative opt-in, the business SHOULD advertise
+`allowed: false` until the buyer chooses otherwise. In contexts that allow
+opt-out, the business MAY advertise `allowed: true` as a default the buyer can
+override. The protocol carries the precomputed `allowed` value; policy and
+regulatory reasoning remain the business's responsibility.
 
 ## Discovery
 
-Businesses advertise consent support in their profile:
+Businesses advertise consent support in their profile. The capability can extend
+cart, checkout, or both:
 
 <!-- ucp:example schema=profile def=business_schema extract=$.capabilities target=$.ucp.capabilities -->
+
 ```json
 {
   "capabilities": {
     "dev.ucp.shopping.buyer_consent": [
       {
         "version": "{{ ucp_version }}",
-        "extends": "dev.ucp.shopping.checkout"
+        "extends": [
+          "dev.ucp.shopping.cart",
+          "dev.ucp.shopping.checkout"
+        ]
       }
     ]
   }
@@ -50,57 +80,80 @@ Businesses advertise consent support in their profile:
 
 ## Schema Composition
 
-The consent extension extends the **buyer object** within checkout:
+When this capability is active, the **buyer object** within cart and/or checkout
+carries a `consent` field:
 
-- **Base schema extended**: `checkout` via `buyer` object
-- **Path**: `checkout.buyer.consent`
-- **Schema reference**: `buyer_consent.json`
+- **Cart path**: `cart.buyer.consent`
+- **Checkout path**: `checkout.buyer.consent`
+
+The `buyer` object (and therefore `consent`) is optional on all cart and
+checkout operations — cart `create` / `update`, and checkout `create` / `update`
+/ `complete`. Platforms MAY submit captured consent on `complete_checkout`
+alongside payment.
 
 ## Schema Definition
 
 ### Consent Object
 
-{{ extension_schema_fields('buyer_consent.json#/$defs/consent', 'buyer-consent') }}
+A map of per-purpose consent decisions. Keys are reverse-DNS purpose identifiers
+such as `dev.ucp.consent.marketing` or `com.example.purpose.loyalty`. Values are
+[Consent Purpose](#consent-purpose) objects. A purpose may contain nested
+[Consent Segment](#consent-segment) refinements for channel, vendor, or program
+scopes.
 
-## Usage
+### Consent Purpose
 
-The platform includes consent within the `buyer` object in checkout operations:
+{{ extension_schema_fields('buyer_consent.json#/$defs/consent_purpose', 'buyer-consent') }}
 
-### Example: Create Checkout with Consent
+### Consent Segment
 
-<!-- ucp:example schema=shopping/checkout op=create direction=request -->
-```json
-POST /checkouts
+{{ extension_schema_fields('buyer_consent.json#/$defs/consent_segment', 'buyer-consent') }}
 
-{
-  "line_items": [
-    {
-      "item": {
-        "id": "prod_123",
-        "title": "Blue T-Shirt",
-        "price": 1999
-      },
-      "id": "li_1",
-      "quantity": 1
-    }
-  ],
-  "buyer": {
-    "email": "jane.doe@example.com",
-    "first_name": "Jane",
-    "last_name": "Doe",
-    "consent": {
-      "analytics": true,
-      "preferences": true,
-      "marketing": false,
-      "sale_of_data": false
-    }
-  }
-}
-```
+## Well-known purposes
 
-### Example: Checkout Response with Consent
+This extension defines four well-known purpose identifiers under the
+`dev.ucp.consent.*` namespace. Businesses may define additional purposes under
+reverse-DNS namespaces they control. These identifiers are operational
+definitions, not legal taxonomies.
 
-<!-- ucp:example schema=shopping/checkout op=read -->
+| Identifier                        | Purpose                                                   |
+| --------------------------------- | --------------------------------------------------------- |
+| `dev.ucp.consent.analytics`       | Analytics and performance measurement                     |
+| `dev.ucp.consent.marketing`       | Marketing communications                                  |
+| `dev.ucp.consent.preferences`     | Remembering buyer preferences                             |
+| `dev.ucp.consent.sale_or_sharing` | Sale or sharing of personal data with third parties       |
+
+## Well-known segments
+
+For the `dev.ucp.consent.marketing` purpose, this extension defines well-known
+channel segment identifiers:
+
+| Identifier                        | Channel |
+| --------------------------------- | ------- |
+| `dev.ucp.consent.marketing.email` | Email   |
+| `dev.ucp.consent.marketing.sms`   | SMS     |
+
+## Advertise and confirm
+
+The same map shape carries two complementary directions of information:
+
+| Direction                | Who populates | Fields populated                                               |
+| ------------------------ | ------------- | -------------------------------------------------------------- |
+| **Advertise** (response) | Business      | `description`, `links`, current `allowed`, optional `segments` |
+| **Confirm** (request)    | Platform      | captured `allowed`, optional `segments`                        |
+
+`description` and `links` are response-only; the platform does not echo them on
+confirm. `allowed` is required in both directions: businesses send the current
+or default state when advertising; platforms send the captured decision when
+confirming.
+
+### Advertise example
+
+Businesses advertise available purposes and segments with the current consent
+state (either the buyer's prior decision or the business default):
+
+<!-- ucp:example schema=shopping/buyer_consent def=consent op=read extract=$.buyer.consent -->
+
 ```json
 {
   "ucp": { ... },
@@ -108,30 +161,122 @@ POST /checkouts
   "status": "ready_for_complete",
   "currency": "USD",
   "buyer": {
-    "email": "jane.doe@example.com",
-    "first_name": "Jane",
-    "last_name": "Doe",
     "consent": {
-      "analytics": true,
-      "preferences": true,
-      "marketing": false,
-      "sale_of_data": false
+      "dev.ucp.consent.marketing": {
+        "allowed": false,
+        "description": "Promotional communications across all channels",
+        "links": [{ "type": "privacy_policy", "url": "https://example.com/privacy" }],
+        "segments": {
+          "dev.ucp.consent.marketing.email": {
+            "allowed": false,
+            "description": "Promotional emails and exclusive offers"
+          },
+          "dev.ucp.consent.marketing.sms": {
+            "allowed": false,
+            "description": "Marketing text messages",
+            "links": [{ "type": "terms_of_service", "url": "https://example.com/sms-terms" }]
+          },
+          "com.example.channel.marketing": {
+            "allowed": false,
+            "description": "Marketing messages via a third-party channel"
+          }
+        }
+      },
+      "dev.ucp.consent.analytics": {
+        "allowed": true,
+        "description": "Site analytics and performance measurement",
+        "segments": {
+          "com.example.analytics": {
+            "allowed": false,
+            "description": "Third-party analytics measurement",
+            "links": [{ "type": "privacy_policy", "url": "https://example.com/analytics-privacy" }]
+          }
+        }
+      },
+      "dev.ucp.consent.preferences": {
+        "allowed": true,
+        "description": "Remember preferences and personalize the shopping experience"
+      },
+      "dev.ucp.consent.sale_or_sharing": {
+        "allowed": false,
+        "description": "Sale or sharing of personal data with third parties",
+        "links": [{ "type": "privacy_policy", "url": "https://example.com/privacy" }]
+      }
     }
-  },
-  "line_items": [...],
-  "totals": [...],
-  "links": [
-    {
-      "type": "privacy_policy",
-      "url": "https://example.com/privacy"
-    }
-  ]
+  }
 }
 ```
 
-## Security & Privacy Considerations
+### Confirm example
 
-1. **Consent is declarative** - The protocol communicates consent, it does not enforce it
-2. **Legal compliance** remains the business's responsibility
-3. **Platforms should not** assume consent without explicit user action
-4. **Default behavior** when consent is not provided is business-specific
+Platforms submit current consent decisions in a subsequent `update_checkout` or
+`complete_checkout` request, with buyer changes applied to the advertised
+settings:
+
+<!-- ucp:example schema=shopping/buyer_consent def=consent op=complete direction=request extract=$.buyer.consent -->
+
+```json
+{
+  "buyer": {
+    "consent": {
+      "dev.ucp.consent.marketing": {
+        "allowed": false,
+        "segments": {
+          "dev.ucp.consent.marketing.email": { "allowed": true },
+          "dev.ucp.consent.marketing.sms": { "allowed": false },
+          "com.example.channel.marketing": { "allowed": false }
+        }
+      },
+      "dev.ucp.consent.analytics": {
+        "allowed": true,
+        "segments": {
+          "com.example.analytics": { "allowed": false }
+        }
+      },
+      "dev.ucp.consent.preferences": { "allowed": true },
+      "dev.ucp.consent.sale_or_sharing": { "allowed": false }
+    }
+  }
+}
+```
+
+## Data dependencies
+
+Some consent states depend on additional buyer or checkout data. For example,
+SMS marketing consent may require a buyer phone number. When required data is
+missing, the business SHOULD use standard `messages[]` warnings or errors to
+inform the platform or buyer.
+
+For example:
+
+<!-- ucp:example schema=shopping/checkout target=$.messages op=read -->
+
+```json
+[
+  {
+    "type": "warning",
+    "code": "missing_consent_data",
+    "content": "Phone number is required for SMS marketing.",
+    "path": "$.buyer.phone_number"
+  }
+]
+```
+
+## Normative requirements
+
+1. **Use the advertised settings.** Platforms MUST initialize and present
+   consent using the advertised `description`, `links`, provided `allowed`
+   values, and purpose/segment grouping. Identifiers are opaque handles; agents
+   MUST NOT infer semantics from identifier paths alone.
+
+2. **Complete confirm.** When submitting consent, platforms MUST include every
+   advertised purpose and segment key, carrying either the advertised `allowed`
+   value or the buyer's captured change.
+
+3. **Advertised set is authoritative.** Businesses MUST ignore purposes and
+   segments in a request that were not advertised in a prior response. Platforms
+   MUST NOT prompt for or transmit purposes or segments the business did not
+   advertise.
+
+4. **More-specific values win.** For an advertised segment, the segment's
+   `allowed` value overrides the parent purpose's `allowed` for that segment.

--- a/docs/specification/buyer-consent.md
+++ b/docs/specification/buyer-consent.md
@@ -160,8 +160,9 @@ The `source` field carries the authorship of the current `checked` value:
 
 The source signals how the platform should treat the current value:
 `source: "business"` invites the platform to present the choice for buyer
-engagement; `source: "platform"` indicates a recorded buyer preference,
-and platforms MAY suppress re-presentation.
+engagement; `source: "platform"` indicates a recorded buyer preference that
+MAY persist across subsequent transactions with the same business. Platforms
+MAY suppress re-presentation.
 
 ### Example: purposes and segments
 
@@ -401,3 +402,6 @@ Handling](checkout.md#error-handling) flow.
    request. Broader buyer preferences that are not tied to a specific business
    are independent of per-business decisions and may be applied to each
    business's advertised choices on their own basis.
+
+7. **Buyer review and revocation.** Platforms MUST provide a way for buyers
+   to audit and revoke or change prior consent decisions.

--- a/docs/specification/buyer-consent.md
+++ b/docs/specification/buyer-consent.md
@@ -27,21 +27,16 @@ Consent is modeled as a two-level structure:
 
 - **Purpose** — what the consent is for. Keyed at the top level by a
     reverse-DNS identifier (e.g., `dev.ucp.consent.marketing`). Each purpose
-    carries a `checked` state, a `source` identifying who asserted that state,
+    carries a `granted` state, a `source` identifying who asserted that state,
     a human-readable `description`, and optional `links`.
 - **Segment** — an optional refinement scoping the parent purpose to a
     specific channel (e.g., email, SMS), vendor (e.g., a measurement provider),
-    or program. Each segment has the same shape (`checked`, `source`,
+    or program. Each segment has the same shape (`granted`, `source`,
     `description`, optional `links`) and overrides the parent purpose for its
     specific scope.
 
 The structure is bounded to one level of nesting: purposes have segments;
 segments do not nest further.
-
-The protocol carries only the binary state and its source attribution.
-The operational meaning of `checked: true` vs `false` (granted, denied,
-enabled, subscribed) is defined by the consent context — not by the field
-name or by the protocol.
 
 ## Scope
 
@@ -53,7 +48,7 @@ displaying current subscription state with an unsubscribe affordance) are
 governed by business policy and applicable regulation, not by this
 specification.
 
-Businesses are responsible for selecting the initial `checked` value according
+Businesses are responsible for selecting the initial `granted` value according
 to their applicable policy before advertising consent options. The advertised
 value with `source: "business"` is the business's authoritative default;
 buyers may override it through the platform. Policy reasoning remains the
@@ -143,15 +138,15 @@ The same map shape carries two complementary directions of information:
 
 | Direction                | Who populates | Fields populated                                                          |
 | ------------------------ | ------------- | ------------------------------------------------------------------------- |
-| **Advertise** (response) | Business      | `checked`, `source`, `description`; `links` and `segments` when present   |
-| **Confirm** (request)    | Platform      | `checked`, `source`; `segments` when present                              |
+| **Advertise** (response) | Business      | `granted`, `source`, `description`; `links` and `segments` when present   |
+| **Confirm** (request)    | Platform      | `granted`, `source`; `segments` when present                              |
 
 `description` and `links` are response-only; the platform does not echo them on
-confirm. `checked` and `source` are required in both directions: businesses
+confirm. `granted` and `source` are required in both directions: businesses
 send the current state and its source when advertising; platforms send the
 current state and its source when confirming.
 
-The `source` field carries the authorship of the current `checked` value:
+The `source` field carries the authorship of the current `granted` value:
 
 - `source: "business"` means the value reflects the business's default; no
   buyer preference applies.
@@ -169,8 +164,8 @@ MAY suppress re-presentation.
 The simplest case is purpose-level consent capture — `analytics` here shows
 the buyer's consent recorded at the parent. Purposes can also carry segments
 for finer-grained control: `marketing` is set to off, but the buyer has
-consented to SMS marketing. The segment's `checked: true`
-overrides the parent's `checked: false` for that scope (more-specific values
+consented to SMS marketing. The segment's `granted: true`
+overrides the parent's `granted: false` for that scope (more-specific values
 win).
 
 <!-- ucp:example schema=shopping/buyer_consent def=consent op=read extract=$.buyer.consent -->
@@ -184,22 +179,22 @@ win).
   "buyer": {
     "consent": {
       "dev.ucp.consent.analytics": {
-        "checked": true,
+        "granted": true,
         "source": "platform",
         "description": "Site analytics and performance measurement"
       },
       "dev.ucp.consent.marketing": {
-        "checked": false,
+        "granted": false,
         "source": "business",
         "description": "Promotional communications",
         "segments": {
           "dev.ucp.consent.marketing.email": {
-            "checked": false,
+            "granted": false,
             "source": "business",
             "description": "Promotional emails"
           },
           "dev.ucp.consent.marketing.sms": {
-            "checked": true,
+            "granted": true,
             "source": "platform",
             "description": "Marketing text messages"
           }
@@ -230,36 +225,36 @@ state (either the buyer's prior decision or the business default):
   "buyer": {
     "consent": {
       "dev.ucp.consent.marketing": {
-        "checked": false,
+        "granted": false,
         "source": "business",
         "description": "Promotional communications across all channels",
         "links": [{ "type": "privacy_policy", "url": "https://example.com/privacy" }],
         "segments": {
           "dev.ucp.consent.marketing.email": {
-            "checked": true,
+            "granted": true,
             "source": "platform",
             "description": "Promotional emails and exclusive offers"
           },
           "dev.ucp.consent.marketing.sms": {
-            "checked": false,
+            "granted": false,
             "source": "business",
             "description": "Marketing text messages",
             "links": [{ "type": "terms_of_service", "url": "https://example.com/sms-terms" }]
           },
           "com.example.channel.marketing": {
-            "checked": false,
+            "granted": false,
             "source": "business",
             "description": "Marketing messages via a third-party channel"
           }
         }
       },
       "dev.ucp.consent.analytics": {
-        "checked": true,
+        "granted": true,
         "source": "business",
         "description": "Site analytics and performance measurement",
         "segments": {
           "com.example.analytics": {
-            "checked": false,
+            "granted": false,
             "source": "business",
             "description": "Third-party analytics measurement",
             "links": [{ "type": "privacy_policy", "url": "https://example.com/analytics-privacy" }]
@@ -267,12 +262,12 @@ state (either the buyer's prior decision or the business default):
         }
       },
       "dev.ucp.consent.preferences": {
-        "checked": true,
+        "granted": true,
         "source": "business",
         "description": "Remember preferences and personalize the shopping experience"
       },
       "dev.ucp.consent.sale_or_sharing": {
-        "checked": false,
+        "granted": false,
         "source": "platform",
         "description": "Sale or sharing of personal data with third parties",
         "links": [{ "type": "privacy_policy", "url": "https://example.com/privacy" }]
@@ -292,9 +287,9 @@ to surface for explicit capture.
 
 Platforms submit the current state of every advertised purpose and segment in a
 subsequent `update_checkout` or `complete_checkout` request. For each choice,
-the platform echoes the advertised `checked` and `source` when no buyer
+the platform echoes the advertised `granted` and `source` when no buyer
 preference applies, or sets `source: "platform"` with the buyer's stated
-`checked` value when one does.
+`granted` value when one does.
 
 <!-- ucp:example schema=shopping/buyer_consent def=consent op=complete direction=request extract=$.buyer.consent -->
 
@@ -303,23 +298,23 @@ preference applies, or sets `source: "platform"` with the buyer's stated
   "buyer": {
     "consent": {
       "dev.ucp.consent.marketing": {
-        "checked": true,
+        "granted": true,
         "source": "platform",
         "segments": {
-          "dev.ucp.consent.marketing.email": { "checked": true,  "source": "platform" },
-          "dev.ucp.consent.marketing.sms":   { "checked": true,  "source": "platform" },
-          "com.example.channel.marketing":   { "checked": false, "source": "business" }
+          "dev.ucp.consent.marketing.email": { "granted": true,  "source": "platform" },
+          "dev.ucp.consent.marketing.sms":   { "granted": true,  "source": "platform" },
+          "com.example.channel.marketing":   { "granted": false, "source": "business" }
         }
       },
       "dev.ucp.consent.analytics": {
-        "checked": true,
+        "granted": true,
         "source": "business",
         "segments": {
-          "com.example.analytics": { "checked": false, "source": "business" }
+          "com.example.analytics": { "granted": false, "source": "business" }
         }
       },
-      "dev.ucp.consent.preferences":     { "checked": true,  "source": "business" },
-      "dev.ucp.consent.sale_or_sharing": { "checked": false, "source": "platform" }
+      "dev.ucp.consent.preferences":     { "granted": true,  "source": "business" },
+      "dev.ucp.consent.sale_or_sharing": { "granted": false, "source": "platform" }
     }
   }
 }
@@ -366,7 +361,7 @@ Handling](checkout.md#error-handling) flow.
 1. **Use the advertised settings.** Businesses MUST advertise the complete
    set of consent options they support. Platforms decide which choices to
    present to the buyer and when; when presenting a choice, platforms MUST
-   use the advertised `description`, `links`, `checked` value, and
+   use the advertised `description`, `links`, `granted` value, and
    purpose/segment grouping. The `source` field informs platform decisions
    (see [Advertise and confirm](#advertise-and-confirm)) and is not
    user-facing content. Identifiers outside the `dev.ucp.consent.*` namespace
@@ -377,7 +372,7 @@ Handling](checkout.md#error-handling) flow.
 2. **Confirm semantics.** The `consent` field is optional on requests;
    omitting it provides no consent update and the business retains its prior
    position. When submitting `consent`, platforms MUST include every advertised
-   purpose and segment key, carrying both `checked` and `source` for each.
+   purpose and segment key, carrying both `granted` and `source` for each.
    Omitting an advertised key within a submitted `consent` map MUST NOT be
    used to signal any value.
 
@@ -387,10 +382,10 @@ Handling](checkout.md#error-handling) flow.
    advertise.
 
 4. **More-specific values win.** For an advertised segment, the segment's
-   `checked` value overrides the parent purpose's `checked` for that segment.
+   `granted` value overrides the parent purpose's `granted` for that segment.
 
 5. **Source attribution requires a buyer-stated preference.** Platforms MUST
-   set `source: "platform"` only when the `checked` value reflects the buyer's
+   set `source: "platform"` only when the `granted` value reflects the buyer's
    stated preference. For choices to which no buyer preference applies,
    platforms MUST echo the advertised `source` unchanged. The protocol does
    not prescribe what counts as a buyer-stated preference; that determination

--- a/docs/specification/buyer-consent.md
+++ b/docs/specification/buyer-consent.md
@@ -155,9 +155,7 @@ The `source` field carries the authorship of the current `granted` value:
 
 The source signals how the platform should treat the current value:
 `source: "business"` invites the platform to present the choice for buyer
-engagement; `source: "platform"` indicates a recorded buyer preference that
-MAY persist across subsequent transactions with the same business. Platforms
-MAY suppress re-presentation.
+engagement; `source: "platform"` indicates a recorded buyer preference.
 
 ### Example: purposes and segments
 
@@ -398,5 +396,8 @@ Handling](checkout.md#error-handling) flow.
    are independent of per-business decisions and may be applied to each
    business's advertised choices on their own basis.
 
-7. **Buyer review and revocation.** Platforms MUST provide a way for buyers
-   to audit and revoke or change prior consent decisions.
+7. **Persistence and reversibility.** Platforms MAY persist a buyer's prior
+   preferences (`source: "platform"`) across interactions with the same
+   business and MAY suppress re-presentation of unchanged values. Where
+   preferences are persisted, platforms SHOULD give the buyer the ability
+   to change them.

--- a/docs/specification/buyer-consent.md
+++ b/docs/specification/buyer-consent.md
@@ -158,10 +158,10 @@ The `source` field carries the authorship of the current `checked` value:
 - `source: "platform"` means the value reflects the buyer's stated
   preference, captured by the platform.
 
-The source signals how to treat the current value: `source: "business"`
-invites the platform to surface the choice for buyer engagement;
-`source: "platform"` indicates a recorded buyer preference the platform
-SHOULD respect unless the buyer initiates a change.
+The source signals how the platform should treat the current value:
+`source: "business"` invites the platform to present the choice for buyer
+engagement; `source: "platform"` indicates a recorded buyer preference,
+and platforms MAY suppress re-presentation.
 
 ### Advertise example
 
@@ -312,11 +312,16 @@ Handling](checkout.md#error-handling) flow.
 
 ## Normative requirements
 
-1. **Use the advertised settings.** Platforms MUST initialize and present
-   consent using the advertised `description`, `links`, provided `checked`
-   values, `source` attribution, and purpose/segment grouping. Identifiers are
-   opaque handles; platforms MUST NOT infer semantics from identifier paths
-   alone.
+1. **Use the advertised settings.** Businesses MUST advertise the complete
+   set of consent options they support. Platforms decide which choices to
+   present to the buyer and when; when presenting a choice, platforms MUST
+   use the advertised `description`, `links`, `checked` value, and
+   purpose/segment grouping. The `source` field informs platform decisions
+   (see [Advertise and confirm](#advertise-and-confirm)) and is not
+   user-facing content. Identifiers outside the `dev.ucp.consent.*` namespace
+   are opaque handles; platforms MUST NOT infer semantics from such paths
+   alone. UCP-defined identifiers carry the semantics established in this
+   specification.
 
 2. **Confirm semantics.** The `consent` field is optional on requests;
    omitting it provides no consent update and the business retains its prior

--- a/docs/specification/buyer-consent.md
+++ b/docs/specification/buyer-consent.md
@@ -163,6 +163,56 @@ The source signals how the platform should treat the current value:
 engagement; `source: "platform"` indicates a recorded buyer preference,
 and platforms MAY suppress re-presentation.
 
+### Example: purposes and segments
+
+The simplest case is purpose-level consent capture — `analytics` here shows
+the buyer's consent recorded at the parent. Purposes can also carry segments
+for finer-grained control: `marketing` is set to off, but the buyer has
+consented to SMS marketing. The segment's `checked: true`
+overrides the parent's `checked: false` for that scope (more-specific values
+win).
+
+<!-- ucp:example schema=shopping/buyer_consent def=consent op=read extract=$.buyer.consent -->
+
+```json
+{
+  "ucp": { ... },
+  "id": "checkout_456",
+  "status": "ready_for_complete",
+  "currency": "USD",
+  "buyer": {
+    "consent": {
+      "dev.ucp.consent.analytics": {
+        "checked": true,
+        "source": "platform",
+        "description": "Site analytics and performance measurement"
+      },
+      "dev.ucp.consent.marketing": {
+        "checked": false,
+        "source": "business",
+        "description": "Promotional communications",
+        "segments": {
+          "dev.ucp.consent.marketing.email": {
+            "checked": false,
+            "source": "business",
+            "description": "Promotional emails"
+          },
+          "dev.ucp.consent.marketing.sms": {
+            "checked": true,
+            "source": "platform",
+            "description": "Marketing text messages"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The buyer has engaged with two specific choices (analytics broadly, SMS
+marketing specifically); both carry `source: "platform"`. The remaining
+values (parent `marketing`, `email` segment) carry `source: "business"`.
+
 ### Advertise example
 
 Businesses advertise available purposes and segments with the current consent

--- a/docs/specification/playground.md
+++ b/docs/specification/playground.md
@@ -529,7 +529,7 @@ const UcpData = {
     ],
     "dev.ucp.shopping.buyer_consent": [
       {
-        extends: "dev.ucp.shopping.checkout",
+        extends: ["dev.ucp.shopping.cart", "dev.ucp.shopping.checkout"],
         version: "{{ ucp_version }}",
         spec: "https://ucp.dev/{{ ucp_version }}/specification/buyer-consent",
         schema: "https://ucp.dev/{{ ucp_version }}/schemas/shopping/buyer_consent.json"

--- a/source/schemas/shopping/buyer_consent.json
+++ b/source/schemas/shopping/buyer_consent.json
@@ -3,17 +3,22 @@
   "$id": "https://ucp.dev/schemas/shopping/buyer_consent.json",
   "name": "dev.ucp.shopping.buyer_consent",
   "title": "Buyer Consent Extension",
-  "description": "Extends the buyer object with per-purpose consent. Each purpose is keyed by a reverse-DNS identifier and carries an `allowed` state, a `description`, optional `links`, and optional `segments` for finer-grained channel, vendor, or program decisions scoped to that purpose.",
+  "description": "Extends the buyer object with per-purpose consent. Each purpose is keyed by a reverse-DNS identifier and carries the current `checked` state, the `source` of that state (business default or platform-captured buyer decision), a `description`, optional `links`, and optional `segments` for finer-grained channel, vendor, or program decisions scoped to that purpose.",
   "$defs": {
     "consent_purpose": {
       "type": "object",
-      "description": "A buyer's consent decision for a purpose (e.g., marketing, analytics). Carries the current consent state, human-readable context, and optional refinements scoping the decision to specific channels, vendors, or programs.",
-      "required": ["allowed", "description"],
+      "description": "A buyer's consent decision for a purpose (e.g., marketing, analytics). Carries the current binary state, its source (business default or platform-captured buyer decision), human-readable context, and optional refinements scoping the decision to specific channels, vendors, or programs.",
+      "required": ["checked", "source", "description"],
       "additionalProperties": false,
       "properties": {
-        "allowed": {
+        "checked": {
           "type": "boolean",
-          "description": "Current consent state for this decision."
+          "description": "Current binary state of this consent decision. The protocol carries only the binary state; the operational meaning of `true` vs `false` (e.g., consent granted or denied) is defined by the consent context, not by this field."
+        },
+        "source": {
+          "type": "string",
+          "enum": ["business", "platform"],
+          "description": "Identifies the party that asserted the current `checked` value. `business` means the value reflects the business's default policy; `platform` means the value reflects an explicit buyer decision captured by the platform."
         },
         "description": {
           "type": "string",
@@ -37,13 +42,18 @@
     },
     "consent_segment": {
       "type": "object",
-      "description": "A buyer's consent decision for a specific refinement of a parent purpose (e.g., email marketing under the marketing purpose). Overrides the parent's consent state for this scope. Segments do not nest further.",
-      "required": ["allowed", "description"],
+      "description": "A buyer's consent decision for a specific refinement of a parent purpose (e.g., email marketing under the marketing purpose). Overrides the parent's `checked` value for this scope. Segments do not nest further.",
+      "required": ["checked", "source", "description"],
       "additionalProperties": false,
       "properties": {
-        "allowed": {
+        "checked": {
           "type": "boolean",
-          "description": "Current consent state for this decision, overriding the parent purpose's value for this specific scope."
+          "description": "Current binary state for this segment, overriding the parent purpose's `checked` value for this specific scope."
+        },
+        "source": {
+          "type": "string",
+          "enum": ["business", "platform"],
+          "description": "Identifies the party that asserted the current `checked` value for this segment. `business` means the value reflects the business's default policy; `platform` means the value reflects an explicit buyer decision captured by the platform."
         },
         "description": {
           "type": "string",

--- a/source/schemas/shopping/buyer_consent.json
+++ b/source/schemas/shopping/buyer_consent.json
@@ -3,43 +3,99 @@
   "$id": "https://ucp.dev/schemas/shopping/buyer_consent.json",
   "name": "dev.ucp.shopping.buyer_consent",
   "title": "Buyer Consent Extension",
-  "description": "Extends Checkout with buyer consent tracking for privacy compliance via the buyer object.",
+  "description": "Extends the buyer object with per-purpose consent. Each purpose is keyed by a reverse-DNS identifier and carries an `allowed` state, a `description`, optional `links`, and optional `segments` for finer-grained channel, vendor, or program decisions scoped to that purpose.",
   "$defs": {
-    "consent": {
+    "consent_purpose": {
       "type": "object",
-      "description": "User consent states for data processing",
+      "description": "A buyer's consent decision for a purpose (e.g., marketing, analytics). Carries the current consent state, human-readable context, and optional refinements scoping the decision to specific channels, vendors, or programs.",
+      "required": ["allowed", "description"],
+      "additionalProperties": false,
       "properties": {
-        "analytics": {
+        "allowed": {
           "type": "boolean",
-          "description": "Consent for analytics and performance tracking."
+          "description": "Current consent state for this decision."
         },
-        "preferences": {
-          "type": "boolean",
-          "description": "Consent for storing user preferences."
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what the buyer is consenting to (e.g., 'Promotional communications across all channels').",
+          "ucp_request": "omit",
+          "ucp_response": "required"
         },
-        "marketing": {
-          "type": "boolean",
-          "description": "Consent for marketing communications."
+        "links": {
+          "type": "array",
+          "items": { "$ref": "../common/types/link.json" },
+          "description": "Optional links providing context (e.g., privacy policy, terms).",
+          "ucp_request": "omit"
         },
-        "sale_of_data": {
-          "type": "boolean",
-          "description": "Consent for selling data to third parties (CCPA)."
+        "segments": {
+          "type": "object",
+          "description": "Optional refinements scoping this purpose to specific channels, vendors, or programs. Keys are reverse-DNS identifiers. UCP currently defines two well-known segment identifiers under `dev.ucp.consent.marketing`: `dev.ucp.consent.marketing.email`, `dev.ucp.consent.marketing.sms`. Other segments follow vendor or merchant reverse-DNS conventions.",
+          "propertyNames": { "$ref": "../common/types/reverse_domain_name.json" },
+          "additionalProperties": { "$ref": "#/$defs/consent_segment" }
         }
       }
     },
+    "consent_segment": {
+      "type": "object",
+      "description": "A buyer's consent decision for a specific refinement of a parent purpose (e.g., email marketing under the marketing purpose). Overrides the parent's consent state for this scope. Segments do not nest further.",
+      "required": ["allowed", "description"],
+      "additionalProperties": false,
+      "properties": {
+        "allowed": {
+          "type": "boolean",
+          "description": "Current consent state for this decision, overriding the parent purpose's value for this specific scope."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what the buyer is consenting to within this segment (e.g., 'Promotional emails and exclusive offers').",
+          "ucp_request": "omit",
+          "ucp_response": "required"
+        },
+        "links": {
+          "type": "array",
+          "items": { "$ref": "../common/types/link.json" },
+          "description": "Optional segment-specific links (e.g., channel terms or privacy disclosures).",
+          "ucp_request": "omit"
+        }
+      }
+    },
+    "consent": {
+      "type": "object",
+      "description": "Per-purpose consent. Keys are reverse-DNS purpose identifiers. UCP defines four well-known purposes: `dev.ucp.consent.marketing`, `dev.ucp.consent.analytics`, `dev.ucp.consent.preferences`, `dev.ucp.consent.sale_or_sharing`. Vendors and merchants may define additional purposes under their own reverse-DNS namespace.",
+      "propertyNames": { "$ref": "../common/types/reverse_domain_name.json" },
+      "additionalProperties": { "$ref": "#/$defs/consent_purpose" }
+    },
     "buyer": {
       "title": "Buyer with Consent",
-      "description": "Buyer object extended with consent tracking.",
+      "description": "Buyer object extended with per-purpose consent.",
       "allOf": [
-        {
-          "$ref": "types/buyer.json"
-        },
+        { "$ref": "types/buyer.json" },
         {
           "type": "object",
           "properties": {
             "consent": {
               "$ref": "#/$defs/consent",
-              "description": "Consent tracking fields."
+              "description": "Per-purpose consent decisions and business-advertised consent options."
+            }
+          }
+        }
+      ]
+    },
+    "dev.ucp.shopping.cart": {
+      "title": "Cart with Buyer Consent",
+      "description": "Cart extended with buyer consent.",
+      "allOf": [
+        { "$ref": "cart.json" },
+        {
+          "type": "object",
+          "properties": {
+            "buyer": {
+              "$ref": "#/$defs/buyer",
+              "description": "Buyer with consent tracking.",
+              "ucp_request": {
+                "create": "optional",
+                "update": "optional"
+              }
             }
           }
         }
@@ -47,11 +103,9 @@
     },
     "dev.ucp.shopping.checkout": {
       "title": "Checkout with Buyer Consent",
-      "description": "Checkout extended with consent tracking via buyer object.",
+      "description": "Checkout extended with buyer consent.",
       "allOf": [
-        {
-          "$ref": "checkout.json"
-        },
+        { "$ref": "checkout.json" },
         {
           "type": "object",
           "properties": {
@@ -61,7 +115,7 @@
               "ucp_request": {
                 "create": "optional",
                 "update": "optional",
-                "complete": "omit"
+                "complete": "optional"
               }
             }
           }

--- a/source/schemas/shopping/buyer_consent.json
+++ b/source/schemas/shopping/buyer_consent.json
@@ -3,21 +3,21 @@
   "$id": "https://ucp.dev/schemas/shopping/buyer_consent.json",
   "name": "dev.ucp.shopping.buyer_consent",
   "title": "Buyer Consent Extension",
-  "description": "Extends the buyer object with per-purpose consent. Each purpose is keyed by a reverse-DNS identifier and carries the current `checked` state, the `source` of that state (business default or platform-captured buyer decision), a `description`, optional `links`, and optional `segments` for finer-grained channel, vendor, or program decisions scoped to that purpose.",
+  "description": "Extends the buyer object with per-purpose consent. Each purpose is keyed by a reverse-DNS identifier and carries the current `granted` state, the `source` of that state (business default or platform-captured buyer decision), a `description`, optional `links`, and optional `segments` for finer-grained channel, vendor, or program decisions scoped to that purpose.",
   "$defs": {
     "consent_purpose": {
       "type": "object",
       "description": "A buyer's consent decision for a purpose (e.g., marketing, analytics). Carries the current binary state, its source (business default or platform-captured buyer decision), human-readable context, and optional refinements scoping the decision to specific channels, vendors, or programs.",
-      "required": ["checked", "source", "description"],
+      "required": ["granted", "source", "description"],
       "properties": {
-        "checked": {
+        "granted": {
           "type": "boolean",
-          "description": "Current binary state of this consent decision. The protocol carries only the binary state; the operational meaning of `true` vs `false` (e.g., consent granted or denied) is defined by the consent context, not by this field."
+          "description": "Whether consent has been granted for this purpose. The `source` field identifies who asserted this state (business default or platform-captured buyer preference)."
         },
         "source": {
           "type": "string",
           "enum": ["business", "platform"],
-          "description": "Identifies the party that asserted the current `checked` value. `business` means the value reflects the business's default policy; `platform` means the value reflects an explicit buyer decision captured by the platform."
+          "description": "Identifies the party that asserted the current `granted` value. `business` means the value reflects the business's default policy; `platform` means the value reflects an explicit buyer decision captured by the platform."
         },
         "description": {
           "type": "string",
@@ -41,17 +41,17 @@
     },
     "consent_segment": {
       "type": "object",
-      "description": "A buyer's consent decision for a specific refinement of a parent purpose (e.g., email marketing under the marketing purpose). Overrides the parent's `checked` value for this scope. Segments do not nest further.",
-      "required": ["checked", "source", "description"],
+      "description": "A buyer's consent decision for a specific refinement of a parent purpose (e.g., email marketing under the marketing purpose). Overrides the parent's `granted` value for this scope. Segments do not nest further.",
+      "required": ["granted", "source", "description"],
       "properties": {
-        "checked": {
+        "granted": {
           "type": "boolean",
-          "description": "Current binary state for this segment, overriding the parent purpose's `checked` value for this specific scope."
+          "description": "Whether consent has been granted for this segment. Overrides the parent purpose's `granted` value for this specific scope."
         },
         "source": {
           "type": "string",
           "enum": ["business", "platform"],
-          "description": "Identifies the party that asserted the current `checked` value for this segment. `business` means the value reflects the business's default policy; `platform` means the value reflects an explicit buyer decision captured by the platform."
+          "description": "Identifies the party that asserted the current `granted` value for this segment. `business` means the value reflects the business's default policy; `platform` means the value reflects an explicit buyer decision captured by the platform."
         },
         "description": {
           "type": "string",

--- a/source/schemas/shopping/buyer_consent.json
+++ b/source/schemas/shopping/buyer_consent.json
@@ -9,7 +9,6 @@
       "type": "object",
       "description": "A buyer's consent decision for a purpose (e.g., marketing, analytics). Carries the current binary state, its source (business default or platform-captured buyer decision), human-readable context, and optional refinements scoping the decision to specific channels, vendors, or programs.",
       "required": ["checked", "source", "description"],
-      "additionalProperties": false,
       "properties": {
         "checked": {
           "type": "boolean",
@@ -44,7 +43,6 @@
       "type": "object",
       "description": "A buyer's consent decision for a specific refinement of a parent purpose (e.g., email marketing under the marketing purpose). Overrides the parent's `checked` value for this scope. Segments do not nest further.",
       "required": ["checked", "source", "description"],
-      "additionalProperties": false,
       "properties": {
         "checked": {
           "type": "boolean",


### PR DESCRIPTION
Evolves the `buyer_consent` extension to support per-purpose and per-segment consent capture under a uniform object shape. Each consent decision carries the current `granted` state, the `source` identifying who asserted it (business default vs. platform-captured buyer preference), and human-readable context — keyed by reverse-DNS identifiers at both purpose and segment levels. This generalizes the per-channel consent capture explored in #407 into a primitive that supports open extensibility for purposes and segments without further schema changes.

Businesses advertise the current state of every supported consent option in cart/checkout responses:

```json
"buyer": {
  "consent": {
    "dev.ucp.consent.marketing": {
      "granted": false,
      "source": "business",
      "description": "Promotional communications across all channels",
      "links": [{ "type": "privacy_policy", "url": "https://example.com/privacy" }],
      "segments": {
        "dev.ucp.consent.marketing.email": {
          "granted": true,
          "source": "platform",
          "description": "Promotional emails and exclusive offers"
        },
        "dev.ucp.consent.marketing.sms": {
          "granted": false,
          "source": "business",
          "description": "Marketing text messages"
        }
      }
    },
    "dev.ucp.consent.analytics": {
      "granted": true,
      "source": "business",
      "description": "Site analytics and performance measurement"
    }
  }
}
```

This is a breaking change: the wire shape and field names differ from the prior `allowed` boolean. `granted` is a past-participle state-adjective ("consent is granted") that reads correctly in all four `{state × source}` combinations: business defaults and platform-captured buyer preferences alike. The `source` field carries causation; `granted` carries the state.

The same map shape carries both directions:

| Direction | Who populates | Fields populated |
| --- | --- | --- |
| **Advertise** (response) | Business | `granted`, `source`, `description`; optional `links` and `segments` |
| **Confirm** (request) | Platform | `granted`, `source`; `segments` when present |

Platforms submit the current state of every advertised purpose and segment back to the business:

```json
"buyer": {
  "consent": {
    "dev.ucp.consent.marketing": {
      "granted": true,
      "source": "platform",
      "segments": {
        "dev.ucp.consent.marketing.email": { "granted": true, "source": "platform" },
        "dev.ucp.consent.marketing.sms":   { "granted": true, "source": "platform" }
      }
    },
    "dev.ucp.consent.analytics": { "granted": true, "source": "business" }
  }
}
```

Per-purpose/segment data requirements (e.g., SMS marketing needs `buyer.phone_number`) are business-specific and not enforced by UCP. Missing dependencies surface via the standard message pattern with asymmetric severity: `warning` on cart/checkout `create`/`update`, `error` on `complete_checkout` (the business MUST NOT transition to `completed` while consent data dependencies are unmet).

```json
{
  "messages": [
    {
      "type": "warning",
      "code": "missing_consent_data",
      "content": "Phone number is required for SMS marketing.",
      "path": "$.buyer.phone_number"
    }
  ]
}
```

---

## Checklist

- [x] **Capability**: New schemas (Discovery, Cart, etc.) or extensions.
- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
