### PR TITLE
feat: add optional note field to line items

### DIFF
--- a/source/schemas/shopping/types/line_item.json
+++ b/source/schemas/shopping/types/line_item.json
@@ -41,6 +41,15 @@
         "create": "omit",
         "update": "optional"
       }
+    },
+    "note": {
+      "type": "string",
+      "maxLength": 500,
+      "description": "Buyer-supplied free-text note for this line item (e.g., gift wrapping instructions, dietary preferences, engraving text). Business echoes the value in responses and MAY include it in order webhook payloads for downstream fulfillment.",
+      "ucp_request": {
+        "create": "optional",
+        "update": "optional"
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #349

## Summary

Adds an optional `note` string field (max 500 chars) to the line item schema, allowing buyers to attach free-text per-item instructions.

## Use cases

- Food ordering: "no onions", "extra sauce"
- Gift wrapping / engraving instructions
- Voice agent scenarios: "make that a gift", "hold the pickles"

## Changes

- `source/schemas/shopping/types/line_item.json`: Added `note` property with `maxLength: 500` and appropriate `ucp_request` annotations

## Design decisions

- Plain text only — structured customization belongs in catalog item variants
- 500-char limit prevents abuse while covering reasonable instructions
- Business echoes the note in responses (confirming receipt)
- Business MAY forward to downstream fulfillment via order webhooks