### PR TITLE
docs: redirect MAINTAINERS.md to central repository

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,44 +16,4 @@
 
 # UCP Maintainers
 
-## Tech Council
-
-The Tech Council is responsible for the technical direction and overall
-design of the protocol.
-
-<!-- cSpell:ignore Amit Handa Anurag Sinha Daniel Wyckoff Drew Olson -->
-<!-- cSpell:ignore Greg Smith Ilya Grigorik Imran Hoosain James Andersen -->
-<!-- cSpell:ignore Jing Li Lee Richmond Maxime Najim Uddhav Kambli -->
-<!-- cSpell:ignore Patrick Jordan Prasad Wangikar Scot DeDeo Twum Djin -->
-<!-- cSpell:ignore Victoria Duggan -->
-| Name | Company |
-| :--- | :--- |
-| Amit Handa | Google |
-| Anurag Sinha | Google |
-| Daniel Wyckoff | Shopify |
-| Drew Olson | Google |
-| Greg Smith | Amazon |
-| Ilya Grigorik | Shopify |
-| Imran Hoosain | Etsy |
-| James Andersen | Meta |
-| Jing Li | Google |
-| Lee Richmond | Shopify |
-| Maxime Najim | Target |
-| Patrick Jordan | Microsoft |
-| Prasad Wangikar | Stripe |
-| Scot DeDeo | Salesforce |
-| Uddhav Kambli | Wayfair |
-| Victoria Duggan | Shopify |
-
-## Governance Council
-
-The Governance Council is responsible for the overall adoption and health of
-the protocol.
-
-| Name | Company |
-| :--- | :--- |
-| Amit Handa | Google |
-| Ilya Grigorik | Shopify |
-| Twum Djin | Stripe |
-| Open | to be elected |
-| Open | to be elected |
+Please see the central [MAINTAINERS.md](https://github.com/Universal-Commerce-Protocol/.github/blob/main/MAINTAINERS.md) in the `.github` repository.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ We welcome community contributions to enhance and evolve UCP.
 - **Contribution Guide:** See our
   [CONTRIBUTING.md](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md)
   for details on how to contribute.
+- **Maintainers:** See our central
+  [MAINTAINERS.md](https://github.com/Universal-Commerce-Protocol/.github/blob/main/MAINTAINERS.md)
+  for the list of project maintainers.
 - **Specific Repositories:** When contributing to SDKs, Samples, Conformance,
   or other UCP repositories, please follow the developer instructions in the
   README of those repositories.


### PR DESCRIPTION
# Description

Redirect `MAINTAINERS.md` to the central one in the `.github` repository to establish a single source of truth. Also update `README.md` to directly reference the central `MAINTAINERS.md`.

## Category (Required)

- [ ] **Core Protocol**
- [ ] **Governance/Contributing**
- [ ] **Capability**
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**
- [ ] **Maintenance**
- [ ] **SDK**
- [ ] **Samples / Conformance**
- [ ] **UCP Schema**
- [ ] **Community Health (.github)**

## Related Issues

None.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A
