### PR TITLE
feat(discount): add gift_line_item_id to applied discount

### DIFF
--- a/docs/specification/discount.md
+++ b/docs/specification/discount.md
@@ -201,8 +201,10 @@ free-gift-with-purchase promotion).
 When a discount grants line items this way:
 
 - Each granted item **MUST** appear as a normal entry in `line_items[]`,
-  with its price reflecting the discount (typically `0`, but a reduced
-  non-zero price is also valid for "buy X get Y at $Z" patterns).
+  priced at its regular value — the same as any other line item — with the
+  discount reflected in that line item's own `totals[]`
+  (`items_discount`/`total`), exactly like a non-gift discount. Do not zero
+  out `item.price` itself.
 - The corresponding `applied_discount` entry **MUST** set
   `gift_line_item_ids` to those line items' `id`s, so platforms can
   attribute the items to the promotion rather than treating them as
@@ -218,10 +220,16 @@ This lets a platform render, for example, "Free gift: T-Shirt — added by
 Summer Sale" instead of surfacing an unexplained zero-price item.
 
 `applied_discount.amount` is still required even when `gift_line_item_ids`
-is present: by the time a gift line item is serialized its price already
-reflects the discount (typically `0`), and the schema has no separate
-"regular price" field to recover the gift's value from — `amount` is the
-only place that value is communicated. See the example below.
+is present. The granted line item's own `price` and `totals[]` already
+carry its regular value and discount delta — same as for any other
+line-item-targeted discount — so `amount` is technically re-derivable from
+`line_items[]`. It stays explicit anyway for the same reason `amount` isn't
+dropped for ordinary discounts either, even though it already equals
+`sum(allocations[].amount)`: a platform shouldn't have to cross-reference
+into `line_items[]` (or sum an array) just to answer "how much was this
+discount worth" — `amount` gives that number directly, and
+`allocations`/`gift_line_item_ids` are there for whoever wants the
+breakdown. See the example below.
 
 ### Example: Free gift with purchase
 
@@ -272,11 +280,12 @@ only place that value is communicated. See the example below.
           "item": {
             "id": "prod_socks_gift",
             "title": "Socks",
-            "price": 0
+            "price": 1200
           },
           "quantity": 1,
           "totals": [
-            {"type": "subtotal", "amount": 0},
+            {"type": "subtotal", "amount": 1200},
+            {"type": "items_discount", "amount": -1200},
             {"type": "total", "amount": 0}
           ]
         }
@@ -288,44 +297,98 @@ only place that value is communicated. See the example below.
             "code": "FREEGIFT",
             "title": "Free Socks with Shoe Purchase",
             "amount": 1200,
-            "gift_line_item_ids": ["li_2"]
+            "gift_line_item_ids": ["li_2"],
+            "allocations": [
+              {"path": "$.line_items[1]", "amount": 1200}
+            ]
           }
         ]
       },
       "totals": [
-        {"type": "subtotal", "display_text": "Subtotal", "amount": 8000},
+        {"type": "subtotal", "display_text": "Subtotal", "amount": 9200},
+        {"type": "items_discount", "display_text": "Item Discounts", "amount": -1200},
         {"type": "total", "display_text": "Total", "amount": 8000}
       ]
     }
     ```
 
-Here, `applied_discount.amount` (1200) reflects the retail value of the
-gifted item, even though it doesn't appear as a line-item or order-level
-discount total — the gift is already reflected by the granted line item's
-own `0` price. Platforms use `gift_line_item_ids` to find and label `li_2`,
-and `amount` to communicate the gift's value to the buyer (e.g. "$12 value,
-free").
+`li_2` shows its full $12 value in `item.price` and `subtotal`, then `-1200`
+in `items_discount` brings its own total to `0` — the same pattern as any
+other discounted line item. `applied_discount.amount` (1200) and
+`allocations` just mirror what `li_2`'s own totals already say;
+`gift_line_item_ids` is the only genuinely new piece of information, and it
+tells the platform *why* `li_2` exists at all.
 
 ### Example: Multiple gifts from one discount
 
 A "buy 2 shirts, get 2 socks free" promotion where the buyer added 4 shirts
-grants two gift line items from the same discount:
+grants two gift line items from the same discount. `li_1` is the 4 shirts;
+`li_2` and `li_3` are the two free pairs of socks:
 
-<!-- ucp:example schema=shopping/cart target=$.discounts.applied -->
+<!-- ucp:example schema=shopping/cart op=read -->
 ```json
