### PR TITLE
docs(discount): document usage-limit and stacking-conflict rejection codes

### DIFF
--- a/docs/specification/discount.md
+++ b/docs/specification/discount.md
@@ -178,8 +178,21 @@ via the `messages[]` array:
 | `discount_code_invalid`                | Code not found or malformed                 |
 | `discount_code_already_applied`        | Code is already applied                     |
 | `discount_code_combination_disallowed` | Cannot combine with another active discount |
+| `discount_code_usage_limit_reached`    | Code has reached its maximum number of allowed uses |
+| `discount_code_stacking_conflict`      | Code is valid, but a higher-priority discount already applied takes precedence |
 | `discount_code_user_not_logged_in`     | Code requires authenticated user            |
 | `discount_code_user_ineligible`        | User does not meet eligibility criteria     |
+
+`discount_code_usage_limit_reached` differs from `discount_code_already_applied`:
+the latter means the buyer is trying to apply a code that is already active on
+*this* cart or checkout; the former means the code's overall usage allowance
+(global or per-customer) has been exhausted by other carts/customers.
+
+`discount_code_stacking_conflict` differs from `discount_code_combination_disallowed`:
+the latter means the business has an explicit rule that these specific
+discounts cannot combine; the former means the code matched and was valid,
+but discount-stacking or best-deal resolution rules resulted in a different,
+already-active discount taking precedence instead.
 
 ## Automatic Discounts
 

--- a/docs/specification/discount.md
+++ b/docs/specification/discount.md
@@ -172,16 +172,16 @@ via the `messages[]` array:
 
 **Error codes for rejected discounts:**
 
-| Code                                   | Description                                 |
-| -------------------------------------- | ------------------------------------------- |
-| `discount_code_expired`                | Code has expired                            |
-| `discount_code_invalid`                | Code not found or malformed                 |
-| `discount_code_already_applied`        | Code is already applied                     |
-| `discount_code_combination_disallowed` | Cannot combine with another active discount |
-| `discount_code_usage_limit_reached`    | Code has reached its maximum number of allowed uses |
+| Code                                   | Description                                                                    |
+| -------------------------------------- | ------------------------------------------------------------------------------ |
+| `discount_code_expired`                | Code has expired                                                               |
+| `discount_code_invalid`                | Code not found or malformed                                                    |
+| `discount_code_already_applied`        | Code is already applied                                                        |
+| `discount_code_combination_disallowed` | Cannot combine with another active discount                                    |
+| `discount_code_usage_limit_reached`    | Code has reached its maximum number of allowed uses                            |
 | `discount_code_stacking_conflict`      | Code is valid, but a higher-priority discount already applied takes precedence |
-| `discount_code_user_not_logged_in`     | Code requires authenticated user            |
-| `discount_code_user_ineligible`        | User does not meet eligibility criteria     |
+| `discount_code_user_not_logged_in`     | Code requires authenticated user                                               |
+| `discount_code_user_ineligible`        | User does not meet eligibility criteria                                        |
 
 `discount_code_usage_limit_reached` differs from `discount_code_already_applied`:
 the latter means the buyer is trying to apply a code that is already active on

--- a/docs/specification/discount.md
+++ b/docs/specification/discount.md
@@ -176,23 +176,12 @@ via the `messages[]` array:
 | -------------------------------------- | ------------------------------------------------------------------------------ |
 | `discount_code_expired`                | Code has expired                                                               |
 | `discount_code_invalid`                | Code not found or malformed                                                    |
-| `discount_code_already_applied`        | Code is already applied                                                        |
-| `discount_code_combination_disallowed` | Cannot combine with another active discount                                    |
+| `discount_code_already_applied`        | Code is already applied on this active session                                 |
+| `discount_code_combination_disallowed` | Business rule prohibits combining with another active discount                 |
 | `discount_code_usage_limit_reached`    | Code has reached its maximum number of allowed uses                            |
 | `discount_code_stacking_conflict`      | Code is valid, but a higher-priority discount already applied takes precedence |
 | `discount_code_user_not_logged_in`     | Code requires authenticated user                                               |
 | `discount_code_user_ineligible`        | User does not meet eligibility criteria                                        |
-
-`discount_code_usage_limit_reached` differs from `discount_code_already_applied`:
-the latter means the buyer is trying to apply a code that is already active on
-*this* cart or checkout; the former means the code's overall usage allowance
-(global or per-customer) has been exhausted by other carts/customers.
-
-`discount_code_stacking_conflict` differs from `discount_code_combination_disallowed`:
-the latter means the business has an explicit rule that these specific
-discounts cannot combine; the former means the code matched and was valid,
-but discount-stacking or best-deal resolution rules resulted in a different,
-already-active discount taking precedence instead.
 
 ## Automatic Discounts
 


### PR DESCRIPTION
# Description

The discount extension's rejection-code table doesn't have an entry for two common cases: a code whose overall usage allowance has been exhausted, and a code that matched and was valid but lost to stacking/best-deal resolution against an already-active discount. Both currently have to be forced into `discount_code_already_applied` or `discount_code_combination_disallowed`, which mean something narrower and would actively mislead a buyer — "already applied" implies the buyer duplicated their own action, not that a promotion's usage cap ran out elsewhere.

Adds `discount_code_usage_limit_reached` and `discount_code_stacking_conflict` to the documented error-code table, with a short note distinguishing each from its nearest existing neighbor. `discount_code_*` values are a documented convention rather than a schema enum (see `error_code.json`), so this is a documentation-only change — no schema files touched.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None.

## Checklist

- [x] I have followed the Contributing Guide (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [ ] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A — documentation change only.