### PR TITLE
docs(shopping): add MCP method, param, and result descriptions for agent tooling parity

### DIFF
--- a/source/services/shopping/mcp.openrpc.json
+++ b/source/services/shopping/mcp.openrpc.json
@@ -68,6 +68,28 @@
           }
         }
       }
+    },
+    "errors": {
+      "authentication_failed": {
+        "code": -32002,
+        "message": "Authentication failed",
+        "data": { "$ref": "../../schemas/common/types/error_response.json" }
+      },
+      "invalid_params": {
+        "code": -32602,
+        "message": "Invalid params",
+        "data": { "$ref": "../../schemas/common/types/error_response.json" }
+      },
+      "not_found": {
+        "code": -32001,
+        "message": "Resource not found",
+        "data": { "$ref": "../../schemas/common/types/error_response.json" }
+      },
+      "idempotency_conflict": {
+        "code": -32003,
+        "message": "Idempotency conflict",
+        "data": { "$ref": "../../schemas/common/types/error_response.json" }
+      }
     }
   },
   "methods": [
@@ -79,18 +101,23 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "checkout",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/checkout.json"}
+          "schema": { "$ref": "../../schemas/shopping/checkout.json" }
         }
       ],
       "result": {
         "name": "checkout",
-        "schema": {"$ref": "#/components/schemas/checkout_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/checkout_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/idempotency_conflict" }
+      ]
     },
     {
       "name": "get_checkout",
@@ -99,18 +126,24 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         }
       ],
       "result": {
         "name": "checkout",
-        "schema": {"$ref": "#/components/schemas/checkout_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/checkout_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/not_found" }
+      ]
     },
     {
       "name": "update_checkout",
@@ -119,23 +152,30 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         },
         {
           "name": "checkout",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/checkout.json"}
+          "schema": { "$ref": "../../schemas/shopping/checkout.json" }
         }
       ],
       "result": {
         "name": "checkout",
-        "schema": {"$ref": "#/components/schemas/checkout_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/checkout_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/not_found" }
+      ]
     },
     {
       "name": "complete_checkout",
@@ -146,26 +186,39 @@
           "required": true,
           "schema": {
             "allOf": [
-              {"$ref": "#/components/schemas/meta"},
-              {"required": ["ucp-agent", "idempotency-key"]}
+              { "$ref": "#/components/schemas/meta" },
+              {
+                "required": [
+                  "ucp-agent",
+                  "idempotency-key"
+                ]
+              }
             ]
           }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         },
         {
           "name": "checkout",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/checkout.json"}
+          "schema": { "$ref": "../../schemas/shopping/checkout.json" }
         }
       ],
       "result": {
         "name": "checkout",
-        "schema": {"$ref": "#/components/schemas/checkout_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/checkout_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/not_found" },
+        { "$ref": "#/components/errors/idempotency_conflict" }
+      ]
     },
     {
       "name": "cancel_checkout",
@@ -176,21 +229,34 @@
           "required": true,
           "schema": {
             "allOf": [
-              {"$ref": "#/components/schemas/meta"},
-              {"required": ["ucp-agent", "idempotency-key"]}
+              { "$ref": "#/components/schemas/meta" },
+              {
+                "required": [
+                  "ucp-agent",
+                  "idempotency-key"
+                ]
+              }
             ]
           }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         }
       ],
       "result": {
         "name": "checkout",
-        "schema": {"$ref": "#/components/schemas/checkout_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/checkout_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/not_found" },
+        { "$ref": "#/components/errors/idempotency_conflict" }
+      ]
     },
     {
       "name": "create_cart",
@@ -200,18 +266,23 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "cart",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/cart.json"}
+          "schema": { "$ref": "../../schemas/shopping/cart.json" }
         }
       ],
       "result": {
         "name": "cart",
-        "schema": {"$ref": "#/components/schemas/cart_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/cart_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/idempotency_conflict" }
+      ]
     },
     {
       "name": "get_cart",
@@ -220,18 +291,24 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         }
       ],
       "result": {
         "name": "cart",
-        "schema": {"$ref": "#/components/schemas/cart_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/cart_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/not_found" }
+      ]
     },
     {
       "name": "update_cart",
@@ -240,23 +317,30 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         },
         {
           "name": "cart",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/cart.json"}
+          "schema": { "$ref": "../../schemas/shopping/cart.json" }
         }
       ],
       "result": {
         "name": "cart",
-        "schema": {"$ref": "#/components/schemas/cart_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/cart_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/not_found" }
+      ]
     },
     {
       "name": "cancel_cart",
@@ -267,21 +351,34 @@
           "required": true,
           "schema": {
             "allOf": [
-              {"$ref": "#/components/schemas/meta"},
-              {"required": ["ucp-agent", "idempotency-key"]}
+              { "$ref": "#/components/schemas/meta" },
+              {
+                "required": [
+                  "ucp-agent",
+                  "idempotency-key"
+                ]
+              }
             ]
           }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         }
       ],
       "result": {
         "name": "cart",
-        "schema": {"$ref": "#/components/schemas/cart_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/cart_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/not_found" },
+        { "$ref": "#/components/errors/idempotency_conflict" }
+      ]
     },
     {
       "name": "search_catalog",
@@ -291,18 +388,22 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "catalog",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_request"}
+          "schema": { "$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_request" }
         }
       ],
       "result": {
         "name": "response",
-        "schema": {"$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_response"}
-      }
+        "schema": { "$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_response" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" }
+      ]
     },
     {
       "name": "lookup_catalog",
@@ -312,18 +413,22 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "catalog",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_request"}
+          "schema": { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_request" }
         }
       ],
       "result": {
         "name": "response",
-        "schema": {"$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_response"}
-      }
+        "schema": { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_response" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" }
+      ]
     },
     {
       "name": "get_order",
@@ -333,18 +438,25 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string", "description": "The unique identifier of the order."}
+          "schema": {
+            "type": "string",
+            "description": "The unique identifier of the order."
+          }
         }
       ],
       "result": {
         "name": "order",
-        "schema": {"$ref": "#/components/schemas/order_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/order_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/not_found" }
+      ]
     },
     {
       "name": "get_product",
@@ -354,18 +466,22 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "catalog",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/get_product_request"}
+          "schema": { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/get_product_request" }
         }
       ],
       "result": {
         "name": "response",
-        "schema": {"$ref": "#/components/schemas/catalog_get_product_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/catalog_get_product_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" }
+      ]
     }
   ]
 }

