### PR TITLE
feat: add inventory signals to availability schema

### DIFF
--- a/source/schemas/shopping/types/availability.json
+++ b/source/schemas/shopping/types/availability.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/shopping/types/availability.json",
   "title": "Availability",
-  "description": "Availability of an item: whether it can be obtained, and a qualifying status.",
+  "description": "Availability of an item: whether it can be obtained, a qualifying status, and optional inventory signals.",
   "type": "object",
   "properties": {
     "available": {
@@ -11,7 +11,17 @@
     },
     "status": {
       "type": "string",
-      "description": "Qualifies available with fulfillment state. Well-known values: `in_stock`, `backorder`, `preorder`, `out_of_stock`, `discontinued`."
+      "description": "Qualifies available with fulfillment state. Well-known values: `in_stock`, `low_stock`, `backorder`, `preorder`, `out_of_stock`, `discontinued`."
+    },
+    "quantity": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Available stock quantity. Business MAY omit if it does not expose exact counts."
+    },
+    "restock_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC 3339 estimated restock timestamp. Business MAY include when status is `out_of_stock` or `backorder`."
     }
   }
 }


### PR DESCRIPTION
Closes #345

## Summary

Extends the availability schema with optional inventory signals: stock quantity and restock ETA.

## Changes

- `source/schemas/shopping/types/availability.json`:
  - Added `low_stock` to well-known status values
  - Added optional `quantity` field (integer, min 0) for stock count
  - Added optional `restock_at` field (RFC 3339 datetime) for restock estimates

## Design decisions

- All new fields are optional — businesses that don't track inventory just omit them
- The existing `available` boolean remains the simple fallback
- `low_stock` added as a well-known status value (thresholds are a business decision)
- Dropped location-level inventory from the issue proposal to keep this minimal; location support can be added via the existing `retail_location` type in a follow-up
- Especially useful for voice/agent scenarios where stock signals guide buyer decisions