### PR TITLE
fix: label array items by type instead of "any" in schema reference

### DIFF
--- a/main.py
+++ b/main.py
@@ -794,8 +794,30 @@ def define_env(env):
           link = create_link(items_ref, spec_file_name, context)
           f_type = f"Array[{link}]"
         elif f_type == "array":
-          # Array of Primitives
-          inner_type = items.get("type", "any")
+          # Array of primitives, or of a composed/bundled item whose type
+          # is not stated inline (e.g. items defined via allOf, where a
+          # $ref to the item type was inlined during resolution). Recover a
+          # label from the item type, a $ref link, or a title so the cell
+          # does not fall back to the uninformative "any".
+          inner_type = items.get("type")
+          if not inner_type:
+            branches = (
+              items["allOf"]
+              if isinstance(items.get("allOf"), list)
+              else [items]
+            )
+            for branch in branches:
+              if not isinstance(branch, dict):
+                continue
+              if branch.get("$ref"):
+                inner_type = create_link(
+                  branch["$ref"], spec_file_name, context
+                )
+                break
+              if branch.get("title"):
+                inner_type = branch["title"]
+                break
+            inner_type = inner_type or "object"
           f_type = f"Array[{inner_type}]"
 
         # --- Handle Description ---


### PR DESCRIPTION
# Description

The reference tables show `Array[any]` in the Type column for some array fields, even though those same fields render with a real type elsewhere on the site.

Why it matters: the Type column is where a reader checks what a field holds. For `totals` on every extension capability (AP2 Mandate, Buyer Consent, Discount, Fulfillment, Split Payments) it shows `Array[any]`, and for `products` in catalog lookup it shows `Array[any]`. Those same fields render correctly as `Array[Total]` and `Array[Product]` in the base schemas, and none of the extensions change the field, so a reader gets a worse, blank answer in exactly the places that build on the base.

Cause: the table generator labels an array from `items.$ref` or a plain `items.type`. When the item is defined through `allOf`, or its `$ref` was inlined while the schema was resolved, neither is present, so it fell back to `any`. The base tables keep the `$ref`, which is why they render fine.

Fix: when the simple cases do not apply, recover the item label from the item type, a `$ref` link, or a title (including titles on `allOf` branches), and fall back to `object` rather than `any`.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable). Not applicable: this changes how the reference renders, with no separate doc content to edit.
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works. `main.py` has no test harness in the repo; verified by rebuilding the spec and diffing every rendered Type cell before and after (1900 cells, 11 changed, 0 regressions). Happy to add a harness if maintainers want one.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas. Not applicable.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk. Not applicable: no schema change.

## Screenshots / Logs (if applicable)

Rendered Type cells before and after, from a full rebuild of the spec.

Before:

| Field | Section | Type |
| :--- | :--- | :--- |
| totals | Checkout with Split Payments | Array[any] |
| totals | Checkout with AP2 Mandate | Array[any] |
| products | Catalog Lookup (lookup_catalog) | Array[any] |

After:

| Field | Section | Type |
| :--- | :--- | :--- |
| totals | Checkout with Split Payments | Array[Total] |
| totals | Checkout with AP2 Mandate | Array[Total] |
| products | Catalog Lookup (lookup_catalog) | Array[Product] |

A diff of every rendered Type cell across the whole spec confirms exactly 11 cells changed, all `Array[any]` to `Array[Total]` or `Array[Product]`, with no other cell affected.
