### PR TITLE
feat: define recipient-required gift checkout

### DIFF
--- a/docs/specification/gift.md
+++ b/docs/specification/gift.md
@@ -1,0 +1,246 @@
+<!--
+   Copyright 2026 UCP Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# Gift Extension
+
+## Overview
+
+The Gift extension represents a buyer-paid purchase for another person. The
+buyer selects and pays for the product, while the recipient is selected and
+validated by the Business.
+
+Gift purchases differ from ordinary checkout because the buyer and recipient
+are distinct participants. A recipient is not necessarily a fulfillment
+destination: the Business may manage recipient selection, recipient acceptance,
+and delivery details in its own experience.
+
+The extension exposes only the information needed for an agent or platform to
+continue the checkout and address the buyer's selected recipient. It does not
+expose a friend graph, contact book, address book, recipient identifier, or
+recipient-selection credential.
+
+## Scope
+
+This version extends Checkout only. It supports a buyer who has selected a
+product and wants to send it as a gift. The Business may require the buyer to
+select a recipient in its own checkout experience before checkout can complete.
+
+This version does not define a recipient-selection API. The Business owns the
+recipient selection and stores its result as private Checkout-bound state. The
+Platform never submits, stores, or reuses a recipient identifier or selection
+credential.
+
+## Data Boundaries
+
+| Data | Owner | UCP visibility |
+| --- | --- | --- |
+| Recipient display name | Business | Buyer-facing display value |
+| Recipient selection state | Business | Checkout status and optional display value only |
+| Friend graph, contact details, address | Business | Never exposed by this extension |
+| Recipient eligibility and acceptance | Business | Reflected only through normal Checkout state and messages |
+
+The Business remains authoritative for recipient identity and for whether a
+recipient is eligible for the selected gift. The Platform MUST NOT infer a
+recipient identity from the display value or use it as an authorization
+credential.
+
+## Discovery
+
+Businesses advertise Gift support alongside Checkout:
+
+<!-- ucp:example schema=profile def=business_schema extract=$.ucp.capabilities target=$.ucp.capabilities -->
+```json
+{
+  "ucp": {
+    "version": "{{ ucp_version }}",
+    "capabilities": {
+      "dev.ucp.shopping.checkout": [
+        {
+          "version": "{{ ucp_version }}",
+          "schema": "https://ucp.dev/{{ ucp_version }}/schemas/shopping/checkout.json"
+        }
+      ],
+      "dev.ucp.shopping.gift": [
+        {
+          "version": "{{ ucp_version }}",
+          "extends": "dev.ucp.shopping.checkout",
+          "spec": "https://ucp.dev/{{ ucp_version }}/specification/gift",
+          "schema": "https://ucp.dev/{{ ucp_version }}/schemas/shopping/gift.json"
+        }
+      ]
+    }
+  }
+}
+```
+
+Platforms MUST negotiate both Checkout and Gift before sending `gift` data.
+
+## Schema
+
+When this extension is active, Checkout gains an optional top-level `gift`
+object. An empty `gift` object is a no-op. A recipient-based gift checkout is
+requested only by `gift.recipient_required: true`.
+
+### Gift Object
+
+{{ extension_schema_fields('gift.json#/$defs/gift', 'gift') }}
+
+### Recipient
+
+{{ extension_schema_fields('gift.json#/$defs/recipient', 'gift') }}
+
+### Recipient Display
+
+{{ extension_schema_fields('gift.json#/$defs/recipient_display', 'gift') }}
+
+`recipient_required: true` means that a selected, eligible recipient is a
+precondition for Complete Checkout. It does not prescribe the recipient
+selection UI: the Business may collect the input in its own experience, or use
+an applicable UCP interaction mechanism.
+
+`recipient` is response-only. Its `display.name` is a merchant-approved
+buyer-facing name or relationship name, such as `Mom`; it is not necessarily a
+legal or account name, verified identity, or authorization credential.
+
+## Checkout Flow
+
+### Start Gift Checkout
+
+The Platform requests a recipient-based gift checkout when the buyer chose a
+product but has not yet selected a recipient.
+
+<!-- ucp:example schema=shopping/gift def=gift op=create direction=request extract=$.gift -->
+```json
+{
+  "gift": {
+    "recipient_required": true
+  }
+}
+```
+
+If recipient selection is required, the Business uses the ordinary Checkout
+handoff flow.
+
+<!-- ucp:example schema=shopping/gift def=gift extract=$.gift -->
+```json
+{
+  "status": "requires_escalation",
+  "messages": [
+    {
+      "type": "error",
+      "code": "recipient_selection_required",
+      "content": "Select a recipient before completing this gift checkout.",
+      "severity": "requires_buyer_input",
+      "path": "$.gift"
+    }
+  ],
+  "continue_url": "https://business.example.com/checkout-sessions/chk_123",
+  "gift": {
+    "recipient_required": true
+  }
+}
+```
+
+The Platform opens `continue_url` for the buyer. The Business stores the
+recipient selection and its authorization as private state bound to the
+Checkout session. Returning from this experience does not itself prove that a
+recipient was selected; the Platform uses Get Checkout to read the
+authoritative Checkout status.
+
+### Read a Selected Recipient
+
+After the buyer returns from the Business experience, the Platform uses Get
+Checkout to obtain the current checkout. When selection succeeds, the Business
+may return its buyer-facing presentation.
+
+<!-- ucp:example schema=shopping/gift def=recipient extract=$.gift.recipient -->
+```json
+{
+  "status": "ready_for_complete",
+  "gift": {
+    "recipient_required": true,
+    "recipient": {
+      "display": {
+        "name": "Mom"
+      }
+    }
+  }
+}
+```
+
+The Platform MAY use `display.name` when speaking to the buyer, for example:
+"This cake will be sent to Mom." It MUST use the latest Checkout response and
+MUST NOT treat the display name as an independently verified identity.
+
+### Update Gift Checkout
+
+For this extension, Update replaces the Platform-writable Gift request state.
+To retain recipient-based gifting, the Platform MUST include
+`recipient_required: true` again. Omitting `gift` or `recipient_required`
+removes Gift request state; the Business MUST clear its private recipient
+selection.
+
+<!-- ucp:example schema=shopping/gift def=gift op=update direction=request extract=$.gift -->
+```json
+{
+  "gift": {
+    "recipient_required": true
+  }
+}
+```
+
+When the request retains Gift state, the Business MUST atomically revalidate an
+existing recipient selection against the resulting Checkout and current
+authorization. It MAY retain a valid selection; otherwise it MUST clear the
+selection and return the normal `requires_escalation` handoff flow. The
+Platform MUST NOT send recipient data back to the Business.
+
+`gift` data is omitted from Complete Checkout requests. Immediately before
+accepting Complete Checkout, the Business MUST atomically verify that a
+recipient selection exists, remains authorized and eligible, and matches the
+current Checkout. If that verification fails, the Business MUST produce no
+payment or order effect and MUST return the appropriate Checkout state. Before
+returning `complete_in_progress`, the Business MUST freeze or reserve the
+recipient state needed to make completion unambiguous.
+
+## Privacy and Security
+
+The Business MUST NOT expose raw friend lists, contact details, address-book
+entries, delivery addresses, or an identifier or credential that a Platform can
+resolve outside the Business. A Platform MUST NOT use `recipient.display.name`
+to construct a cross-Business recipient profile or to infer information beyond
+the display value the Business returned.
+
+The Business MUST clear a recipient selection when Gift request state is
+removed, the Checkout is canceled or expires, the buyer selects a different
+recipient, or the Business revokes the selection. Selection MUST NOT outlive
+the Checkout's `expires_at`.
+
+Missing, expired, revoked, unauthorized, or ineligible selection
+normally requires the same generic recipient-selection handoff: a
+`requires_escalation` Checkout with a `requires_buyer_input` message and
+`continue_url`. The Business MUST NOT expose distinguishable recipient errors
+that let a Platform enumerate recipient state.
+
+## Out of Scope
+
+This version does not define:
+
+* recipient-first catalog search or cart flows,
+* raw recipient identity, contact data, or selection credentials,
+* multiple recipients in one checkout,
+* gift messages, card artwork, recipient acceptance, or scheduled gifting, or
+* recipient data in Order resources or events.

