### PR TITLE
docs(fulfillment): correct options[].total row to match the schema (totals array)

### DIFF
--- a/docs/specification/fulfillment.md
+++ b/docs/specification/fulfillment.md
@@ -184,7 +184,7 @@ human-readable fields that platforms render directly.
 | --------------------- | ------------- | -------- | ------------------------------------------------------- |
 | `groups[].options[]`  | `title`       | Yes      | Primary label that distinguishes from siblings          |
 | `groups[].options[]`  | `description` | No       | Supplementary context for the title                     |
-| `groups[].options[]`  | `totals`      | Yes      | Cost breakdown for this option: an array of `total` objects (`type`, `amount`, `display_text`) |
+| `groups[].options[]`  | `totals`      | Yes      | Cost breakdown: an array of `total` objects             |
 | `available_methods[]` | `description` | No       | Standalone explanation of alternative availability      |
 
 ### Business Responsibilities

--- a/docs/specification/fulfillment.md
+++ b/docs/specification/fulfillment.md
@@ -184,7 +184,7 @@ human-readable fields that platforms render directly.
 | --------------------- | ------------- | -------- | ------------------------------------------------------- |
 | `groups[].options[]`  | `title`       | Yes      | Primary label that distinguishes from siblings          |
 | `groups[].options[]`  | `description` | No       | Supplementary context for the title                     |
-| `groups[].options[]`  | `total`       | Yes      | Price in minor units (may be null if not yet available) |
+| `groups[].options[]`  | `totals`      | Yes      | Cost breakdown for this option: an array of `total` objects (`type`, `amount`, `display_text`) |
 | `available_methods[]` | `description` | No       | Standalone explanation of alternative availability      |
 
 ### Business Responsibilities


### PR DESCRIPTION
Corrects the `groups[].options[].total` row in `fulfillment.md` to match the schema.

`source/schemas/shopping/types/fulfillment_option.json` requires **`totals`** — an array of `total.json` — and defines no `total` field. `total.json`'s `amount` is a bare `integer` (`common/types/signed_amount.json`), so the documented "may be null" is impossible in any position.

Closes #559. Found while building an unofficial UCP conformance suite (https://spck.dev). Happy to adjust the wording — in particular, if a "price not yet available" state is intended, it needs a schema-supported mechanism, which I left out rather than guess at.
