### PR TITLE
docs(checkout): add missing Discovery section to REST binding

### DIFF
--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -21,6 +21,41 @@ This document specifies the REST binding for the
 
 ## Protocol Fundamentals
 
+### Discovery
+
+Businesses advertise REST transport availability through their UCP profile at
+`/.well-known/ucp`.
+
+<!-- ucp:example schema=profile def=business_schema -->
+```json
+{
+  "ucp": {
+    "version": "{{ ucp_version }}",
+    "services": {
+      "dev.ucp.shopping": [
+        {
+          "version": "{{ ucp_version }}",
+          "spec": "https://ucp.dev/{{ ucp_version }}/specification/overview",
+          "transport": "rest",
+          "schema": "https://ucp.dev/{{ ucp_version }}/services/shopping/rest.openapi.json",
+          "endpoint": "https://business.example.com/ucp/v1"
+        }
+      ]
+    },
+    "capabilities": {
+      "dev.ucp.shopping.checkout": [
+        {
+          "version": "{{ ucp_version }}",
+          "spec": "https://ucp.dev/{{ ucp_version }}/specification/checkout",
+          "schema": "https://ucp.dev/{{ ucp_version }}/schemas/shopping/checkout.json"
+        }
+      ]
+    },
+    "payment_handlers": {}
+  }
+}
+```
+
 ### Base URL
 
 All UCP REST endpoints are relative to the business's base URL, which is


### PR DESCRIPTION
## Summary

Adds the missing `### Discovery` section to `docs/specification/checkout-rest.md`. Every other REST-binding spec page documents how the capability is advertised via the business's UCP profile at `/.well-known/ucp` — checkout was the only one without it.

## Why

`cart-rest.md` and `order-rest.md` both include a Discovery section between `## Protocol Fundamentals` and `### Base URL`, with a sample UCP profile showing the relevant service + capability declaration. `checkout-rest.md` skips straight from Protocol Fundamentals to Base URL, leaving readers without a worked example for the checkout capability — even though checkout is the canonical purchase-finalization flow.

## What changed

- `docs/specification/checkout-rest.md`: +35 lines, insertion-only. New `### Discovery` subsection placed in the same slot as in the sibling REST docs, with a `dev.ucp.shopping.checkout` capability declaration and the same `<!-- ucp:example schema=profile def=business_schema -->` annotation used by `cart-rest.md` / `order-rest.md`.
- Uses `{{ ucp_version }}` macro (per #226) rather than hard-coded versions.

## Reference

- Established pattern: [`cart-rest.md`](https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/cart-rest.md#discovery), [`order-rest.md`](https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/order-rest.md#discovery)

## Test plan

- [x] Section renders correctly in mkdocs preview
- [x] `{{ ucp_version }}` macro substitutes to the right value on draft + release branches
- [x] No anchors changed (`#authentication`, `#base-url` etc. still resolve — verified `order.md` link to `checkout-rest.md#authentication` is unaffected)