--- a/docs/specification/gift.md
+++ b/docs/specification/gift.md
@@ -19,17 +19,16 @@
 ## Overview
 
 The Gift extension supports a buyer-paid purchase for another person. The
-buyer selects and pays for the product. The Business selects and validates the
-recipient.
+buyer selects and pays for the product, then selects a recipient. The Business
+validates that selection.
 
 Gift purchases differ from ordinary checkout because the buyer and recipient
 are distinct participants. A recipient is not necessarily a fulfillment
 destination: the Business may manage recipient selection, recipient acceptance,
 and delivery details in its own experience.
 
-The extension gives the Platform only what it needs to continue checkout and
-refer to the selected recipient. It does not expose a friend graph, contact
-book, address book, recipient identifier, or selection credential.
+The extension does not expose a friend graph, contact book, address book,
+recipient identifier, or selection credential.
 
 ## Scope
 
@@ -88,9 +87,9 @@ Platforms MUST negotiate both Checkout and Gift before sending `gift` data.
 
 ## Authentication and Identity Linking
 
-Gift does not define a login flow or require Identity Linking. A Business can
-sign in the buyer while they select a recipient. It can require authentication
-for Checkout operations through the existing
+Gift does not define a login flow or require Identity Linking. The buyer may
+sign in to the Business while selecting a recipient. The Business can require
+authentication for Checkout operations through the existing
 [Identity Linking](identity-linking.md) capability and its
 `dev.ucp.shopping.checkout:manage` scope.
 

