### PR TITLE
Replacing Google TC member 

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,10 +22,10 @@ The Tech Council is responsible for the technical direction and overall
 design of the protocol.
 
 <!-- cSpell:ignore Amit Handa Anurag Sinha Daniel Wyckoff Drew Olson -->
-<!-- cSpell:ignore Greg Smith Ilya Grigorik Imran Hoosain Lee Richmond -->
-<!-- cSpell:ignore James Andersen Maxime Najim Najim Naga Malepati -->
-<!-- cSpell:ignore Patrick Jordan Prasad Wangikar Scot DeDeo -->
-<!-- cSpell:ignore Twum Djin Venu Vemula Victoria Duggan -->
+<!-- cSpell:ignore Greg Smith Ilya Grigorik Imran Hoosain James Andersen -->
+<!-- cSpell:ignore Jing Li Lee Richmond Maxime Najim Naga Malepati -->
+<!-- cSpell:ignore Patrick Jordan Prasad Wangikar Scot DeDeo Twum Djin -->
+<!-- cSpell:ignore Victoria Duggan -->
 | Name | Company |
 | :--- | :--- |
 | Amit Handa | Google |
@@ -36,13 +36,13 @@ design of the protocol.
 | Ilya Grigorik | Shopify |
 | Imran Hoosain | Etsy |
 | James Andersen | Meta |
+| Jing Li | Google |
 | Lee Richmond | Shopify |
 | Maxime Najim | Target |
 | Naga Malepati | Wayfair |
 | Patrick Jordan | Microsoft |
 | Prasad Wangikar | Stripe |
 | Scot DeDeo | Salesforce |
-| Venu Vemula | Google |
 | Victoria Duggan | Shopify |
 
 ## Governance Council


### PR DESCRIPTION
# Description
This PR updates the Tech Council roster in `MAINTAINERS.md` to replace Venu Vemula with Jing Li for Google. 


## Category (Required)
_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [x] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues
## Checklist
- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.