### PR TITLE
docs: add server timing response header

### DIFF
--- a/docs/specification/cart-rest.md
+++ b/docs/specification/cart-rest.md
@@ -80,6 +80,16 @@ All request and response bodies **MUST** be valid JSON as specified in
 
 All REST endpoints **MUST** be served over HTTPS with minimum TLS version 1.3.
 
+### Response Timing
+
+Business responses **MAY** include the
+[`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing){ target="_blank" }
+header to report business-side processing duration. When present, UCP responses
+**SHOULD** use the `ucp` metric with `dur` in milliseconds, for example
+`Server-Timing: ucp;dur=42.3`. This value excludes network time and is
+informational; platforms **SHOULD** measure client-observed latency
+independently.
+
 ## Operations
 
 | Operation | Method | Endpoint | Description |
@@ -132,6 +142,7 @@ All REST endpoints **MUST** be served over HTTPS with minimum TLS version 1.3.
     ```json
     HTTP/1.1 201 Created
     Content-Type: application/json
+    Server-Timing: ucp;dur=42.3
 
     {
       "ucp": {
@@ -182,6 +193,7 @@ All REST endpoints **MUST** be served over HTTPS with minimum TLS version 1.3.
     ```json
     HTTP/1.1 200 OK
     Content-Type: application/json
+    Server-Timing: ucp;dur=18.7
 
     {
       "ucp": { "version": "{{ ucp_version }}", "status": "error" },
@@ -487,6 +499,10 @@ operations unless otherwise noted.
     3. Return `409 Conflict` if the key is reused with a mismatched body.
     See [Message Signatures — Idempotency Key Requirements](signatures.md#replay-protection)
     for the full payload-matching contract.
+* **Server-Timing**: Responses **MAY** include `Server-Timing` with the `ucp`
+    metric to expose business-side processing duration in milliseconds. This
+    value is informational and **MUST NOT** be used as a substitute for
+    platform-measured end-to-end latency.
 
 ## Protocol Mechanics
 

--- a/docs/specification/catalog/rest.md
+++ b/docs/specification/catalog/rest.md
@@ -59,6 +59,16 @@ Businesses advertise REST transport availability through their UCP profile at
 }
 ```
 
+### Response Timing
+
+Business responses **MAY** include the
+[`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing){ target="_blank" }
+header to report business-side processing duration. When present, UCP responses
+**SHOULD** use the `ucp` metric with `dur` in milliseconds, for example
+`Server-Timing: ucp;dur=42.3`. This value excludes network time and is
+informational; platforms **SHOULD** measure client-observed latency
+independently.
+
 ## Endpoints
 
 | Endpoint | Method | Capability | Description |

--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -76,6 +76,16 @@ All request and response bodies **MUST** be valid JSON as specified in
 All REST endpoints **MUST** be served over HTTPS with minimum TLS version
 1.3.
 
+### Response Timing
+
+Business responses **MAY** include the
+[`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing){ target="_blank" }
+header to report business-side processing duration. When present, UCP responses
+**SHOULD** use the `ucp` metric with `dur` in milliseconds, for example
+`Server-Timing: ucp;dur=42.3`. This value excludes network time and is
+informational; platforms **SHOULD** measure client-observed latency
+independently.
+
 ## Operations
 
 | Operation                                          | Method | Endpoint                           | Description                |
@@ -116,6 +126,7 @@ All REST endpoints **MUST** be served over HTTPS with minimum TLS version
     ```json
     HTTP/1.1 201 Created
     Content-Type: application/json
+    Server-Timing: ucp;dur=42.3
 
     {
       "ucp": {
@@ -211,6 +222,7 @@ All REST endpoints **MUST** be served over HTTPS with minimum TLS version
     ```json
     HTTP/1.1 200 OK
     Content-Type: application/json
+    Server-Timing: ucp;dur=18.7
 
     {
       "ucp": { "version": "2026-01-11", "status": "error" },
@@ -1295,6 +1307,10 @@ operations unless otherwise noted.
     3. Return `409 Conflict` if the key is reused with a mismatched body.
     See [Message Signatures — Idempotency Key Requirements](signatures.md#replay-protection)
     for the full payload-matching contract.
+* **Server-Timing**: Responses **MAY** include `Server-Timing` with the `ucp`
+    metric to expose business-side processing duration in milliseconds. This
+    value is informational and **MUST NOT** be used as a substitute for
+    platform-measured end-to-end latency.
 
 ## Protocol Mechanics
 

--- a/docs/specification/order-rest.md
+++ b/docs/specification/order-rest.md
@@ -72,6 +72,16 @@ All response bodies **MUST** be valid JSON as specified in
 
 All REST endpoints **MUST** be served over HTTPS with minimum TLS version 1.3.
 
+### Response Timing
+
+Business responses **MAY** include the
+[`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing){ target="_blank" }
+header to report business-side processing duration. When present, UCP responses
+**SHOULD** use the `ucp` metric with `dur` in milliseconds, for example
+`Server-Timing: ucp;dur=42.3`. This value excludes network time and is
+informational; platforms **SHOULD** measure client-observed latency
+independently.
+
 ## Operations
 
 | Operation | Method | Endpoint | Description |
@@ -111,6 +121,7 @@ Returns the current-state snapshot of an order.
     ```json
     HTTP/1.1 200 OK
     Content-Type: application/json
+    Server-Timing: ucp;dur=42.3
 
     {
       "ucp": {
@@ -240,6 +251,18 @@ syntax:
 ```http
 UCP-Agent: profile="https://platform.example/.well-known/ucp"
 ```
+
+**Server-Timing** (optional on responses):
+
+Business-side processing duration using the `ucp` metric and millisecond
+`dur` value:
+
+```http
+Server-Timing: ucp;dur=42.3
+```
+
+Platforms **SHOULD** treat this value as informational and measure
+client-observed latency independently.
 
 ## Message Signing
 

--- a/main.py
+++ b/main.py
@@ -1497,26 +1497,32 @@ def define_env(env):
         if param.get("in") == "header":
           req_headers.append(param)
 
-      # 3. Extract Response Headers (Assumes 200 OK)
-      res_headers_defs = (
-        operation.get("responses", {}).get("200", {}).get("headers", {})
-      )
+      # 3. Extract Response Headers
       res_headers = []
-      for name, header in res_headers_defs.items():
-        if "$ref" in header:
-          resolved = _resolve_json_pointer(header["$ref"], data)
-          if resolved:
-            h = resolved.copy()
+      seen_res_headers = set()
+      for response in operation.get("responses", {}).values():
+        if not isinstance(response, dict):
+          continue
+
+        for name, header in response.get("headers", {}).items():
+          if name in seen_res_headers:
+            continue
+          seen_res_headers.add(name)
+
+          if "$ref" in header:
+            resolved = _resolve_json_pointer(header["$ref"], data)
+            if resolved:
+              h = resolved.copy()
+              h["name"] = name
+              res_headers.append(h)
+            else:
+              # If ref not resolved, just use name
+              h = {"name": name, "description": "Ref not resolved"}
+              res_headers.append(h)
+          else:
+            h = header.copy()
             h["name"] = name
             res_headers.append(h)
-          else:
-            # If ref not resolved, just use name
-            h = {"name": name, "description": "Ref not resolved"}
-            res_headers.append(h)
-        else:
-          h = header.copy()
-          h["name"] = name
-          res_headers.append(h)
 
       if not req_headers and not res_headers:
         return "_No headers defined._"

--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -83,6 +83,9 @@
               },
               "Content-Digest": {
                 "$ref": "#/components/headers/content_digest"
+              },
+              "Server-Timing": {
+                "$ref": "#/components/headers/server_timing"
               }
             },
             "content": {
@@ -151,6 +154,9 @@
               },
               "Content-Digest": {
                 "$ref": "#/components/headers/content_digest"
+              },
+              "Server-Timing": {
+                "$ref": "#/components/headers/server_timing"
               }
             },
             "content": {
@@ -228,6 +234,9 @@
               },
               "Content-Digest": {
                 "$ref": "#/components/headers/content_digest"
+              },
+              "Server-Timing": {
+                "$ref": "#/components/headers/server_timing"
               }
             },
             "content": {
@@ -310,6 +319,9 @@
               },
               "Content-Digest": {
                 "$ref": "#/components/headers/content_digest"
+              },
+              "Server-Timing": {
+                "$ref": "#/components/headers/server_timing"
               }
             },
             "content": {
@@ -382,6 +394,9 @@
               },
               "Content-Digest": {
                 "$ref": "#/components/headers/content_digest"
+              },
+              "Server-Timing": {
+                "$ref": "#/components/headers/server_timing"
               }
             },
             "content": {
@@ -429,7 +444,8 @@
             "headers": {
               "Signature": { "$ref": "#/components/headers/signature" },
               "Signature-Input": { "$ref": "#/components/headers/signature_input" },
-              "Content-Digest": { "$ref": "#/components/headers/content_digest" }
+              "Content-Digest": { "$ref": "#/components/headers/content_digest" },
+              "Server-Timing": { "$ref": "#/components/headers/server_timing" }
             },
             "content": {
               "application/json": {
@@ -467,7 +483,8 @@
             "headers": {
               "Signature": { "$ref": "#/components/headers/signature" },
               "Signature-Input": { "$ref": "#/components/headers/signature_input" },
-              "Content-Digest": { "$ref": "#/components/headers/content_digest" }
+              "Content-Digest": { "$ref": "#/components/headers/content_digest" },
+              "Server-Timing": { "$ref": "#/components/headers/server_timing" }
             },
             "content": {
               "application/json": {
@@ -510,7 +527,8 @@
             "headers": {
               "Signature": { "$ref": "#/components/headers/signature" },
               "Signature-Input": { "$ref": "#/components/headers/signature_input" },
-              "Content-Digest": { "$ref": "#/components/headers/content_digest" }
+              "Content-Digest": { "$ref": "#/components/headers/content_digest" },
+              "Server-Timing": { "$ref": "#/components/headers/server_timing" }
             },
             "content": {
               "application/json": {
@@ -550,7 +568,8 @@
             "headers": {
               "Signature": { "$ref": "#/components/headers/signature" },
               "Signature-Input": { "$ref": "#/components/headers/signature_input" },
-              "Content-Digest": { "$ref": "#/components/headers/content_digest" }
+              "Content-Digest": { "$ref": "#/components/headers/content_digest" },
+              "Server-Timing": { "$ref": "#/components/headers/server_timing" }
             },
             "content": {
               "application/json": {
@@ -594,7 +613,8 @@
             "headers": {
               "Signature": { "$ref": "#/components/headers/signature" },
               "Signature-Input": { "$ref": "#/components/headers/signature_input" },
-              "Content-Digest": { "$ref": "#/components/headers/content_digest" }
+              "Content-Digest": { "$ref": "#/components/headers/content_digest" },
+              "Server-Timing": { "$ref": "#/components/headers/server_timing" }
             },
             "content": {
               "application/json": {
@@ -638,7 +658,8 @@
             "headers": {
               "Signature": { "$ref": "#/components/headers/signature" },
               "Signature-Input": { "$ref": "#/components/headers/signature_input" },
-              "Content-Digest": { "$ref": "#/components/headers/content_digest" }
+              "Content-Digest": { "$ref": "#/components/headers/content_digest" },
+              "Server-Timing": { "$ref": "#/components/headers/server_timing" }
             },
             "content": {
               "application/json": {
@@ -676,7 +697,8 @@
             "headers": {
               "Signature": { "$ref": "#/components/headers/signature" },
               "Signature-Input": { "$ref": "#/components/headers/signature_input" },
-              "Content-Digest": { "$ref": "#/components/headers/content_digest" }
+              "Content-Digest": { "$ref": "#/components/headers/content_digest" },
+              "Server-Timing": { "$ref": "#/components/headers/server_timing" }
             },
             "content": {
               "application/json": {
@@ -720,7 +742,8 @@
             "headers": {
               "Signature": { "$ref": "#/components/headers/signature" },
               "Signature-Input": { "$ref": "#/components/headers/signature_input" },
-              "Content-Digest": { "$ref": "#/components/headers/content_digest" }
+              "Content-Digest": { "$ref": "#/components/headers/content_digest" },
+              "Server-Timing": { "$ref": "#/components/headers/server_timing" }
             },
             "content": {
               "application/json": {
@@ -965,6 +988,13 @@
           "type": "string"
         },
         "description": "JCS-canonicalized body digest per RFC 8785. Format: `sha-256=:<base64-digest>:`."
+      },
+      "server_timing": {
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Optional merchant-reported server processing duration using the W3C Server-Timing header. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing. UCP responses SHOULD use the `ucp` metric with `dur` in milliseconds, for example `ucp;dur=42.3`. This excludes network time and is informational; platforms SHOULD measure client-observed latency independently."
       }
     },
     "schemas": {


### PR DESCRIPTION
## Summary
- Add optional `Server-Timing` response header to UCP Shopping REST responses
- Document the `ucp;dur=<milliseconds>` metric for checkout, cart, catalog, and order REST bindings
- Link to the MDN `Server-Timing` reference and clarify that platforms should still measure client-observed latency
- Update the docs header macro so response headers render for non-200 responses such as `201 Created`

## Related
- Catalog REST's missing HTTP Headers section is split into #548 so that documentation structure fix can land separately first.

## Validation
- `python3 -m json.tool source/services/shopping/rest.openapi.json >/dev/null`
- `python3 -m py_compile main.py`
- `python3 scripts/validate_examples.py --schema-base source/schemas/ --file docs/specification/checkout-rest.md docs/specification/cart-rest.md docs/specification/order-rest.md docs/specification/catalog/rest.md`
- `python3 scripts/test_validate_examples.py`
- `uv run mkdocs build --site-dir /tmp/ucp-mkdocs-check`

Note: `uv run mkdocs build --strict` is blocked locally by missing native Cairo libraries required by CairoSVG image conversion.
