### PR TITLE
ci: fix ucp-schema caching

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -20,7 +20,11 @@ runs:
       id: get-version
       shell: bash
       run: |
-        VERSION=$(curl -s https://crates.io/api/v1/crates/ucp-schema | jq -r '.crate.max_version')
+        VERSION=$(cargo info ucp-schema | sed -n 's/^version: //p')
+        if [[ -z "$VERSION" ]]; then
+          echo "Error: Failed to fetch valid version from crates.io using cargo info" >&2
+          exit 1
+        fi
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Cache ucp-schema binary
@@ -33,7 +37,7 @@ runs:
     - name: Install ucp-schema
       if: steps.cache-ucp-schema.outputs.cache-hit != 'true'
       shell: bash
-      run: cargo install ucp-schema
+      run: cargo install ucp-schema --version ${{ steps.get-version.outputs.version }}
 
     - name: Add cargo to PATH
       shell: bash

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -28,9 +28,13 @@ NC='\033[0m' # No Color
 echo "Using ucp-schema CLI: $(which ucp-schema)"
 UCP_CLI_VERSION=$(ucp-schema --version | sed 's/ucp-schema //')
 echo "Local ucp-schema version:  '$UCP_CLI_VERSION'"
-UCP_CRATES_VERSION=$(cargo search ucp-schema -q | sed 's/ucp-schema = "//' | sed 's/".*$//')
+UCP_CRATES_VERSION=$(cargo info ucp-schema | sed -n 's/^version: //p')
 echo "Crates ucp-schema version: '$UCP_CRATES_VERSION'"
 if [[ $UCP_CLI_VERSION != "$UCP_CRATES_VERSION" ]]; then
+	if [[ "$CI" = "true" ]]; then
+		echo -e "${PURPLE}*ucp-schema version mismatch in CI*${NC}"
+		exit 1
+	fi
 	while true; do
 		echo -e "${PURPLE}*ucp-schema version mismatch*${NC}"
 		read -r -p " Continue? (y/n) " yn
@@ -41,7 +45,7 @@ if [[ $UCP_CLI_VERSION != "$UCP_CRATES_VERSION" ]]; then
 			;;
 		[Nn]*)
 			echo "exiting..."
-			exit
+			exit 1
 			;;
 		*) echo "invalid response" ;;
 		esac


### PR DESCRIPTION
# Description

Switch to using cargo info to correctly get the latest version of ucp-schema.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [x] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Checklist

- [ ] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [ ] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.