--- a/source/services/shopping/mcp.openrpc.json
+++ b/source/services/shopping/mcp.openrpc.json
@@ -65,6 +65,11 @@
             "type": "string",
             "format": "uuid",
             "description": "Unique key for retry safety. Maps to HTTP Idempotency-Key header."
+          },
+          "request-id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique request identifier for tracing across network layers. Maps to HTTP Request-Id header."
           }
         }
       }
@@ -100,17 +105,20 @@
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification and optional idempotency key.",
           "required": true,
           "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "checkout",
+          "description": "Checkout session state to create.",
           "required": true,
           "schema": { "$ref": "../../schemas/shopping/checkout.json" }
         }
       ],
       "result": {
         "name": "checkout",
+        "description": "The created checkout session or an error response.",
         "schema": { "$ref": "#/components/schemas/checkout_result" }
       },
       "errors": [
@@ -122,14 +130,17 @@
     {
       "name": "get_checkout",
       "summary": "Get checkout",
+      "description": "Get the latest state of a checkout session.",
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification.",
           "required": true,
           "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
+          "description": "The unique identifier of the checkout session.",
           "required": true,
           "schema": {
             "type": "string"
@@ -138,6 +149,7 @@
       ],
       "result": {
         "name": "checkout",
+        "description": "The current checkout session state or an error response.",
         "schema": { "$ref": "#/components/schemas/checkout_result" }
       },
       "errors": [
@@ -148,14 +160,17 @@
     {
       "name": "update_checkout",
       "summary": "Update checkout",
+      "description": "Update a checkout session. If an optional field is provided, its value replaces the corresponding data. If omitted, the current value is unchanged.",
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification.",
           "required": true,
           "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
+          "description": "The unique identifier of the checkout session.",
           "required": true,
           "schema": {
             "type": "string"
@@ -163,12 +178,14 @@
         },
         {
           "name": "checkout",
+          "description": "Checkout session fields to update.",
           "required": true,
           "schema": { "$ref": "../../schemas/shopping/checkout.json" }
         }
       ],
       "result": {
         "name": "checkout",
+        "description": "The updated checkout session or an error response.",
         "schema": { "$ref": "#/components/schemas/checkout_result" }
       },
       "errors": [
@@ -180,9 +197,11 @@
     {
       "name": "complete_checkout",
       "summary": "Complete checkout and place order",
+      "description": "Place the order.",
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification and required idempotency key.",
           "required": true,
           "schema": {
             "allOf": [
@@ -198,6 +217,7 @@
         },
         {
           "name": "id",
+          "description": "The unique identifier of the checkout session.",
           "required": true,
           "schema": {
             "type": "string"
@@ -205,12 +225,14 @@
         },
         {
           "name": "checkout",
+          "description": "Final checkout state for order placement.",
           "required": true,
           "schema": { "$ref": "../../schemas/shopping/checkout.json" }
         }
       ],
       "result": {
         "name": "checkout",
+        "description": "The completed checkout session or an error response.",
         "schema": { "$ref": "#/components/schemas/checkout_result" }
       },
       "errors": [
@@ -223,9 +245,11 @@
     {
       "name": "cancel_checkout",
       "summary": "Cancel checkout",
+      "description": "Cancel a checkout session.",
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification and required idempotency key.",
           "required": true,
           "schema": {
             "allOf": [
@@ -241,6 +265,7 @@
         },
         {
           "name": "id",
+          "description": "The unique identifier of the checkout session.",
           "required": true,
           "schema": {
             "type": "string"
@@ -249,6 +274,7 @@
       ],
       "result": {
         "name": "checkout",
+        "description": "The cancelled checkout session or an error response.",
         "schema": { "$ref": "#/components/schemas/checkout_result" }
       },
       "errors": [
@@ -265,17 +291,20 @@
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification and optional idempotency key.",
           "required": true,
           "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "cart",
+          "description": "Cart session state to create.",
           "required": true,
           "schema": { "$ref": "../../schemas/shopping/cart.json" }
         }
       ],
       "result": {
         "name": "cart",
+        "description": "The created cart session or an error response.",
         "schema": { "$ref": "#/components/schemas/cart_result" }
       },
       "errors": [
@@ -287,14 +316,17 @@
     {
       "name": "get_cart",
       "summary": "Get cart",
+      "description": "Get the latest state of a cart session.",
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification.",
           "required": true,
           "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
+          "description": "The unique identifier of the cart session.",
           "required": true,
           "schema": {
             "type": "string"
@@ -303,6 +335,7 @@
       ],
       "result": {
         "name": "cart",
+        "description": "The current cart session state or an error response.",
         "schema": { "$ref": "#/components/schemas/cart_result" }
       },
       "errors": [
@@ -313,14 +346,17 @@
     {
       "name": "update_cart",
       "summary": "Update cart",
+      "description": "Update a cart session.",
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification.",
           "required": true,
           "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
+          "description": "The unique identifier of the cart session.",
           "required": true,
           "schema": {
             "type": "string"
@@ -328,12 +364,14 @@
         },
         {
           "name": "cart",
+          "description": "Cart session fields to update.",
           "required": true,
           "schema": { "$ref": "../../schemas/shopping/cart.json" }
         }
       ],
       "result": {
         "name": "cart",
+        "description": "The updated cart session or an error response.",
         "schema": { "$ref": "#/components/schemas/cart_result" }
       },
       "errors": [
@@ -345,9 +383,11 @@
     {
       "name": "cancel_cart",
       "summary": "Cancel cart",
+      "description": "Cancel a cart session. Returns the cart state at time of cancellation.",
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification and required idempotency key.",
           "required": true,
           "schema": {
             "allOf": [
@@ -363,6 +403,7 @@
         },
         {
           "name": "id",
+          "description": "The unique identifier of the cart session.",
           "required": true,
           "schema": {
             "type": "string"
@@ -371,6 +412,7 @@
       ],
       "result": {
         "name": "cart",
+        "description": "The cancelled cart session or an error response.",
         "schema": { "$ref": "#/components/schemas/cart_result" }
       },
       "errors": [
@@ -387,17 +429,20 @@
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification.",
           "required": true,
           "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "catalog",
+          "description": "Catalog search query parameters.",
           "required": true,
           "schema": { "$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_request" }
         }
       ],
       "result": {
         "name": "response",
+        "description": "Catalog search results.",
         "schema": { "$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_response" }
       },
       "errors": [
@@ -412,17 +457,20 @@
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification.",
           "required": true,
           "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "catalog",
+          "description": "Catalog lookup request parameters.",
           "required": true,
           "schema": { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_request" }
         }
       ],
       "result": {
         "name": "response",
+        "description": "Catalog lookup results.",
         "schema": { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_response" }
       },
       "errors": [
@@ -437,6 +485,7 @@
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification.",
           "required": true,
           "schema": { "$ref": "#/components/schemas/meta" }
         },
@@ -451,6 +500,7 @@
       ],
       "result": {
         "name": "order",
+        "description": "The current order state or an error response.",
         "schema": { "$ref": "#/components/schemas/order_result" }
       },
       "errors": [
@@ -465,17 +515,20 @@
       "params": [
         {
           "name": "meta",
+          "description": "Request metadata containing platform identification.",
           "required": true,
           "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "catalog",
+          "description": "Product detail request parameters.",
           "required": true,
           "schema": { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/get_product_request" }
         }
       ],
       "result": {
         "name": "response",
+        "description": "Product details or an error response.",
         "schema": { "$ref": "#/components/schemas/catalog_get_product_result" }
       },
       "errors": [

--- a/source/services/shopping/mcp.openrpc.json
+++ b/source/services/shopping/mcp.openrpc.json
@@ -78,37 +78,44 @@
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification and any operation-specific idempotency key.",
           "required": true,
           "schema": {"$ref": "#/components/schemas/meta"}
         },
         {
           "name": "checkout",
+          "description": "Checkout input used to create the session.",
           "required": true,
           "schema": {"$ref": "../../schemas/shopping/checkout.json"}
         }
       ],
       "result": {
         "name": "checkout",
+        "description": "The created Checkout, or a UCP business outcome when no valid Checkout can be created.",
         "schema": {"$ref": "#/components/schemas/checkout_result"}
       }
     },
     {
       "name": "get_checkout",
       "summary": "Get checkout",
+      "description": "Get the latest state of a checkout session.",
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification.",
           "required": true,
           "schema": {"$ref": "#/components/schemas/meta"}
         },
         {
           "name": "id",
+          "description": "The unique identifier of the checkout session.",
           "required": true,
           "schema": {"type": "string"}
         }
       ],
       "result": {
         "name": "checkout",
+        "description": "The current Checkout, or a UCP business outcome when no valid Checkout can be returned.",
         "schema": {"$ref": "#/components/schemas/checkout_result"}
       }
     },
@@ -119,31 +126,37 @@
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification and any operation-specific idempotency key.",
           "required": true,
           "schema": {"$ref": "#/components/schemas/meta"}
         },
         {
           "name": "id",
+          "description": "The unique identifier of the checkout session.",
           "required": true,
           "schema": {"type": "string"}
         },
         {
           "name": "checkout",
+          "description": "Replacement Checkout state for the session.",
           "required": true,
           "schema": {"$ref": "../../schemas/shopping/checkout.json"}
         }
       ],
       "result": {
         "name": "checkout",
+        "description": "The authoritative Checkout after the update attempt, including any business outcome messages.",
         "schema": {"$ref": "#/components/schemas/checkout_result"}
       }
     },
     {
       "name": "complete_checkout",
       "summary": "Complete checkout and place order",
+      "description": "Complete a checkout session and place its order.",
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification and the required idempotency key.",
           "required": true,
           "schema": {
             "allOf": [
@@ -154,26 +167,31 @@
         },
         {
           "name": "id",
+          "description": "The unique identifier of the checkout session.",
           "required": true,
           "schema": {"type": "string"}
         },
         {
           "name": "checkout",
+          "description": "Checkout state used to complete the session and place the order.",
           "required": true,
           "schema": {"$ref": "../../schemas/shopping/checkout.json"}
         }
       ],
       "result": {
         "name": "checkout",
+        "description": "The Checkout after the completion attempt, including any business outcome messages.",
         "schema": {"$ref": "#/components/schemas/checkout_result"}
       }
     },
     {
       "name": "cancel_checkout",
       "summary": "Cancel checkout",
+      "description": "Cancel a checkout session.",
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification and the required idempotency key.",
           "required": true,
           "schema": {
             "allOf": [
@@ -184,12 +202,14 @@
         },
         {
           "name": "id",
+          "description": "The unique identifier of the checkout session.",
           "required": true,
           "schema": {"type": "string"}
         }
       ],
       "result": {
         "name": "checkout",
+        "description": "The canceled Checkout, or a UCP business outcome when no valid Checkout can be returned.",
         "schema": {"$ref": "#/components/schemas/checkout_result"}
       }
     },
@@ -200,71 +220,85 @@
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification and any operation-specific idempotency key.",
           "required": true,
           "schema": {"$ref": "#/components/schemas/meta"}
         },
         {
           "name": "cart",
+          "description": "Cart input used to create the session.",
           "required": true,
           "schema": {"$ref": "../../schemas/shopping/cart.json"}
         }
       ],
       "result": {
         "name": "cart",
+        "description": "The created Cart, or a UCP business outcome when no valid Cart can be created.",
         "schema": {"$ref": "#/components/schemas/cart_result"}
       }
     },
     {
       "name": "get_cart",
       "summary": "Get cart",
+      "description": "Get the latest state of a cart session.",
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification.",
           "required": true,
           "schema": {"$ref": "#/components/schemas/meta"}
         },
         {
           "name": "id",
+          "description": "The unique identifier of the cart session.",
           "required": true,
           "schema": {"type": "string"}
         }
       ],
       "result": {
         "name": "cart",
+        "description": "The current Cart, or a UCP business outcome when no valid Cart can be returned.",
         "schema": {"$ref": "#/components/schemas/cart_result"}
       }
     },
     {
       "name": "update_cart",
       "summary": "Update cart",
+      "description": "Replace the current state of a cart session.",
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification and any operation-specific idempotency key.",
           "required": true,
           "schema": {"$ref": "#/components/schemas/meta"}
         },
         {
           "name": "id",
+          "description": "The unique identifier of the cart session.",
           "required": true,
           "schema": {"type": "string"}
         },
         {
           "name": "cart",
+          "description": "Replacement Cart state for the session.",
           "required": true,
           "schema": {"$ref": "../../schemas/shopping/cart.json"}
         }
       ],
       "result": {
         "name": "cart",
+        "description": "The authoritative Cart after the update attempt, including any business outcome messages.",
         "schema": {"$ref": "#/components/schemas/cart_result"}
       }
     },
     {
       "name": "cancel_cart",
       "summary": "Cancel cart",
+      "description": "Cancel a cart session and return its state at cancellation.",
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification and the required idempotency key.",
           "required": true,
           "schema": {
             "allOf": [
@@ -275,12 +309,14 @@
         },
         {
           "name": "id",
+          "description": "The unique identifier of the cart session.",
           "required": true,
           "schema": {"type": "string"}
         }
       ],
       "result": {
         "name": "cart",
+        "description": "The canceled Cart, or a UCP business outcome when no valid Cart can be returned.",
         "schema": {"$ref": "#/components/schemas/cart_result"}
       }
     },
@@ -291,17 +327,20 @@
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification.",
           "required": true,
           "schema": {"$ref": "#/components/schemas/meta"}
         },
         {
           "name": "catalog",
+          "description": "Catalog search query, filters, and pagination input.",
           "required": true,
           "schema": {"$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_request"}
         }
       ],
       "result": {
         "name": "response",
+        "description": "Catalog search results and pagination state.",
         "schema": {"$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_response"}
       }
     },
