### PR TITLE
feat: Add 2 more well-known values (stable user ID & location) to signals for abuse prevention

### DIFF
--- a/docs/specification/checkout-a2a.md
+++ b/docs/specification/checkout-a2a.md
@@ -267,7 +267,12 @@ checkout object containing an `order` attribute with `id` and `permalink_url`.
             "a2a.ucp.checkout.payment": { ... },
             "a2a.ucp.checkout.signals": {
               "dev.ucp.buyer_ip": "203.0.113.42",
-              "dev.ucp.user_agent": "Mozilla/5.0 ..."
+              "dev.ucp.user_agent": "Mozilla/5.0 ...",
+              "dev.ucp.user_id": "0a041b9462caa4a31bac3567e...",
+              "dev.ucp.user_location": {
+                "address_region": "CA",
+                "address_country": "US"
+              }
             }
           }
         }

--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -804,7 +804,12 @@ place to set these expectations via `messages`.
       },
       "signals": {
         "dev.ucp.buyer_ip": "203.0.113.42",
-        "dev.ucp.user_agent": "Mozilla/5.0 ..."
+        "dev.ucp.user_agent": "Mozilla/5.0 ...",
+        "dev.ucp.user_id": "0a041b9462caa4a31bac3567e...",
+        "dev.ucp.user_location": {
+          "address_region": "CA",
+          "address_country": "US"
+        }
       }
     }
     ```

--- a/docs/specification/examples/encrypted-credential-handler.md
+++ b/docs/specification/examples/encrypted-credential-handler.md
@@ -334,7 +334,12 @@ Content-Type: application/json
   },
   "signals": {
     "dev.ucp.buyer_ip": "203.0.113.42",
-    "dev.ucp.user_agent": "Mozilla/5.0 ..."
+    "dev.ucp.user_agent": "Mozilla/5.0 ...",
+    "dev.ucp.user_id": "0a041b9462caa4a31bac3567e...",
+    "dev.ucp.user_location": {
+      "address_region": "CA",
+      "address_country": "US"
+    }
   }
 }
 ```

--- a/docs/specification/examples/platform-tokenizer-payment-handler.md
+++ b/docs/specification/examples/platform-tokenizer-payment-handler.md
@@ -403,7 +403,12 @@ Content-Type: application/json
   },
   "signals": {
     "dev.ucp.buyer_ip": "203.0.113.42",
-    "dev.ucp.user_agent": "Mozilla/5.0 ..."
+    "dev.ucp.user_agent": "Mozilla/5.0 ...",
+    "dev.ucp.user_id": "0a041b9462caa4a31bac3567e...",
+    "dev.ucp.user_location": {
+      "address_region": "CA",
+      "address_country": "US"
+    }
   }
 }
 ```

--- a/docs/specification/examples/processor-tokenizer-payment-handler.md
+++ b/docs/specification/examples/processor-tokenizer-payment-handler.md
@@ -273,7 +273,12 @@ Content-Type: application/json
   },
   "signals": {
     "dev.ucp.buyer_ip": "203.0.113.42",
-    "dev.ucp.user_agent": "Mozilla/5.0 ..."
+    "dev.ucp.user_agent": "Mozilla/5.0 ...",
+    "dev.ucp.user_id": "0a041b9462caa4a31bac3567e...",
+    "dev.ucp.user_location": {
+      "address_region": "CA",
+      "address_country": "US"
+    }
   }
 }
 ```

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -1696,7 +1696,12 @@ POST /checkout-sessions/{id}/complete
   },
   "signals": {
     "dev.ucp.buyer_ip": "203.0.113.42",
-    "dev.ucp.user_agent": "Mozilla/5.0 ..."
+    "dev.ucp.user_agent": "Mozilla/5.0 ...",
+    "dev.ucp.user_id": "0a041b9462caa4a31bac3567e...",
+    "dev.ucp.user_location": {
+      "address_region": "SC",
+      "address_country": "US"
+    }
   }
 }
 ```
@@ -1763,7 +1768,12 @@ POST /checkout-sessions/{id}/complete
   },
   "signals": {
     "dev.ucp.buyer_ip": "203.0.113.42",
-    "dev.ucp.user_agent": "Mozilla/5.0 ..."
+    "dev.ucp.user_agent": "Mozilla/5.0 ...",
+    "dev.ucp.user_id": "0a041b9462caa4a31bac3567e...",
+    "dev.ucp.user_location": {
+      "address_region": "CA",
+      "address_country": "US"
+    }
   }
 }
 ```
@@ -1845,6 +1855,7 @@ POST /checkout-sessions/{id}/complete
   },
   "signals": {
     "dev.ucp.buyer_ip": "203.0.113.42",
+    "dev.ucp.user_id": "0a041b9462caa4a31bac3567e...",
     "com.example.risk_score": 0.95
   },
   "ap2": {
@@ -1930,7 +1941,7 @@ certified and handle:
 UCP supports fraud prevention through [Signals](#signals) and the
 payment architecture:
 
-- Platforms provide transaction environment [signals](#signals) (IP, user
+- Platforms provide transaction environment [signals](#signals) (e.g., IP, user
     agent) on catalog, cart, and checkout requests
 - Businesses can require additional fields in handler configurations (e.g.,
     3DS requirements)

--- a/source/schemas/shopping/types/signals.json
+++ b/source/schemas/shopping/types/signals.json
@@ -16,6 +16,14 @@
     "dev.ucp.user_agent": {
       "type": "string",
       "description": "Client's HTTP User-Agent header or equivalent."
+    },
+    "dev.ucp.user_id": {
+      "type": "string",
+      "description": "A stable, opaque identifier for the user represented by the platform. MUST be consistent across sessions for the same user."
+    },
+    "dev.ucp.user_location": {
+      "$ref": "../../common/types/locality.json",
+      "description": "User's geographic location. Platforms SHOULD populate at least region & country."
     }
   },
   "additionalProperties": true


### PR DESCRIPTION
# Description

Add 2 more well-known values to `signals.json` to help with abuse prevention.
- `dev.ucp.user_id`: identifier representing the end-user that remains stable across multiple sessions
- `dev.ucp.user_location`: address location of the end-user that is detected by the platform (may differ from contextual hints and/or billing/shipping address)

Propose to add them under UCP's namespace as these are common, generic first-class signals instead of vendor specific.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [x] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.
