### PR TITLE
fix(schema): allow hyphenated reverse-domain namespaces

### DIFF
--- a/source/schemas/common/types/reverse_domain_name.json
+++ b/source/schemas/common/types/reverse_domain_name.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/common/types/reverse_domain_name.json",
   "title": "Reverse Domain Name",
-  "description": "Reverse-domain identifier used for collision-safe namespacing of capabilities, services, handlers, eligibility claims, and extension-contributed keys. Must contain at least two dot-separated segments (e.g., 'dev.ucp.shopping.checkout', 'com.example.loyalty_gold').",
+  "description": "Reverse-domain identifier used for collision-safe namespacing of capabilities, services, handlers, eligibility claims, and extension-contributed keys. Must contain at least two dot-separated segments (e.g., 'dev.ucp.shopping.checkout', 'com.example-shop.loyalty_gold'). Hyphens are allowed inside segments to support domain-derived namespaces, but segments must not start or end with a hyphen.",
   "type": "string",
-  "pattern": "^[a-z][a-z0-9]*(?:\\.[a-z][a-z0-9_]*)+$"
+  "pattern": "^[a-z][a-z0-9]*(?:\\.[a-z](?:[a-z0-9_-]*[a-z0-9_])?)+$"
 }


### PR DESCRIPTION
## Summary

Allow reverse-domain namespace segments to contain interior hyphens, so domain-derived namespaces such as `com.example-shop.shopping.checkout` validate.

Fixes #478.

## Motivation

UCP namespace authority is based on reverse-domain ownership. Many real merchant and vendor domains include hyphens, including domains such as `harley-davidson.com`, `ray-ban.com`, `t-mobile.com`, `new-balance.com`, and `coca-cola.com`.

The current regex rejects those domain-derived namespaces, which can force implementations to use workaround domains or less-authoritative namespace choices.

## Details

This updates `common/types/reverse_domain_name.json` to permit hyphens inside namespace segments while keeping the existing constraints that segments start with a letter and do not end with a hyphen. Underscores remain supported in later segments for existing names such as `identity_linking` and `loyalty_gold`.

## Compatibility / Risk

This is backward compatible for existing identifiers because it only broadens accepted values. The updated pattern continues to reject leading/trailing hyphens in a segment, digit-starting segments, and underscore-starting segments.

Downstream implementations with stricter local validators may need to align with this schema change.

## Test Plan

- `npx --yes cspell --no-progress --no-summary source/schemas/common/types/reverse_domain_name.json`
- `npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -s source/schemas/common/types/reverse_domain_name.json`
- `git diff --check`
- Local Node regex checks covering valid and invalid hyphenated namespace cases

Not run locally: `ucp-schema lint source/` because `ucp-schema` is not installed in this environment. CI should run the repository schema lint.

## Contribution Notes

I read the organization contribution guide before opening this. The PR uses a conventional commit title and is intentionally scoped to issue #478. I understand the Google CLA may need to be completed before review/merge.