### PR TITLE
fix: declare standard signature headers on get_order 200 response

### DIFF
--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -673,6 +673,11 @@
         "responses": {
           "200": {
             "description": "Order retrieved or business outcome message",
+            "headers": {
+              "Signature": { "$ref": "#/components/headers/signature" },
+              "Signature-Input": { "$ref": "#/components/headers/signature_input" },
+              "Content-Digest": { "$ref": "#/components/headers/content_digest" }
+            },
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/order_response" }


### PR DESCRIPTION
## Summary

- Adds `Signature`, `Signature-Input`, and `Content-Digest` response headers to the `get_order` (`GET /orders/{id}`) operation in `source/services/shopping/rest.openapi.json`.
- Every other REST operation in this spec (`get_checkout`, `complete_checkout`, `create_checkout`, `update_checkout`, `cancel_checkout`, `get_cart`, `create_cart`, `update_cart`, `cancel_cart`, `catalog_search`, `catalog_lookup`, `get_product`) already declares this same block — `get_order` was the only one missing it.

## Why

Without these declared on the operation, OpenAPI generators (openapi-generator, Kiota, Orval, etc.) won't surface signature headers in typed `get_order` responses, forcing consumers to drop to raw HTTP. Order responses are at least as sensitive as the reads that already declare these headers (financial amounts, payment status, PII, downstream refunds/disputes), and `signatures.md` recommends signing payment-authorization / checkout-completion responses — orders being the durable result of checkout completion.

Closes #364

## Test plan

- [x] `python -m json.tool source/services/shopping/rest.openapi.json` parses cleanly
- [x] Diff is a single 5-line addition; no other operations touched
- [x] Block matches the format used by adjacent operations (`get_product`, `catalog_lookup`)