### PR TITLE
chore: validate catalog examples by op+direction, drop def=

### DIFF
--- a/docs/documentation/schema-authoring.md
+++ b/docs/documentation/schema-authoring.md
@@ -651,12 +651,22 @@ shows an envelope but only a subtree is the UCP payload under validation.
 <!-- ucp:example schema=shopping/checkout op=create direction=request extract=$.params.arguments.checkout -->
 ```
 
-**Schema with `$defs`.** Some schemas (e.g. catalog) define request/response
-inside `$defs`. Use `def=` to extract and validate against the named
-definition.
+**Schema with `$defs`.** Some schemas hold several message shapes under
+`$defs`. When a capability's request and response are different objects (e.g.
+catalog: a search request is a query, a search response is a list of products),
+just name the operation and direction — the validator selects
+`$defs/{op}_{direction}` automatically:
 
 ```text
-<!-- ucp:example schema=shopping/catalog_search def=request_schema direction=request -->
+<!-- ucp:example schema=shopping/catalog_search op=search direction=response extract=$.result.structuredContent -->
+```
+
+For a shape that isn't an operation+direction — a transport's `error_response`,
+a profile's `business_schema`, or a named sub-type — select it explicitly with
+`def=`:
+
+```text
+<!-- ucp:example schema=transports/jsonrpc def=error_response op=read -->
 ```
 
 **Empty body.** A `{}` payload (e.g. cancel, GET) validates trivially against

--- a/docs/specification/catalog/index.md
+++ b/docs/specification/catalog/index.md
@@ -190,7 +190,7 @@ rendering contract.
 
 When search finds no matches, return an empty array without messages.
 
-<!-- ucp:example schema=shopping/catalog_search def=search_response op=read -->
+<!-- ucp:example schema=shopping/catalog_search op=search -->
 ```json
 {
   "ucp": {...},
@@ -205,7 +205,7 @@ This is not an error - the query was valid but returned no results.
 When a product is available but has delayed fulfillment, return the product with
 a warning message. Use the `path` field to target specific variants.
 
-<!-- ucp:example schema=shopping/catalog_search def=search_response op=read -->
+<!-- ucp:example schema=shopping/catalog_search op=search -->
 ```json
 {
   "ucp": {...},
@@ -249,7 +249,7 @@ When requested identifiers don't exist, return success with the found products
 (if any). The response MAY include informational messages indicating which
 identifiers were not found.
 
-<!-- ucp:example schema=shopping/catalog_lookup def=lookup_response op=read -->
+<!-- ucp:example schema=shopping/catalog_lookup op=lookup -->
 ```json
 {
   "ucp": {...},
@@ -274,7 +274,7 @@ return it as a warning with `presentation: "disclosure"`. The `path` field targe
 relevant component in the response — when it targets a product, the
 disclosure applies to all of its variants.
 
-<!-- ucp:example schema=shopping/catalog_search def=search_response op=read -->
+<!-- ucp:example schema=shopping/catalog_search op=search -->
 ```json
 {
   "ucp": {...},

--- a/docs/specification/catalog/mcp.md
+++ b/docs/specification/catalog/mcp.md
@@ -64,7 +64,7 @@ Businesses advertise MCP transport availability through their UCP profile at
 MCP clients **MUST** include a `meta` object in every request containing
 protocol metadata:
 
-<!-- ucp:example schema=shopping/catalog_search def=search_request op=create direction=request extract=$.params.arguments.catalog -->
+<!-- ucp:example schema=shopping/catalog_search op=search direction=request extract=$.params.arguments.catalog -->
 ```json
 {
   "jsonrpc": "2.0",
@@ -121,7 +121,7 @@ Maps to the [Catalog Search](search.md) capability.
 
 === "Request"
 
-    <!-- ucp:example schema=shopping/catalog_search def=search_request op=create direction=request extract=$.params.arguments.catalog -->
+    <!-- ucp:example schema=shopping/catalog_search op=search direction=request extract=$.params.arguments.catalog -->
     ```json
     {
       "jsonrpc": "2.0",
@@ -159,7 +159,7 @@ Maps to the [Catalog Search](search.md) capability.
 
 === "Response"
 
-    <!-- ucp:example schema=shopping/catalog_search def=search_response op=read direction=response extract=$.result.structuredContent -->
+    <!-- ucp:example schema=shopping/catalog_search op=search direction=response extract=$.result.structuredContent -->
     ```json
     {
       "jsonrpc": "2.0",
@@ -281,7 +281,7 @@ The `catalog.ids` parameter accepts an array of identifiers and optional context
 
 === "Request"
 
-    <!-- ucp:example schema=shopping/catalog_lookup def=lookup_request op=create direction=request extract=$.params.arguments.catalog -->
+    <!-- ucp:example schema=shopping/catalog_lookup op=lookup direction=request extract=$.params.arguments.catalog -->
     ```json
     {
       "jsonrpc": "2.0",
@@ -308,7 +308,7 @@ The `catalog.ids` parameter accepts an array of identifiers and optional context
 
 === "Response"
 
-    <!-- ucp:example schema=shopping/catalog_lookup def=lookup_response op=read direction=response extract=$.result.structuredContent -->
+    <!-- ucp:example schema=shopping/catalog_lookup op=lookup direction=response extract=$.result.structuredContent -->
     ```json
     {
       "jsonrpc": "2.0",
@@ -404,7 +404,7 @@ The `catalog.ids` parameter accepts an array of identifiers and optional context
 When some identifiers are not found, the response includes the found products. The
 response MAY include informational messages indicating which identifiers were not found.
 
-<!-- ucp:example schema=shopping/catalog_lookup def=lookup_response op=read extract=$.result.structuredContent -->
+<!-- ucp:example schema=shopping/catalog_lookup op=lookup extract=$.result.structuredContent -->
 ```json
 {
   "jsonrpc": "2.0",
@@ -471,7 +471,7 @@ Maps to the [Catalog Lookup](lookup.md#get-product-get_product) capability. Retu
 
 === "Request"
 
-    <!-- ucp:example schema=shopping/catalog_lookup def=get_product_request op=create direction=request extract=$.params.arguments.catalog -->
+    <!-- ucp:example schema=shopping/catalog_lookup op=get_product direction=request extract=$.params.arguments.catalog -->
     ```json
     {
       "jsonrpc": "2.0",
@@ -502,7 +502,7 @@ Maps to the [Catalog Lookup](lookup.md#get-product-get_product) capability. Retu
 
 === "Response"
 
-    <!-- ucp:example schema=shopping/catalog_lookup def=get_product_response op=read direction=response extract=$.result.structuredContent -->
+    <!-- ucp:example schema=shopping/catalog_lookup op=get_product direction=response extract=$.result.structuredContent -->
     ```json
     {
       "jsonrpc": "2.0",
@@ -654,7 +654,7 @@ When all requested identifiers fail to resolve, the response contains an empty `
 array. The response MAY include informational messages indicating which identifiers were
 not found.
 
-<!-- ucp:example schema=shopping/catalog_lookup def=lookup_response op=read direction=response extract=$.result.structuredContent -->
+<!-- ucp:example schema=shopping/catalog_lookup op=lookup direction=response extract=$.result.structuredContent -->
 ```json
 {
   "jsonrpc": "2.0",

--- a/docs/specification/catalog/rest.md
+++ b/docs/specification/catalog/rest.md
@@ -77,7 +77,7 @@ Maps to the [Catalog Search](search.md) capability.
 
 === "Request"
 
-    <!-- ucp:example schema=shopping/catalog_search def=search_request op=create direction=request -->
+    <!-- ucp:example schema=shopping/catalog_search op=search direction=request -->
     ```json
     {
       "query": "blue running shoes",
@@ -100,7 +100,7 @@ Maps to the [Catalog Search](search.md) capability.
 
 === "Response"
 
-    <!-- ucp:example schema=shopping/catalog_search def=search_response op=read -->
+    <!-- ucp:example schema=shopping/catalog_search op=search -->
     ```json
     {
       "ucp": {
@@ -207,7 +207,7 @@ applies to all lookups in the batch.
 
 === "Request"
 
-    <!-- ucp:example schema=shopping/catalog_lookup def=lookup_request op=create direction=request -->
+    <!-- ucp:example schema=shopping/catalog_lookup op=lookup direction=request -->
     ```json
     POST /catalog/lookup HTTP/1.1
     Host: business.example.com
@@ -224,7 +224,7 @@ applies to all lookups in the batch.
 
 === "Response"
 
-    <!-- ucp:example schema=shopping/catalog_lookup def=lookup_response op=read -->
+    <!-- ucp:example schema=shopping/catalog_lookup op=lookup -->
     ```json
     {
       "ucp": {
@@ -296,7 +296,7 @@ messages indicating which identifiers were not found.
 
 === "Request"
 
-    <!-- ucp:example schema=shopping/catalog_lookup def=lookup_request op=create direction=request -->
+    <!-- ucp:example schema=shopping/catalog_lookup op=lookup direction=request -->
     ```json
     {
       "ids": ["prod_abc123", "prod_invalid", "prod_def456"]
@@ -305,7 +305,7 @@ messages indicating which identifiers were not found.
 
 === "Response"
 
-    <!-- ucp:example schema=shopping/catalog_lookup def=lookup_response op=read -->
+    <!-- ucp:example schema=shopping/catalog_lookup op=lookup -->
     ```json
     {
       "ucp": {
@@ -362,7 +362,7 @@ on option values and returns variants matching the selection.
 
 === "Request"
 
-    <!-- ucp:example schema=shopping/catalog_lookup def=get_product_request op=create direction=request -->
+    <!-- ucp:example schema=shopping/catalog_lookup op=get_product direction=request -->
     ```json
     POST /catalog/product HTTP/1.1
     Host: business.example.com
@@ -382,7 +382,7 @@ on option values and returns variants matching the selection.
 
 === "Response"
 
-    <!-- ucp:example schema=shopping/catalog_lookup def=get_product_response op=read -->
+    <!-- ucp:example schema=shopping/catalog_lookup op=get_product -->
     ```json
     {
       "ucp": {
@@ -535,7 +535,7 @@ for message semantics and common scenarios.
 When all requested identifiers fail lookup, the `products` array is empty. The response
 MAY include informational messages indicating which identifiers were not found.
 
-<!-- ucp:example schema=shopping/catalog_lookup def=lookup_response op=read -->
+<!-- ucp:example schema=shopping/catalog_lookup op=lookup -->
 ```json
 {
   "ucp": {

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -953,12 +953,16 @@ def process_block(
   except RuntimeError as e:
     return Result(file, line, "error", str(e), annotation)
 
-  # 6. Coverage check — def= selects the base validation schema;
-  # target= optionally selects a sub-schema within that base for
-  # partial examples. Final validation still runs against the full
-  # selected base schema after scaffold merge.
+  # 6. Coverage check — pick the schema the example is checked against.
+  # Container capabilities (no root body; request/response shapes under
+  # $defs/{op}_{direction}, e.g. catalog) derive the shape from op+direction,
+  # matching what `ucp-schema validate` selects. def= remains the explicit
+  # selector for shapes that aren't an operation+direction (a transport's
+  # error_response, a profile's business_schema, a sub-type). target=
+  # optionally narrows to a sub-schema for partial examples.
+  defs = resolved.get("$defs", {})
+  op_key = f"{op}_{direction}"
   if schema_def:
-    defs = resolved.get("$defs", {})
     if schema_def not in defs:
       return Result(
         file,
@@ -968,6 +972,8 @@ def process_block(
         annotation,
       )
     validation_schema = defs[schema_def]
+  elif "properties" not in resolved and op_key in defs:
+    validation_schema = defs[op_key]
   else:
     validation_schema = resolved
 


### PR DESCRIPTION
Catalog capabilities (`catalog.search`, `catalog.lookup`) carry distinct request/response shapes under `$defs/{op}_{direction}`. Example annotations named the shape twice — `op=read` **plus** `def=search_response` — which is redundant now that `ucp-schema` derives the shape from operation + direction.

## Changes

- **Annotations (22):** `op=read/create def=<shape>` → `op=search|lookup|get_product` (+ `direction`) across `docs/specification/catalog/{mcp,index,rest}.md`. `def=` dropped.
- **Harness:** the coverage check derives `$defs/{op}_{direction}` for container schemas instead of reading `def=`. Validation already flows through `ucp-schema validate` (full schema), which auto-selects the shape. `def=` stays for shapes that *aren't* an operation+direction (transport `error_response`, profile `business_schema`, sub-types).
- **Docs:** `schema-authoring.md` `$defs` section now teaches the op+direction convention, with `def=` shown for the non-operation case.

**⚠️ Depends on ucp-schema container validation**
Blocked by **Universal-Commerce-Protocol/ucp-schema#31** (https://github.com/Universal-Commerce-Protocol/ucp-schema/pull/31). The harness shells out to the installed `ucp-schema`; an older binary won't auto-select the now-`def`-less catalog shapes and would regress them to vacuous passes. **Merge only after that PR ships in a release.**

---

## Checklist

- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities.
- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md)
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] New and existing unit tests pass locally with my changes.