### PR TITLE
docs(order): webhook example must sign ucp-agent (identity otherwise unbound)

### DIFF
--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -1434,7 +1434,7 @@ Content-Type: application/json
 UCP-Agent: profile="https://platform.example/.well-known/ucp"
 Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000
 Content-Digest: sha-256=:X48E9q...:
-Signature-Input: sig1=("@method" "@authority" "@path" "idempotency-key" "content-digest" "content-type");keyid="platform-2025"
+Signature-Input: sig1=("@method" "@authority" "@path" "ucp-agent" "idempotency-key" "content-digest" "content-type");keyid="platform-2025"
 Signature: sig1=:6G4i8TS6oUkGrx8KnCFUpsSPwd74...:
 
 {"line_items":[{"item":{"id":"item_123"},"quantity":2}]}

--- a/docs/specification/order.md
+++ b/docs/specification/order.md
@@ -490,7 +490,7 @@ Host: platform.example.com
 Content-Type: application/json
 UCP-Agent: profile="https://merchant.example/.well-known/ucp"
 Content-Digest: sha-256=:X48E9q...:
-Signature-Input: sig1=("@method" "@authority" "@path" "content-digest" "content-type");keyid="merchant-2026"
+Signature-Input: sig1=("@method" "@authority" "@path" "ucp-agent" "content-digest" "content-type");keyid="merchant-2026"
 Signature: sig1=:MEUCIQDTxNq8h7LGHpvVZQp1iHkFp9+3N8Mxk2zH1wK4YuVN8w...:
 
 {"id":"order_abc123","event_id":"evt_123","created_time":"2026-01-15T12:00:00Z",...}


### PR DESCRIPTION
The "Example Webhook Request" in `docs/specification/order.md` carries a `UCP-Agent` header but its `Signature-Input` signs only `("@method" "@authority" "@path" "content-digest" "content-type")` — omitting `ucp-agent`.

This contradicts the normative signed-component rules in `signatures.md`:

- The request signed-components table marks `ucp-agent` **"Required if `UCP-Agent` header is present"** (the `**` footnote), and there is no separate webhook component table.
- `signatures.md` explicitly derives webhook identity from the `UCP-Agent` header ("Business → Platform webhooks: Profile URL from `UCP-Agent` header") and requires webhooks to be signed.

Because the example doesn't sign `ucp-agent`, the sender's identity (the component's documented purpose — "binds identity") is not cryptographically bound in the illustrated signature, and a platform copying the example produces a signature that a table-following verifier would reject.

One-line fix: add `ucp-agent` to the example's signed components, matching the request example in `signatures.md`.

Found while building an unofficial UCP conformance test suite (https://spck.dev); verified against main @ 7e5fc42.

---

**Update (class sweep):** re-checked every RFC 9421 example in `docs/` for this same pattern (UCP-Agent header present but not among the signed components). One more instance: `checkout-rest.md`'s "Example Signed Request" — fixed in the second commit with the same one-line change, matching the component order of the canonical request example in `signatures.md`. All other examples either already sign `ucp-agent`, omit the header entirely, or are response/elided examples where the component doesn't apply.