--- a/docs/specification/gift.md
+++ b/docs/specification/gift.md
@@ -18,36 +18,34 @@
 
 ## Overview
 
-The Gift extension represents a buyer-paid purchase for another person. The
-buyer selects and pays for the product, while the recipient is selected and
-validated by the Business.
+The Gift extension supports a buyer-paid purchase for another person. The
+buyer selects and pays for the product. The Business selects and validates the
+recipient.
 
 Gift purchases differ from ordinary checkout because the buyer and recipient
 are distinct participants. A recipient is not necessarily a fulfillment
 destination: the Business may manage recipient selection, recipient acceptance,
 and delivery details in its own experience.
 
-The extension exposes only the information needed for an agent or platform to
-continue the checkout and address the buyer's selected recipient. It does not
-expose a friend graph, contact book, address book, recipient identifier, or
-recipient-selection credential.
+The extension gives the Platform only what it needs to continue checkout and
+refer to the selected recipient. It does not expose a friend graph, contact
+book, address book, recipient identifier, or selection credential.
 
 ## Scope
 
-This version extends Checkout only. It supports a buyer who has selected a
-product and wants to send it as a gift. The Business may require the buyer to
-select a recipient in its own checkout experience before checkout can complete.
+Gift extends Checkout. It starts after a buyer selects a product and decides to
+send it as a gift. The Business may require the buyer to select a recipient in
+its own checkout experience before it completes checkout.
 
-This version does not define a recipient-selection API. The Business owns the
-recipient selection and stores its result as private Checkout-bound state. The
-Platform never submits, stores, or reuses a recipient identifier or selection
-credential.
+Gift does not define a recipient-selection API. The Business owns the selection
+and keeps it as private state for that Checkout. The Platform never submits,
+stores, or reuses a recipient identifier or selection credential.
 
 ## Data Boundaries
 
 | Data | Owner | UCP visibility |
 | --- | --- | --- |
-| Recipient display name | Business | Buyer-facing display value |
+| Recipient display name | Business | Buyer-facing display value, only on a user-authenticated and authorized Checkout response |
 | Recipient selection state | Business | Checkout status and optional display value only |
 | Friend graph, contact details, address | Business | Never exposed by this extension |
 | Recipient eligibility and acceptance | Business | Reflected only through normal Checkout state and messages |
@@ -87,6 +85,24 @@ Businesses advertise Gift support alongside Checkout:
 ```
 
 Platforms MUST negotiate both Checkout and Gift before sending `gift` data.
+
+## Authentication and Identity Linking
+
+Gift does not define a login flow or require Identity Linking. A Business can
+sign in the buyer while they select a recipient. It can require authentication
+for Checkout operations through the existing
+[Identity Linking](identity-linking.md) capability and its
+`dev.ucp.shopping.checkout:manage` scope.
+
+The Business MUST NOT return `gift.recipient` unless the Checkout request is
+user-authenticated and authorized for the operation. It MUST ensure that the
+recipient selection belongs to the authenticated buyer and the current
+Checkout. A Business session created through `continue_url` does not by itself
+authenticate the Platform's UCP requests.
+
+An unauthenticated Checkout response may show Checkout status and generic
+messages, but MUST omit `gift.recipient`. The Platform can tell the buyer that
+a recipient was selected, but not who it was.
 
 ## Schema
 
@@ -164,7 +180,8 @@ authoritative Checkout status.
 
 After the buyer returns from the Business experience, the Platform uses Get
 Checkout to obtain the current checkout. When selection succeeds, the Business
-may return its buyer-facing presentation.
+may return its buyer-facing presentation only on a user-authenticated and
+authorized request.
 
 <!-- ucp:example schema=shopping/gift def=recipient extract=$.gift.recipient -->
 ```json

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -324,9 +324,8 @@ plugins:
               Fulfillment extension for checkouts, defining delivery methods,
               pickup destinations, and method-agnostic UI rendering contracts.
           - specification/gift.md: >-
-              Gift Extension for recipient-based checkout, defining
-              recipient-required checkout and privacy-preserving checkout
-              handoff and resumption.
+              Gift Extension for Checkout, defining recipient-required gift
+              purchases.
           - specification/loyalty.md: >-
               Loyalty Extension, enabling high-fidelity member benefit recognition
               during catalog, cart, and checkout by defining schemas for

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
           - Buyer Consent Extension: specification/buyer-consent.md
           - Discounts Extension: specification/discount.md
           - Fulfillment Extension: specification/fulfillment.md
+          - Gift Extension: specification/gift.md
           - Loyalty Extension: specification/loyalty.md
           - Split Payments Extension: specification/split-payments.md
       - Cart Capability:
