### PR TITLE
docs(overview): fix "Capabilities Incompatible" examples to use capabilities_incompatible

### DIFF
--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -918,8 +918,8 @@ task through the standard web interface.
       "messages": [
         {
           "type": "error",
-          "code": "version_unsupported",
-          "content": "UCP version 2024-01-01 is not supported",
+          "code": "capabilities_incompatible",
+          "content": "No compatible capabilities in the intersection",
           "severity": "unrecoverable"
         }
       ],
@@ -1000,8 +1000,8 @@ task through the standard web interface.
           "messages": [
             {
               "type": "error",
-              "code": "version_unsupported",
-              "content": "UCP version 2024-01-01 is not supported",
+              "code": "capabilities_incompatible",
+              "content": "No compatible capabilities in the intersection",
               "severity": "unrecoverable"
             }
           ],


### PR DESCRIPTION
Both examples headed **"Capabilities Incompatible"** carried `"code": "version_unsupported"` (with version-failure content), contradicting the negotiation-errors table where `capabilities_incompatible` → `200`. This corrects the `code` and `content` in both the REST (`200 OK`) and JSON-RPC (`result`) examples.

The three legitimate `version_unsupported` examples ("Version Unsupported" headings + the prose example) are untouched.

Closes #560. Found while building an unofficial UCP conformance suite (https://spck.dev).
