### PR TITLE
docs: update fulfillment extension fields to target checkout

### DIFF
--- a/docs/specification/fulfillment.md
+++ b/docs/specification/fulfillment.md
@@ -61,7 +61,7 @@ method.
 
 ### Properties
 
-{{ extension_fields('fulfillment', 'fulfillment') }}
+{{ extension_fields('fulfillment', 'checkout') }}
 
 ### Entities
 

--- a/docs/specification/fulfillment.md
+++ b/docs/specification/fulfillment.md
@@ -61,7 +61,7 @@ method.
 
 ### Properties
 
-{{ extension_fields('fulfillment', 'checkout') }}
+{{ extension_fields('fulfillment', 'fulfillment') }}
 
 ### Entities
 

--- a/main.py
+++ b/main.py
@@ -1243,7 +1243,7 @@ def define_env(env):
 
   # --- MACRO 2: For Standalone JSON Extensions ---
   @env.macro
-  def extension_fields(entity_name, spec_file_name):
+  def extension_fields(entity_name, spec_file_name, target="checkout"):
     """Parse an extension schema file and render a table from its $defs.
 
     Usage: {{ extension_fields('discount', 'checkout') }}
@@ -1253,6 +1253,8 @@ def define_env(env):
       entity_name: The name of the extension schema (e.g., 'discount').
       spec_file_name: The name of the spec file indicating where the dictionary
         should be rendered (e.g., "checkout", "fulfillment").
+      target: Optional. The core schema name that is being extended (e.g.,
+        "checkout", "cart"). Defaults to "checkout".
 
     """
     # Construct full path based on new structure
@@ -1265,8 +1267,22 @@ def define_env(env):
       # or $defs.order_line_item.
       defs = data.get("$defs", {})
 
-      # Dynamically find the composed type by looking for an entry with 'allOf'
-      # where one of the items defines 'properties'.
+      # Try to find the specific target first (e.g. dev.ucp.shopping.checkout)
+      # We look for a key that ends with target.
+      target_def = None
+      for key, schema_def in defs.items():
+        if (key == target or key.endswith("." + target)) and (
+          isinstance(schema_def, dict) and "allOf" in schema_def
+        ):
+          target_def = schema_def
+          break
+
+      if target_def:
+        for item in target_def["allOf"]:
+          if "properties" in item:
+            return _render_table_from_schema(item, spec_file_name)
+
+      # Fallback to dynamically finding the composed type (old behavior)
       for schema_def in defs.values():
         if isinstance(schema_def, dict) and "allOf" in schema_def:
           for item in schema_def["allOf"]:
@@ -1274,7 +1290,8 @@ def define_env(env):
               return _render_table_from_schema(item, spec_file_name)
 
       raise RuntimeError(
-        f"Could not find extension properties in '{entity_name}'"
+        f"Could not find extension properties for target '{target}' "
+        f"in '{entity_name}'"
         f"{get_error_context()}"
       )
     except (FileNotFoundError, json.JSONDecodeError) as e:


### PR DESCRIPTION
# Description
Originated from https://github.com/Universal-Commerce-Protocol/ucp/pull/588

Update the `extension_fields` macro call in `fulfillment.md` to use `'checkout'` as the second argument (spec file name) instead of `'fulfillment'`. This ensures that references in the rendered properties table correctly target the checkout specification context where these extension fields are applied.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.
