### PR TITLE
docs(cart): correct invalid UCP version in error response examples

### DIFF
--- a/docs/specification/cart-mcp.md
+++ b/docs/specification/cart-mcp.md
@@ -231,7 +231,7 @@ Maps to the [Create Cart](cart.md#create-cart) operation.
       "id": 1,
       "result": {
         "structuredContent": {
-          "ucp": { "version": "2026-01-15", "status": "error" },
+          "ucp": { "version": "2026-04-08", "status": "error" },
           "messages": [
             {
               "type": "error",

--- a/docs/specification/cart-mcp.md
+++ b/docs/specification/cart-mcp.md
@@ -231,7 +231,7 @@ Maps to the [Create Cart](cart.md#create-cart) operation.
       "id": 1,
       "result": {
         "structuredContent": {
-          "ucp": { "version": "2026-04-08", "status": "error" },
+          "ucp": { "version": "{{ ucp_version }}", "status": "error" },
           "messages": [
             {
               "type": "error",

--- a/docs/specification/cart-rest.md
+++ b/docs/specification/cart-rest.md
@@ -184,7 +184,7 @@ All REST endpoints **MUST** be served over HTTPS with minimum TLS version 1.3.
     Content-Type: application/json
 
     {
-      "ucp": { "version": "2026-04-08", "status": "error" },
+      "ucp": { "version": "{{ ucp_version }}", "status": "error" },
       "messages": [
         {
           "type": "error",

--- a/docs/specification/cart-rest.md
+++ b/docs/specification/cart-rest.md
@@ -184,7 +184,7 @@ All REST endpoints **MUST** be served over HTTPS with minimum TLS version 1.3.
     Content-Type: application/json
 
     {
-      "ucp": { "version": "2026-01-15", "status": "error" },
+      "ucp": { "version": "2026-04-08", "status": "error" },
       "messages": [
         {
           "type": "error",

--- a/docs/specification/cart.md
+++ b/docs/specification/cart.md
@@ -149,7 +149,7 @@ indicator:
 <!-- ucp:example schema=common/types/error_response op=read -->
 ```json
 {
-  "ucp": { "version": "2026-01-15", "status": "error" },
+  "ucp": { "version": "2026-04-08", "status": "error" },
   "messages": [
     {
       "type": "error",

--- a/docs/specification/cart.md
+++ b/docs/specification/cart.md
@@ -149,7 +149,7 @@ indicator:
 <!-- ucp:example schema=common/types/error_response op=read -->
 ```json
 {
-  "ucp": { "version": "2026-04-08", "status": "error" },
+  "ucp": { "version": "{{ ucp_version }}", "status": "error" },
   "messages": [
     {
       "type": "error",


### PR DESCRIPTION
## Summary

The error response examples in three cart docs reference `\"version\": \"2026-01-15\"`, which does not correspond to any published UCP release. This PR replaces the invalid version with `2026-04-08` — the actual first release that included the cart capability.

**Files changed (1 line each, identical change):**
- `docs/specification/cart.md` L152
- `docs/specification/cart-rest.md` L187
- `docs/specification/cart-mcp.md` L234

## Why

Published UCP releases (`git tag -l`): `v2026-01-11`, `v2026-01-23`, `v2026-04-08`. `2026-01-15` is not among them — the date appears to be a typo or stale placeholder that has shipped in the official `release/2026-04-08` docs (verified via `git show upstream/release/2026-04-08:docs/specification/cart.md`).

The cart capability did **not** exist in the `2026-01-11` or `2026-01-23` release branches (`docs/specification/cart.md` is absent there). It was first introduced in `release/2026-04-08`, so anchoring the error examples to that version is the correct semantic.

This matches the pattern used by other capability docs that ship with static error examples — the checkout family (`checkout.md`, `checkout-rest.md`, `checkout-mcp.md`) anchors equivalent examples to `2026-01-11` because checkout shipped in that release.

## Test plan

- [x] `grep -rn 2026-01-15 docs/specification` returns only an unrelated timestamp in `order.md:491` after the change
- [x] All three replaced values are identical (`2026-04-08`)
- [x] Diff is exactly +3/-3, scoped to error response examples only
- [x] `2026-04-08` is verifiably a real release (`git tag -l v2026-04-08`)