@@ -322,6 +323,10 @@ plugins:
           - specification/fulfillment.md: >-
               Fulfillment extension for checkouts, defining delivery methods,
               pickup destinations, and method-agnostic UI rendering contracts.
+          - specification/gift.md: >-
+              Gift Extension for recipient-based checkout, defining
+              recipient-required checkout and privacy-preserving checkout
+              handoff and resumption.
           - specification/loyalty.md: >-
               Loyalty Extension, enabling high-fidelity member benefit recognition
               during catalog, cart, and checkout by defining schemas for

--- a/source/schemas/shopping/gift.json
+++ b/source/schemas/shopping/gift.json
@@ -13,7 +13,7 @@
   "$defs": {
     "recipient_display": {
       "type": "object",
-      "description": "Merchant-approved buyer-facing presentation of a selected recipient.",
+      "description": "Business-provided buyer-facing presentation of a selected recipient.",
       "required": ["name"],
       "properties": {
         "name": {

--- a/source/schemas/shopping/gift.json
+++ b/source/schemas/shopping/gift.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/gift.json",
+  "name": "dev.ucp.shopping.gift",
+  "title": "Gift Extension",
+  "description": "Extends Checkout with recipient-based gift purchases.",
+  "requires": {
+    "protocol": { "min": "2026-04-08" },
+    "capabilities": {
+      "dev.ucp.shopping.checkout": { "min": "2026-04-08" }
+    }
+  },
+  "$defs": {
+    "recipient_display": {
+      "type": "object",
+      "description": "Merchant-approved buyer-facing presentation of a selected recipient.",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Buyer-facing recipient name, relationship name, or other merchant-approved display value, such as 'Mom'."
+        }
+      }
+    },
+    "recipient": {
+      "type": "object",
+      "description": "Business-provided buyer-facing presentation of the recipient selected for a gift checkout. The Business remains authoritative for recipient identity, eligibility, and fulfillment details.",
+      "required": ["display"],
+      "properties": {
+        "display": {
+          "$ref": "#/$defs/recipient_display",
+          "description": "Buyer-facing presentation of the recipient, supplied by the Business. This is presentation data, not a verified identity or authorization credential.",
+          "ucp_request": "omit"
+        }
+      }
+    },
+    "gift": {
+      "type": "object",
+      "description": "Gift checkout context. An empty object is a no-op; recipient-based gifting is requested by `recipient_required: true`.",
+      "properties": {
+        "recipient_required": {
+          "type": "boolean",
+          "const": true,
+          "description": "When `true`, requests a recipient-based gift checkout. The Business MUST require a selected, eligible recipient before accepting Complete Checkout. This field does not prescribe how the Business collects recipient input."
+        },
+        "recipient": {
+          "$ref": "#/$defs/recipient",
+          "description": "The selected recipient's Business-provided presentation.",
+          "ucp_request": "omit"
+        }
+      }
+    },
+    "dev.ucp.shopping.checkout": {
+      "title": "Checkout with Gift",
+      "description": "Checkout extended with recipient-based gift support.",
+      "allOf": [
+        { "$ref": "checkout.json" },
+        {
+          "type": "object",
+          "properties": {
+            "gift": {
+              "$ref": "#/$defs/gift",
+              "description": "Gift context for this checkout.",
+              "ucp_request": {
+                "create": "optional",
+                "update": "optional",
+                "complete": "omit"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `dev.ucp.shopping.gift`, a Checkout extension for purchases sent to another person.

A Platform starts a gift checkout with:

```json
{
  "gift": {
    "recipient_required": true
  }
}
```

`gift: {}` has no effect. With `recipient_required: true`, the Business must have a selected, eligible recipient before it completes checkout. The buyer chooses the recipient; the Business validates the choice.

The Business keeps that choice as state for the Checkout. UCP does not carry recipient IDs, selection tokens, friend lists, contact data, or addresses. A user-authenticated Checkout response may include a buyer-facing recipient name.

## Flow

- If recipient selection needs buyer input, the Business returns `requires_escalation` and `continue_url`.
- The buyer can sign in and select a recipient in the Business experience. Returning from that page does not prove that selection succeeded; the Platform reads the Checkout again.
- An Update must include `recipient_required: true` to keep the Gift request. Omitting it clears the Business selection.
- Complete omits `gift`. The Business revalidates the recipient before it creates a payment or order.

## Authentication

Gift does not define a login flow. The buyer may sign in to the Business during recipient selection. If the Platform needs the recipient name, it uses the existing Identity Linking flow. Opening `continue_url` does not authenticate later UCP calls by itself.

## Not included

Recipient search, reusable recipient handles, multiple recipients, messages or cards, acceptance, scheduling, and recipient data in Orders or events are out of scope.