@@ -312,17 +351,20 @@
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification.",
           "required": true,
           "schema": {"$ref": "#/components/schemas/meta"}
         },
         {
           "name": "catalog",
+          "description": "Catalog identifiers and lookup input.",
           "required": true,
           "schema": {"$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_request"}
         }
       ],
       "result": {
         "name": "response",
+        "description": "Catalog lookup results correlated to the requested identifiers.",
         "schema": {"$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_response"}
       }
     },
@@ -333,17 +375,20 @@
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification.",
           "required": true,
           "schema": {"$ref": "#/components/schemas/meta"}
         },
         {
           "name": "id",
+          "description": "The unique identifier of the order.",
           "required": true,
-          "schema": {"type": "string", "description": "The unique identifier of the order."}
+          "schema": {"type": "string"}
         }
       ],
       "result": {
         "name": "order",
+        "description": "The current Order, or a UCP business outcome when no valid Order can be returned.",
         "schema": {"$ref": "#/components/schemas/order_result"}
       }
     },
@@ -354,17 +399,20 @@
       "params": [
         {
           "name": "meta",
+          "description": "UCP request metadata containing Platform identification.",
           "required": true,
           "schema": {"$ref": "#/components/schemas/meta"}
         },
         {
           "name": "catalog",
+          "description": "Product identifier and optional interactive option selections.",
           "required": true,
           "schema": {"$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/get_product_request"}
         }
       ],
       "result": {
         "name": "response",
+        "description": "Product details, or a UCP business outcome when no valid product can be returned.",
         "schema": {"$ref": "#/components/schemas/catalog_get_product_result"}
       }
     }

