### PR TITLE
feat(catalog): add brand, condition, and availability/brand filters

### DIFF
--- a/docs/specification/catalog/index.md
+++ b/docs/specification/catalog/index.md
@@ -106,11 +106,20 @@ A catalog item representing a sellable item with one or more purchasable variant
 relevant variant and image first—default for lookups, best match based on query
 and context for search. Platforms SHOULD treat the first element as featured.
 
+`brand` identifies the manufacturer or brand name generally recognized by
+consumers. Businesses SHOULD provide the brand name only when a genuine brand
+applies — do not submit placeholder values such as "Generic" or "N/A".
+
 {{ schema_fields('types/product', 'catalog') }}
 
 ### Variant
 
 A purchasable item with specific option selections, price, and availability.
+
+`condition` describes the item state using an open vocabulary. Well-known
+values: `new` (original, unopened packaging), `refurbished` (professionally
+restored, with warranty), `used` (previously used, original packaging may be
+missing). When omitted, platforms SHOULD assume `new`.
 
 In lookup responses, each variant carries an `inputs` array for correlation:
 which request identifiers resolved to this variant, and whether the match

--- a/docs/specification/catalog/search.md
+++ b/docs/specification/catalog/search.md
@@ -19,7 +19,7 @@
 * **Capability Name:** `dev.ucp.shopping.catalog.search`
 
 Performs a search against the business's product catalog. Supports free-text
-queries, filtering by category and price, and pagination.
+queries, filtering by category, price, availability, and brand, and pagination.
 
 ## Operation
 
@@ -60,6 +60,22 @@ merchants MAY support additional custom filters via `additionalProperties`.
 ### Price Filter
 
 {{ schema_fields('types/price_filter', 'catalog') }}
+
+### Availability Filter
+
+The `availability` filter narrows results to products with at least one variant
+matching a listed status. Values use the same vocabulary defined in the variant
+`availability.status` field.
+
+When omitted, the business returns products regardless of availability status.
+Businesses that do not track availability status MAY ignore this filter and
+SHOULD notify the platform via a message.
+
+### Brand Filter
+
+The `brand` filter narrows results to products whose `brand` field matches any
+listed value (OR logic). Matching SHOULD be case-insensitive. Businesses that
+do not index brand data MAY ignore this filter.
 
 ## Pagination
 

--- a/source/schemas/shopping/types/product.json
+++ b/source/schemas/shopping/types/product.json
@@ -24,6 +24,10 @@
       "type": "string",
       "description": "Product title."
     },
+    "brand": {
+      "type": "string",
+      "description": "Brand or manufacturer name (e.g., 'Nike', 'Sony')."
+    },
     "description": {
       "$ref": "../../common/types/description.json",
       "description": "Product description in one or more formats."

--- a/source/schemas/shopping/types/search_filters.json
+++ b/source/schemas/shopping/types/search_filters.json
@@ -12,6 +12,16 @@
     },
     "price": {
       "$ref": "price_filter.json"
+    },
+    "availability": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Filter by variant availability status (OR logic — matches products with at least one variant whose availability.status matches a listed value). Values use the same vocabulary defined in availability.status."
+    },
+    "brand": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Filter by brand name (OR logic — matches products whose brand field matches any listed value). Values are case-insensitive."
     }
   },
   "additionalProperties": true

--- a/source/schemas/shopping/types/variant.json
+++ b/source/schemas/shopping/types/variant.json
@@ -37,6 +37,10 @@
       },
       "description": "Industry-standard product identifiers for cross-reference and correlation."
     },
+    "condition": {
+      "type": "string",
+      "description": "Item condition. Well-known values: `new`, `refurbished`, `used`."
+    },
     "handle": {
       "type": "string",
       "description": "URL-safe variant handle/slug."


### PR DESCRIPTION
Add commonly-needed product attributes and search filters to the catalog capability, improving agent discovery and product disambiguation.

## Changes

### Product schema (types/product.json)
- Add `brand` (string, optional): manufacturer or brand name recognized by consumers. Enables brand-based filtering and cross-merchant disambiguation.

### Variant schema (types/variant.json)
- Add `condition` (string, optional, open vocabulary): item state. Well-known values: `new`, `refurbished`, `used`.

### Search filters (types/search_filters.json)
- Add `availability` filter (array of strings, OR logic): narrow results to products with at least one variant matching a listed availability status (`in_stock`, `backorder`, `preorder`).
- Add `brand` filter (array of strings, OR logic, case-insensitive): narrow results by brand name.

### Documentation (docs/specification/catalog/)
- Update search.md: document availability and brand filter semantics.
- Update index.md: document brand and condition field conventions.

## Design Notes

- All fields are optional and backward-compatible.
- Field names and well-known values use widely adopted commerce conventions (`brand`, `condition`, `in_stock`, `preorder`, etc.).
- `condition` and `availability.status` use open vocabularies (not closed enums), consistent with UCP's schema-authoring conventions for extensibility.
- Filters follow the existing pattern: array values use OR logic within a filter; multiple filters combine with AND logic.
- Businesses MAY ignore filters they do not support and SHOULD notify the platform via a message when doing so.