### PR TITLE
fix: render inline oneOf branches in schema reference type column

### DIFF
--- a/main.py
+++ b/main.py
@@ -773,16 +773,19 @@ def define_env(env):
 
         # --- Logic to determine Display Type ---
         if "oneOf" in details:
-          # List of values embedded within an oneOf
-          f_type = "OneOf["
-          for idx, one_of_type in enumerate(details.get("oneOf", [])):
+          # Render each branch: a $ref becomes a type link, an inline
+          # branch shows its JSON type (matching the prose oneOf renderer
+          # above). Without the inline case, a oneOf of scalars such as
+          # capability `extends` (string | array) rendered as "OneOf[]".
+          parts = []
+          for one_of_type in details.get("oneOf", []):
             if "$ref" in one_of_type:
-              f_type += create_link(
-                one_of_type["$ref"], spec_file_name, context
+              parts.append(
+                create_link(one_of_type["$ref"], spec_file_name, context)
               )
-              if idx < len(details.get("oneOf", [])) - 1:
-                f_type += ", "
-          f_type += "]"
+            elif one_of_type.get("type"):
+              parts.append(f"`{one_of_type['type']}`")
+          f_type = f"OneOf[{', '.join(parts)}]"
         elif ref:
           if version_data:
             f_type = version_data.get("type", "any")


### PR DESCRIPTION
# Description

The generated schema reference renders an empty `OneOf[]` in the Type column for any field whose `oneOf` is built from inline types instead of `$ref`s. Why this matters: the reference table is the first place a developer looks to find out what a field accepts. Right now anyone reading the `extends` field sees empty brackets in the Type column, even though the field is a string or an array, so they learn nothing and have to go dig through the raw schema files to figure it out, which is exactly what the generated reference is meant to save them from. 

The description on that same row even says "Use array for multi-parent extensions," so the page contradicts itself: the words say string or array, the type says nothing. The cause is in the `schema_fields` / `extension_schema_fields` macros in `main.py`. When a field is a `oneOf`, the generator builds an `OneOf[...]` label but only handled branches that were a `$ref` and dropped branches that were a plain inline type, and the comma handling could also leave a trailing separator. So a `oneOf` made entirely of inline types came out as empty brackets. This is live today. The capability `extends` field (`string | array`) shows `OneOf[]` on the reference page and on the checkout, overview, and order pages that include the capability table. The `jsonrpc` `params` field (`object | array`) hits the same path. 

The fix renders every branch the way the prose `oneOf` renderer a few lines above in the same function already does: a `$ref` becomes a type link and an inline branch shows its JSON type. After the change, `extends` renders `OneOf[`string`, `array`]`.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable). Not applicable: this changes how the reference renders, with no separate doc content to edit.
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works. `main.py` has no test harness in the repo; verified by running the macro against `capability.json` (before/after below). Happy to add a harness if maintainers want one.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas. Not applicable.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk. Not applicable: no schema change.

## Screenshots / Logs (if applicable)

Rendered output for the capability `extends` field.

**Before:**

| extends | OneOf[] | No | Parent capability(s) this extends. Present for extensions, absent for root capabilities. Use array for multi-parent extensions. |

**After:**

| extends | OneOf[`string`, `array`] | No | Parent capability(s) this extends. Present for extensions, absent for root capabilities. Use array for multi-parent extensions. |