--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -92,6 +92,36 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -157,6 +187,26 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/checkout_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
                 }
               }
             }
@@ -234,6 +284,46 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/checkout_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
                 }
               }
             }
@@ -317,6 +407,46 @@
                 "schema": { "$ref": "#/components/schemas/checkout_response" }
               }
             }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -391,6 +521,36 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -436,6 +596,36 @@
                 "schema": { "$ref": "#/components/schemas/cart_response" }
               }
             }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -472,6 +662,26 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/cart_response" }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
               }
             }
           }
@@ -517,6 +727,46 @@
                 "schema": { "$ref": "#/components/schemas/cart_response" }
               }
             }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -555,6 +805,36 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/cart_response" }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
               }
             }
           }
@@ -601,6 +881,26 @@
                 "schema": { "$ref": "#/components/schemas/catalog_search_response" }
               }
             }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -645,6 +945,26 @@
                 "schema": { "$ref": "#/components/schemas/catalog_lookup_response" }
               }
             }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -681,6 +1001,26 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/order_response" }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
               }
             }
           }
@@ -725,6 +1065,26 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/catalog_get_product_response" }
+              }
+            }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
               }
             }
           }
@@ -1021,6 +1381,9 @@
           { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/get_product_response" },
           { "$ref": "../../schemas/common/types/error_response.json" }
         ]