-[
-  {
-    "code": "BUYSHIRTGETSOCKS",
-    "title": "Free Socks with Every 2 Shirts",
-    "amount": 2400,
-    "gift_line_item_ids": ["li_2", "li_3"]
-  }
-]
+{
+  "ucp": { ... },
+  "id": "...",
+  "currency": "...",
+  "line_items": [
+    {
+      "id": "li_1",
+      "item": {"id": "prod_shirt", "title": "Shirt", "price": 3000},
+      "quantity": 4,
+      "totals": [
+        {"type": "subtotal", "amount": 12000},
+        {"type": "total", "amount": 12000}
+      ]
+    },
+    {
+      "id": "li_2",
+      "item": {"id": "prod_socks_gift", "title": "Socks", "price": 1200},
+      "quantity": 1,
+      "totals": [
+        {"type": "subtotal", "amount": 1200},
+        {"type": "items_discount", "amount": -1200},
+        {"type": "total", "amount": 0}
+      ]
+    },
+    {
+      "id": "li_3",
+      "item": {"id": "prod_socks_gift", "title": "Socks", "price": 1200},
+      "quantity": 1,
+      "totals": [
+        {"type": "subtotal", "amount": 1200},
+        {"type": "items_discount", "amount": -1200},
+        {"type": "total", "amount": 0}
+      ]
+    }
+  ],
+  "discounts": {
+    "applied": [
+      {
+        "title": "Free Socks with Every 2 Shirts",
+        "amount": 2400,
+        "automatic": true,
+        "gift_line_item_ids": ["li_2", "li_3"],
+        "allocations": [
+          {"path": "$.line_items[1]", "amount": 1200},
+          {"path": "$.line_items[2]", "amount": 1200}
+        ]
+      }
+    ]
+  },
+  "totals": [
+    {"type": "subtotal", "display_text": "Subtotal", "amount": 14400},
+    {"type": "items_discount", "display_text": "Item Discounts", "amount": -2400},
+    {"type": "total", "display_text": "Total", "amount": 12000}
+  ]
+}
 ```
 
-`amount` (2400) is the combined retail value of both gifted pairs of socks;
-`gift_line_item_ids` lists each one so the platform can label them
-individually.
+`amount` (2400) still equals the sum of the two gift line items' own
+`items_discount` totals (1200 + 1200) — which is exactly why it's safe to
+read `amount` directly instead of cross-referencing `gift_line_item_ids`
+against `line_items[]` yourself, the same way you would for any other
+line-item-targeted discount.
 
 ## Eligibility Claims
 

--- a/docs/specification/discount.md
+++ b/docs/specification/discount.md
@@ -191,6 +191,112 @@ segment, or promotional rules:
 - Cannot be removed by the platform
 - Surfaced for transparency (platform can explain to user why discount was applied)
 
+## Gift Line Items
+
+Some discounts grant an entirely new line item to the cart or checkout — a
+free or discounted product — rather than reducing the price of items the
+buyer already added (e.g. "buy one get one free," or a free-gift-with-purchase
+promotion).
+
+When a discount grants a line item this way:
+
+- The granted item **MUST** appear as a normal entry in `line_items[]`, with
+  its price reflecting the discount (typically `0`, but a reduced non-zero
+  price is also valid for "buy X get Y at $Z" patterns).
+- The corresponding `applied_discount` entry **MUST** set
+  `gift_line_item_id` to that line item's `id`, so platforms can attribute
+  the item to the promotion rather than treating it as an unexplained
+  addition.
+- `gift_line_item_id` is omitted for ordinary amount-based discounts — it
+  only applies when the discount's effect is granting a line item, not
+  reducing the price of one.
+
+This lets a platform render, for example, "Free gift: T-Shirt — added by
+Summer Sale" instead of surfacing an unexplained zero-price item.
+
+### Example: Free gift with purchase
+
+=== "Request"
+
+    <!-- ucp:example schema=shopping/cart op=update direction=request -->
+    ```json
+    {
+      "id": "...",
+      "line_items": [
+        {
+          "item": {
+            "id": "prod_shoes"
+          },
+          "quantity": 1
+        }
+      ],
+      "discounts": {
+        "codes": ["FREEGIFT"]
+      }
+    }
+    ```
+
+=== "Response"
+
+    <!-- ucp:example schema=shopping/cart op=read -->
+    ```json
+    {
+      "ucp": { ... },
+      "id": "...",
+      "currency": "...",
+      "line_items": [
+        {
+          "id": "li_1",
+          "item": {
+            "id": "prod_shoes",
+            "title": "Running Shoes",
+            "price": 8000
+          },
+          "quantity": 1,
+          "totals": [
+            {"type": "subtotal", "amount": 8000},
+            {"type": "total", "amount": 8000}
+          ]
+        },
+        {
+          "id": "li_2",
+          "item": {
+            "id": "prod_socks_gift",
+            "title": "Socks",
+            "price": 0
+          },
+          "quantity": 1,
+          "totals": [
+            {"type": "subtotal", "amount": 0},
+            {"type": "total", "amount": 0}
+          ]
+        }
+      ],
+      "discounts": {
+        "codes": ["FREEGIFT"],
+        "applied": [
+          {
+            "code": "FREEGIFT",
+            "title": "Free Socks with Shoe Purchase",
+            "amount": 1200,
+            "gift_line_item_id": "li_2"
+          }
+        ]
+      },
+      "totals": [
+        {"type": "subtotal", "display_text": "Subtotal", "amount": 8000},
+        {"type": "total", "display_text": "Total", "amount": 8000}
+      ]
+    }
+    ```
+
+Here, `applied_discount.amount` (1200) reflects the retail value of the
+gifted item, even though it doesn't appear as a line-item or order-level
+discount total — the gift is already reflected by the granted line item's
+own `0` price. Platforms use `gift_line_item_id` to find and label `li_2`,
+and `amount` to communicate the gift's value to the buyer (e.g. "$12 value,
+free").
+
 ## Eligibility Claims
 
 Eligibility claims are buyer claims about eligible benefits (see

--- a/docs/specification/discount.md
+++ b/docs/specification/discount.md
@@ -220,16 +220,19 @@ This lets a platform render, for example, "Free gift: T-Shirt — added by
 Summer Sale" instead of surfacing an unexplained zero-price item.
 
 `applied_discount.amount` is still required even when `gift_line_item_ids`
-is present. The granted line item's own `price` and `totals[]` already
-carry its regular value and discount delta — same as for any other
-line-item-targeted discount — so `amount` is technically re-derivable from
-`line_items[]`. It stays explicit anyway for the same reason `amount` isn't
-dropped for ordinary discounts either, even though it already equals
-`sum(allocations[].amount)`: a platform shouldn't have to cross-reference
-into `line_items[]` (or sum an array) just to answer "how much was this
-discount worth" — `amount` gives that number directly, and
-`allocations`/`gift_line_item_ids` are there for whoever wants the
-breakdown. See the example below.
+is present, for the same reason it's required for every discount, gift or
+not: `allocations` is optional, so there may be nothing to sum at all. And
+even when a gift line item's own `price`/`totals[]` correctly show its
+regular value and discount delta, nothing guarantees this is the *only*
+discount touching that line item — an unrelated discount (e.g. a
+storewide percentage-off) can add its own `items_discount` entry to the
+same line item, and nothing in `totals[]` says which discount produced
+which entry. Reading the line item's totals only tells you the combined
+effect of everything that hit it, not this discount's individual share.
+`amount` is the one value a platform can always attribute to this specific
+discount, regardless of whether the business provides `allocations` or how
+many other discounts happen to be stacked on the same items. See the
+example below.
 
 ### Example: Free gift with purchase
 

--- a/docs/specification/discount.md
+++ b/docs/specification/discount.md
@@ -193,26 +193,35 @@ segment, or promotional rules:
 
 ## Gift Line Items
 
-Some discounts grant an entirely new line item to the cart or checkout — a
-free or discounted product — rather than reducing the price of items the
-buyer already added (e.g. "buy one get one free," or a free-gift-with-purchase
-promotion).
+Some discounts grant one or more entirely new line items to the cart or
+checkout — a free or discounted product — rather than reducing the price of
+items the buyer already added (e.g. "buy one get one free," or a
+free-gift-with-purchase promotion).
 
-When a discount grants a line item this way:
+When a discount grants line items this way:
 
-- The granted item **MUST** appear as a normal entry in `line_items[]`, with
-  its price reflecting the discount (typically `0`, but a reduced non-zero
-  price is also valid for "buy X get Y at $Z" patterns).
+- Each granted item **MUST** appear as a normal entry in `line_items[]`,
+  with its price reflecting the discount (typically `0`, but a reduced
+  non-zero price is also valid for "buy X get Y at $Z" patterns).
 - The corresponding `applied_discount` entry **MUST** set
-  `gift_line_item_id` to that line item's `id`, so platforms can attribute
-  the item to the promotion rather than treating it as an unexplained
-  addition.
-- `gift_line_item_id` is omitted for ordinary amount-based discounts — it
-  only applies when the discount's effect is granting a line item, not
-  reducing the price of one.
+  `gift_line_item_ids` to those line items' `id`s, so platforms can
+  attribute the items to the promotion rather than treating them as
+  unexplained additions. Most promotions grant a single gift, so this is
+  usually a one-element array — it holds more than one entry when a single
+  discount grants multiple gift units (e.g. "buy 2, get 2 free" scaling with
+  how much the buyer already added).
+- `gift_line_item_ids` is omitted for ordinary amount-based discounts — it
+  only applies when the discount's effect is granting line items, not
+  reducing the price of ones already in the cart.
 
 This lets a platform render, for example, "Free gift: T-Shirt — added by
 Summer Sale" instead of surfacing an unexplained zero-price item.
+
+`applied_discount.amount` is still required even when `gift_line_item_ids`
+is present: by the time a gift line item is serialized its price already
+reflects the discount (typically `0`), and the schema has no separate
+"regular price" field to recover the gift's value from — `amount` is the
+only place that value is communicated. See the example below.
 
 ### Example: Free gift with purchase
 
@@ -279,7 +288,7 @@ Summer Sale" instead of surfacing an unexplained zero-price item.
             "code": "FREEGIFT",
             "title": "Free Socks with Shoe Purchase",
             "amount": 1200,
-            "gift_line_item_id": "li_2"
+            "gift_line_item_ids": ["li_2"]
           }
         ]
       },
@@ -293,9 +302,30 @@ Summer Sale" instead of surfacing an unexplained zero-price item.
 Here, `applied_discount.amount` (1200) reflects the retail value of the
 gifted item, even though it doesn't appear as a line-item or order-level
 discount total — the gift is already reflected by the granted line item's
-own `0` price. Platforms use `gift_line_item_id` to find and label `li_2`,
+own `0` price. Platforms use `gift_line_item_ids` to find and label `li_2`,
 and `amount` to communicate the gift's value to the buyer (e.g. "$12 value,
 free").
+
+### Example: Multiple gifts from one discount
+
+A "buy 2 shirts, get 2 socks free" promotion where the buyer added 4 shirts
+grants two gift line items from the same discount:
+
+<!-- ucp:example schema=shopping/cart target=$.discounts.applied -->
+```json
+[
+  {
+    "code": "BUYSHIRTGETSOCKS",
+    "title": "Free Socks with Every 2 Shirts",
+    "amount": 2400,
+    "gift_line_item_ids": ["li_2", "li_3"]
+  }
+]
+```
+
+`amount` (2400) is the combined retail value of both gifted pairs of socks;
+`gift_line_item_ids` lists each one so the platform can label them
+individually.
 
 ## Eligibility Claims
 

--- a/source/schemas/shopping/discount.json
+++ b/source/schemas/shopping/discount.json
@@ -77,9 +77,12 @@
           },
           "description": "Breakdown of where this discount was allocated. Sum of allocation amounts equals total amount."
         },
-        "gift_line_item_id": {
-          "type": "string",
-          "description": "The `id` of the `line_items[]` entry granted to the cart or checkout as a free or discounted gift because of this discount (e.g. a 'buy X get Y free' or free-gift-with-purchase promotion). Present only when the discount's effect is granting a line item rather than reducing the price of one; omitted for ordinary amount-based discounts."
+        "gift_line_item_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The `id`s of the `line_items[]` entries granted to the cart or checkout as a free or discounted gift because of this discount (e.g. a 'buy X get Y free' or free-gift-with-purchase promotion). More than one entry when a single discount grants multiple gift units (e.g. 'buy 2, get 2 free' scaling with quantity). Present only when the discount's effect is granting one or more line items rather than reducing the price of one; omitted for ordinary amount-based discounts."
         }
       }
     },

--- a/source/schemas/shopping/discount.json
+++ b/source/schemas/shopping/discount.json
@@ -76,6 +76,10 @@
             "$ref": "#/$defs/allocation"
           },
           "description": "Breakdown of where this discount was allocated. Sum of allocation amounts equals total amount."
+        },
+        "gift_line_item_id": {
+          "type": "string",
+          "description": "The `id` of the `line_items[]` entry granted to the cart or checkout as a free or discounted gift because of this discount (e.g. a 'buy X get Y free' or free-gift-with-purchase promotion). Present only when the discount's effect is granting a line item rather than reducing the price of one; omitted for ordinary amount-based discounts."
         }
       }
     },


### PR DESCRIPTION
# Description

Some promotions grant a free or discounted line item (buy-one-get-one, free-gift-with-purchase) rather than reducing the price of an item the buyer already has. Today `applied_discount` can only describe an amount-based effect — a business granting a gift line item has no structured way to link it back to the discount that produced it, so a platform/agent sees an unexplained zero-price item in `line_items[]`.

This adds an optional `gift_line_item_id` field to `applied_discount`, pointing at the `line_items[]` entry the discount granted. It's omitted for ordinary amount-based discounts, so this is backward compatible.

Motivated by implementing the discount extension against a commerce backend whose "gift line item" cart discount type is a common, first-class promotion pattern — this gap surfaced immediately when mapping that feature onto the current schema.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [x] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None filed yet — happy to open one first if maintainers would rather see this go through a fuller proposal before schema changes.

## Checklist

- [x] I have followed the Contributing Guide (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [ ] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A — schema/documentation change only.