### PR TITLE
docs: add catalog REST headers section

### DIFF
--- a/docs/specification/catalog/rest.md
+++ b/docs/specification/catalog/rest.md
@@ -509,6 +509,20 @@ Unlike `/catalog/lookup` (which returns partial results for batch requests),
 application error with `unrecoverable` severity — the agent should not retry
 with the same identifier.
 
+## HTTP Headers
+
+The following headers are defined for the HTTP binding and apply to all
+operations unless otherwise noted.
+
+{{ header_fields('search_catalog', 'rest.openapi.json') }}
+
+### Specific Header Requirements
+
+* **UCP-Agent**: All requests **MUST** include the `UCP-Agent` header
+    containing the platform profile URI using Dictionary Structured Field syntax
+    ([RFC 8941](https://datatracker.ietf.org/doc/html/rfc8941){target="_blank"}).
+    Format: `profile="https://platform.example/profile"`.
+
 ## Error Handling
 
 UCP uses a two-layer error model separating transport errors from business outcomes.


### PR DESCRIPTION
## Summary
- Add the missing HTTP Headers section to the Catalog REST binding
- Render request and response headers from the existing `search_catalog` OpenAPI operation
- Document the `UCP-Agent` catalog REST request header requirement

## Validation
- `python3 scripts/validate_examples.py --schema-base source/schemas/ --file docs/specification/catalog/rest.md`
- Verified `header_fields('search_catalog', 'rest.openapi.json')` renders response headers including `Content-Digest`