+      },
+      "error_response": {
+        "$ref": "../../schemas/common/types/error_response.json"
       }
     }
   }


### PR DESCRIPTION
# Description

The Shopping OpenRPC definition is the machine-readable source used to expose
UCP operations as MCP tools. Several methods had only a summary, while parameter
and result Content Descriptors had no descriptions. Tooling and agents therefore
had to infer how arguments and results should be used from names alone.

This PR adds descriptions to the existing contract without changing any schema,
required field, method name, or behavior:

- all 13 methods now have a description;
- all 29 parameters now have a Content Descriptor description; and
- all 13 results now distinguish returned UCP business outcomes from JSON-RPC
  transport errors.

The descriptions follow the current transport-neutral Shopping semantics. In
particular, Update Checkout and Update Cart are described as full-replacement
operations. The existing `get_order.id` description is moved from its nested
JSON Schema into the OpenRPC parameter Content Descriptor for consistency with
the other parameters.

Request tracing is deliberately out of scope. The previous branch revision
added a Shopping-only `meta.request-id`; standardizing request correlation is a
horizontal protocol decision and is not required to complete these descriptions.

## Category (Required)

- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)

## Related Issues

None.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all available local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works. Description coverage is asserted structurally rather than with a new test suite.
- [ ] New and existing unit tests pass locally with my changes. The repository's `uv`/`ucp-schema` toolchain is unavailable locally; CI is authoritative.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas. Not applicable: descriptions only.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk. Not applicable: no model schema changes.

## Screenshots / Logs (if applicable)

No visual change.

Local checks completed:

- JSON parse with `jq`;
- `git diff --check`;
- structural assertions: 13/13 methods, 29/29 parameters, and 13/13 results have descriptions; and
- structural assertion that no `meta.request-id` protocol field is introduced.
