### PR TITLE
style: increase Amadeus logo prominence in lodging section

### DIFF
--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -310,7 +310,10 @@ p.hero-description {
   max-height: 45px;
 }
 
-.partner-logo img[src*="Amadeus"],
+.partner-logo img[src*="Amadeus"] {
+  max-height: 62px;
+}
+
 .partner-logo img[src*="Block"],
 .partner-logo img[src*="Booking"],
 .partner-logo img[src*="Choice"],
@@ -358,6 +361,12 @@ p.hero-description {
   padding: 0;
 }
 
+.lodging-logos .partner-logo img[src*="Amadeus"] {
+  height: 60px;
+  width: 170px;
+  max-width: 170px;
+}
+
 .tab-action-container {
   text-align: center;
   margin-top: 24px;
@@ -395,9 +404,11 @@ p.hero-description {
     height: 30px;
   }
 
-  /* Specific override for Amadeus to make it smaller */
+  /* Make Amadeus more prominent in Lodging */
   .lodging-logos .partner-logo img[src*="Amadeus"] {
-    height: 25px;
+    height: 60px;
+    width: 170px;
+    max-width: 170px;
   }
 
   /* Increase Google slightly in Lodging */


### PR DESCRIPTION
# Description

This pull request adjusts partner logo styling in the Lodging tab so the Amadeus logo has visual parity with the surrounding logos.

### What changed
- Split Amadeus out of the shared small-logo sizing selector.
- Kept the general Amadeus max-height override.
- Added an explicit Lodging-specific Amadeus size override for desktop.
- Updated the Lodging mobile override so Amadeus is no longer reduced.

### Files changed
- `docs/stylesheets/custom.css`

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [ ] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

<!-- If applicable, add screenshots or log output to help explain your changes. For any edits to the rendering of UCP.dev content, a screenshot is appreciated; for fixes, a before/after comparison is especially helpful for reviewers. -->

BEFORE:
<img width="958" height="420" alt="image" src="https://github.com/user-attachments/assets/cca3e611-1721-4869-b55d-869bf58aa451" />

AFTER:
<img width="1488" height="608" alt="image" src="https://github.com/user-attachments/assets/791f46dd-340c-4b5c-b163-0f30f09fae5a" />



