### PR TITLE
feat(catalog): proposal for list_catalog operation 

### DIFF
--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -1,0 +1,128 @@
+# Catalog List Operation -- Paginated Catalog Enumeration for UCP
+
+**Capability:** `dev.ucp.shopping.catalog.list`
+
+## Motivation
+
+Platforms building agentic shopping experiences need to index a business's entire catalog for offline ranking, embedding, and recommendation. Today the only catalog operation in UCP is **search**, which requires a query or filter, returns relevance-ranked results, and is designed for buyer-initiated discovery rather than platform-initiated indexing. There is no way to deterministically enumerate all products in a business's catalog.
+
+A live list API fills this gap:
+
+- **Full enumeration** -- no query required, returns all products (paginated)
+- **Incremental sync** -- `modified_since` filter fetches only changes since last sync
+- **Real-time** -- reflects current catalog state, not a periodic snapshot
+- **Same schema** -- returns the same Product/Variant objects used by search and lookup
+
+Note: [RFC #550](https://github.com/Universal-Commerce-Protocol/ucp/issues/550) proposes a complementary static-feed approach for bulk discovery. This proposal addresses the live API use case independently.
+
+## How it fits
+
+| Operation  | Input                | Use case                           |
+| ---------- | -------------------- | ---------------------------------- |
+| **Search** | Query text + filters | Buyer-initiated discovery          |
+| **Lookup** | Known IDs            | Cart validation, deep links        |
+| **List**   | None required        | Platform indexing, incremental sync |
+
+## Design
+
+A new operation within the existing `dev.ucp.shopping.catalog` capability.
+No new capability namespace -- businesses that support catalog already have
+the infrastructure.
+
+### Request
+
+```json
+{
+  "filters": {
+    "modified_since": "2026-07-01T00:00:00Z"
+  },
+  "pagination": {
+    "cursor": "eyJsYXN0X2lkIjoicHJvZF8xMjM0In0=",
+    "limit": 100
+  }
+}
+```
+
+When no filters are provided, the operation returns all products in the catalog.
+
+### Response
+
+Same shape as `catalog.search` -- reuses existing pagination and product schemas:
+
+```json
+{
+  "ucp": {},
+  "products": [
+    {
+      "id": "prod_abc123",
+      "title": "Classic Running Shoe",
+      "description": { "plain": "Lightweight running shoe." },
+      "price_range": {
+        "min": { "amount": 8900, "currency": "USD" },
+        "max": { "amount": 12900, "currency": "USD" }
+      },
+      "variants": [
+        {
+          "id": "var_001",
+          "title": "Black / Size 10",
+          "description": { "plain": "Black colorway, men's size 10." },
+          "price": { "amount": 8900, "currency": "USD" },
+          "availability": { "available": true, "status": "in_stock" }
+        }
+      ]
+    }
+  ],
+  "pagination": {
+    "cursor": "eyJsYXN0X2lkIjoicHJvZF9hYmMxMjMifQ==",
+    "has_next_page": true,
+    "total_count": 5420
+  }
+}
+```
+
+### Key semantics
+
+- **Page size** -- implementations SHOULD accept at least 100 (higher than
+  search's 10, since list targets bulk ingestion)
+- **Ordering** -- stable and deterministic within a pagination sequence
+  (implementation-defined, typically by internal ID)
+- **`modified_since`** -- inclusive; covers any change to product or its
+  variants. Businesses that do not track modification timestamps MAY ignore
+  and return the full catalog, notifying via a message
+- **Deleted products** -- MAY be indicated via `messages` with
+  `code: "deleted"`, or omitted entirely
+
+## Design principles
+
+- **Purely additive.** New operation within an existing capability -- no
+  breaking changes.
+- **Shared product schema.** Same Product/Variant objects used by search and
+  lookup. Platforms reuse existing parsers.
+- **Existing pagination primitive.** Reuses `common/types/pagination.json`
+  already defined for search.
+- **Open vocabulary filters.** `list_filters.json` uses
+  `additionalProperties: true` for extensibility, matching `search_filters.json`.
+
+## Files in this PR
+
+| File                                              | Purpose                             |
+| ------------------------------------------------- | ----------------------------------- |
+| `source/schemas/shopping/catalog_list.json`       | Operation schema (request/response) |
+| `source/schemas/shopping/types/list_filters.json` | Filter type (`modified_since`)      |
+| `source/services/shopping/rest.openapi.json`      | OpenAPI -- `/catalog/list` endpoint |
+| `source/services/shopping/mcp.openrpc.json`       | OpenRPC -- `list_catalog` tool      |
+| `docs/specification/catalog/list.md`              | Specification page                  |
+| `docs/specification/catalog/index.md`             | Capabilities table                  |
+| `docs/specification/catalog/rest.md`              | REST binding (endpoint + example)   |
+| `docs/specification/catalog/mcp.md`               | MCP binding (tool entry)            |
+| `mkdocs.yml`                                      | Navigation                          |
+
+## Open questions for TC
+
+- **Scope** -- is list appropriate within `catalog`, or should it live under a
+  separate capability namespace?
+- **`modified_since` support** -- MUST vs MAY for businesses?
+- **Deleted product signaling** -- is `messages`-based sufficient, or should
+  deleted products appear with a `status` field?
+- **Rate limiting** -- should the spec include normative language about
+  rate-limiting list differently from search?

--- a/docs/specification/catalog/index.md
+++ b/docs/specification/catalog/index.md
@@ -18,13 +18,15 @@
 
 ## Overview
 
-The Catalog capability allows platforms to search and browse business product catalogs.
-This enables product discovery before checkout, supporting use cases like:
+The Catalog capability allows platforms to search, browse, and enumerate business
+product catalogs. This enables product discovery before checkout, supporting use
+cases like:
 
 * Free-text product search
 * Category and filter-based browsing
 * Batch product/variant retrieval by identifier
 * Price comparison across variants
+* Full catalog enumeration for platform indexing and incremental sync
 
 ## Capabilities
 
@@ -32,6 +34,7 @@ This enables product discovery before checkout, supporting use cases like:
 | :--- | :--- |
 | [`dev.ucp.shopping.catalog.search`](search.md) | Search for products using query text and filters. |
 | [`dev.ucp.shopping.catalog.lookup`](lookup.md) | Retrieve products or variants by identifier. |
+| [`dev.ucp.shopping.catalog.list`](list.md) | Paginate through the full product catalog. |
 
 ## Key Concepts
 

--- a/docs/specification/catalog/list.md
+++ b/docs/specification/catalog/list.md
@@ -1,0 +1,93 @@
+<!--
+   Copyright 2026 UCP Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# Catalog List Capability
+
+* **Capability Name:** `dev.ucp.shopping.catalog.list`
+
+Enumerates a business's product catalog via cursor-based pagination. Unlike
+search (query-driven, relevance-ranked), list returns all products in a stable,
+deterministic order without requiring a query or filter.
+
+## Operation
+
+| Operation | Description |
+| :--- | :--- |
+| **List Catalog** | Paginate through the business's product catalog. |
+
+### Request
+
+{{ extension_schema_fields('catalog_list.json#/$defs/list_request', 'catalog') }}
+
+### Response
+
+{{ extension_schema_fields('catalog_list.json#/$defs/list_response', 'catalog') }}
+
+## List Filters
+
+Filter criteria for narrowing the enumerated set. When no filters are provided,
+the operation returns all products in the catalog. Businesses MAY support
+additional custom filters via `additionalProperties`.
+
+{{ schema_fields('types/list_filters', 'catalog') }}
+
+### Modified Since
+
+The `modified_since` filter enables incremental sync. When provided, only
+products created or updated at or after the given timestamp are returned.
+"Modified" includes any change to the product or its variants (price,
+availability, title, media, options, etc.).
+
+Businesses that do not track modification timestamps MAY ignore this filter
+and return the full catalog. When ignored, businesses SHOULD notify the
+platform via a message with `code: "filter_ignored"`.
+
+## Ordering
+
+Products are returned in a stable, deterministic order. The ordering is
+implementation-defined (typically by internal ID or creation time) and MUST
+be consistent across pages within a single pagination sequence.
+
+## Pagination
+
+Uses the same cursor-based pagination as catalog search. Cursors are opaque
+strings that implementations MAY encode as stateless keyset tokens.
+
+### Page Size
+
+Implementations SHOULD accept a page size of at least 100 for list operations.
+When the requested limit exceeds the implementation's maximum, implementations
+MAY clamp to their maximum silently. Clients MUST NOT assume the response size
+equals the requested limit.
+
+### Pagination Request
+
+{{ extension_schema_fields('types/pagination.json#/$defs/request', 'catalog') }}
+
+### Pagination Response
+
+{{ extension_schema_fields('types/pagination.json#/$defs/response', 'catalog') }}
+
+## Deleted Products
+
+Businesses MAY signal deletions via a message with `code: "deleted"` and the
+product ID in `content`. Platforms that need deletion detection SHOULD maintain
+a local manifest and diff against list results.
+
+## Transport Bindings
+
+* [REST Binding](rest.md#post-cataloglist): `POST /catalog/list`
+* [MCP Binding](mcp.md#list_catalog): `list_catalog` tool

--- a/docs/specification/catalog/mcp.md
+++ b/docs/specification/catalog/mcp.md
@@ -52,6 +52,11 @@ Businesses advertise MCP transport availability through their UCP profile at
         "version": "{{ ucp_version }}",
         "spec": "https://ucp.dev/{{ ucp_version }}/specification/catalog/lookup",
         "schema": "https://ucp.dev/{{ ucp_version }}/schemas/shopping/catalog_lookup.json"
+      }],
+      "dev.ucp.shopping.catalog.list": [{
+        "version": "{{ ucp_version }}",
+        "spec": "https://ucp.dev/{{ ucp_version }}/specification/catalog/list",
+        "schema": "https://ucp.dev/{{ ucp_version }}/schemas/shopping/catalog_list.json"
       }]
     },
     "payment_handlers": {}
@@ -100,6 +105,7 @@ version compatibility checking and capability negotiation.
 | `search_catalog` | [Search](search.md) | Search for products. |
 | `lookup_catalog` | [Lookup](lookup.md) | Lookup one or more products or variants by identifier. |
 | `get_product` | [Lookup](lookup.md#get-product-get_product) | Get full product detail by identifier. |
+| `list_catalog` | [List](list.md) | Paginate through the full product catalog. |
 
 ### `search_catalog`
 

--- a/docs/specification/catalog/rest.md
+++ b/docs/specification/catalog/rest.md
@@ -52,6 +52,11 @@ Businesses advertise REST transport availability through their UCP profile at
         "version": "{{ ucp_version }}",
         "spec": "https://ucp.dev/{{ ucp_version }}/specification/catalog/lookup",
         "schema": "https://ucp.dev/{{ ucp_version }}/schemas/shopping/catalog_lookup.json"
+      }],
+      "dev.ucp.shopping.catalog.list": [{
+        "version": "{{ ucp_version }}",
+        "spec": "https://ucp.dev/{{ ucp_version }}/specification/catalog/list",
+        "schema": "https://ucp.dev/{{ ucp_version }}/schemas/shopping/catalog_list.json"
       }]
     },
     "payment_handlers": {}
@@ -66,6 +71,7 @@ Businesses advertise REST transport availability through their UCP profile at
 | `/catalog/search` | POST | [Search](search.md) | Search for products. |
 | `/catalog/lookup` | POST | [Lookup](lookup.md) | Lookup one or more products by ID. |
 | `/catalog/product` | POST | [Lookup](lookup.md#get-product-get_product) | Get full product detail by identifier. |
+| `/catalog/list` | POST | [List](list.md) | Paginate through the full product catalog. |
 
 ### `POST /catalog/search`
 
@@ -508,6 +514,60 @@ Unlike `/catalog/lookup` (which returns partial results for batch requests),
 `/catalog/product` is a single-resource operation. A missing product is an
 application error with `unrecoverable` severity — the agent should not retry
 with the same identifier.
+
+### `POST /catalog/list`
+
+Maps to the [Catalog List](list.md) capability.
+
+#### Example
+
+=== "Request"
+
+    <!-- ucp:example schema=shopping/catalog_list op=list direction=request -->
+    ```json
+    {
+      "filters": {
+        "modified_since": "2026-07-01T00:00:00Z"
+      },
+      "pagination": {
+        "limit": 100
+      }
+    }
+    ```
+
+=== "Response"
+
+    <!-- ucp:example schema=shopping/catalog_list op=list direction=response -->
+    ```json
+    {
+      "ucp": {},
+      "products": [
+        {
+          "id": "prod_abc123",
+          "title": "Classic Running Shoe",
+          "description": { "plain": "Lightweight running shoe with cushioned sole." },
+          "price_range": {
+            "min": { "amount": 8900, "currency": "USD" },
+            "max": { "amount": 12900, "currency": "USD" }
+          },
+          "variants": [
+            {
+              "id": "var_001",
+              "title": "Black / Size 10",
+              "description": { "plain": "Black colorway, men's size 10." },
+              "price": { "amount": 8900, "currency": "USD" },
+              "availability": { "available": true, "status": "in_stock" }
+            }
+          ]
+        }
+      ],
+      "pagination": {
+        "cursor": "eyJsYXN0X2lkIjoicHJvZF9hYmMxMjMifQ==",
+        "has_next_page": true,
+        "total_count": 5420
+      }
+    }
+    ```
 
 ## HTTP Headers
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
           - Overview: specification/catalog/index.md
           - Search: specification/catalog/search.md
           - Lookup: specification/catalog/lookup.md
+          - List: specification/catalog/list.md
           - Transports:
               - REST: specification/catalog/rest.md
               - MCP: specification/catalog/mcp.md
@@ -362,6 +363,10 @@ plugins:
               Direct item retrieval via the Lookup Catalog capability,
               specifying variant resolution logic, batch identifiers,
               and interactive option selection.
+          - specification/catalog/list.md: >-
+              Full catalog enumeration via the List Catalog capability,
+              specifying cursor-paginated traversal with incremental
+              sync support via modified_since filtering.
           - specification/catalog/rest.md: >-
               HTTP REST transport binding for the Catalog Capability,
               detailing search, batch lookup, and product detail

--- a/source/schemas/shopping/catalog_list.json
+++ b/source/schemas/shopping/catalog_list.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/catalog_list.json",
+  "name": "dev.ucp.shopping.catalog.list",
+  "title": "Catalog List",
+  "description": "Paginated enumeration of a business's product catalog.",
+  "type": "object",
+  "$defs": {
+    "list_request": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "$ref": "types/list_filters.json"
+        },
+        "context": {
+          "$ref": "types/context.json"
+        },
+        "signals": {
+          "$ref": "types/signals.json"
+        },
+        "pagination": {
+          "$ref": "../common/types/pagination.json#/$defs/request"
+        }
+      }
+    },
+    "list_response": {
+      "type": "object",
+      "required": [
+        "ucp",
+        "products"
+      ],
+      "properties": {
+        "ucp": {
+          "$ref": "../ucp.json#/$defs/response_catalog_schema"
+        },
+        "products": {
+          "type": "array",
+          "items": {
+            "$ref": "types/product.json"
+          },
+          "description": "Products in the catalog."
+        },
+        "pagination": {
+          "$ref": "../common/types/pagination.json#/$defs/response"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "../common/types/message.json"
+          },
+          "description": "Informational messages about the listing."
+        }
+      }
+    }
+  }
+}

--- a/source/schemas/shopping/types/list_filters.json
+++ b/source/schemas/shopping/types/list_filters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/types/list_filters.json",
+  "title": "List Filters",
+  "description": "Filter criteria for catalog list operations. All specified filters combine with AND logic.",
+  "type": "object",
+  "properties": {
+    "modified_since": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Return products created or updated at or after this timestamp (ISO 8601). Covers any change to the product or its variants."
+    }
+  },
+  "additionalProperties": true
+}

--- a/source/services/shopping/mcp.openrpc.json
+++ b/source/services/shopping/mcp.openrpc.json
@@ -366,6 +366,27 @@
         "name": "response",
         "schema": {"$ref": "#/components/schemas/catalog_get_product_result"}
       }
+    },
+    {
+      "name": "list_catalog",
+      "summary": "List catalog products",
+      "description": "Paginate through the business's full product catalog. Supports optional modified_since filtering for incremental sync.",
+      "params": [
+        {
+          "name": "meta",
+          "required": true,
+          "schema": {"$ref": "#/components/schemas/meta"}
+        },
+        {
+          "name": "catalog",
+          "required": true,
+          "schema": {"$ref": "../../schemas/shopping/catalog_list.json#/$defs/list_request"}
+        }
+      ],
+      "result": {
+        "name": "response",
+        "schema": {"$ref": "../../schemas/shopping/catalog_list.json#/$defs/list_response"}
+      }
     }
   ]
 }

--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -730,6 +730,50 @@
           }
         }
       }
+    },
+    "/catalog/list": {
+      "post": {
+        "operationId": "list_catalog",
+        "summary": "List Catalog Products",
+        "description": "Paginate through the business's full product catalog. Supports optional modified_since filtering for incremental sync. Returns products in a stable, deterministic order.",
+        "parameters": [
+          { "$ref": "#/components/parameters/authorization" },
+          { "$ref": "#/components/parameters/x_api_key" },
+          { "$ref": "#/components/parameters/signature" },
+          { "$ref": "#/components/parameters/signature_input" },
+          { "$ref": "#/components/parameters/content_digest" },
+          { "$ref": "#/components/parameters/request_id" },
+          { "$ref": "#/components/parameters/user_agent" },
+          { "$ref": "#/components/parameters/ucp_agent" },
+          { "$ref": "#/components/parameters/content_type" },
+          { "$ref": "#/components/parameters/accept" },
+          { "$ref": "#/components/parameters/accept_language" },
+          { "$ref": "#/components/parameters/accept_encoding" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/catalog_list_request" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Paginated catalog products",
+            "headers": {
+              "Signature": { "$ref": "#/components/headers/signature" },
+              "Signature-Input": { "$ref": "#/components/headers/signature_input" },
+              "Content-Digest": { "$ref": "#/components/headers/content_digest" }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/catalog_list_response" }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "webhooks": {
@@ -1021,6 +1065,12 @@
           { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/get_product_response" },
           { "$ref": "../../schemas/common/types/error_response.json" }
         ]
+      },
+      "catalog_list_request": {
+        "$ref": "../../schemas/shopping/catalog_list.json#/$defs/list_request"
+      },
+      "catalog_list_response": {
+        "$ref": "../../schemas/shopping/catalog_list.json#/$defs/list_response"
       }
     }
   }


### PR DESCRIPTION
# Catalog List Operation -- Paginated Catalog Enumeration for UCP

**Capability:** `dev.ucp.shopping.catalog.list`

## Motivation

Platforms building agentic shopping experiences need to index a business's entire catalog for offline ranking, embedding, and recommendation. Today the only catalog operation in UCP is **search**, which requires a query or filter,
returns relevance-ranked results, and is designed for buyer-initiated discovery rather than platform-initiated indexing. There is no way to deterministically enumerate all products in a business's catalog.

A live list API fills this gap:

- **Full enumeration** -- no query required, returns all products (paginated)
- **Incremental sync** -- `modified_since` filter fetches only changes since last sync
- **Real-time** -- reflects current catalog state, not a periodic snapshot
- **Same schema** -- returns the same Product/Variant objects used by search and lookup

Note: [RFC #550](https://github.com/Universal-Commerce-Protocol/ucp/issues/550) proposes a complementary static-feed approach for bulk discovery.This proposal addresses the live API use case independently.

## How it fits

| Operation  | Input                | Use case                            |
| ---------- | -------------------- | ----------------------------------- |
| **Search** | Query text + filters | Buyer-initiated discovery           |
| **Lookup** | Known IDs            | Cart validation, deep links         |
| **List**   | None required        | Platform indexing, incremental sync |

## Design

A new operation within the existing `dev.ucp.shopping.catalog` capability.
No new capability namespace -- businesses that support catalog already have
the infrastructure.

### Request

```json
{
  "filters": {
    "modified_since": "2026-07-01T00:00:00Z"
  },
  "pagination": {
    "cursor": "eyJsYXN0X2lkIjoicHJvZF8xMjM0In0=",
    "limit": 100
  }
}
```

When no filters are provided, the operation returns all products in the catalog.

### Response

Same shape as `catalog.search` -- reuses existing pagination and product schemas:

```json
{
  "ucp": {},
  "products": [
    {
      "id": "prod_abc123",
      "title": "Classic Running Shoe",
      "description": { "plain": "Lightweight running shoe." },
      "price_range": {
        "min": { "amount": 8900, "currency": "USD" },
        "max": { "amount": 12900, "currency": "USD" }
      },
      "variants": [
        {
          "id": "var_001",
          "title": "Black / Size 10",
          "description": { "plain": "Black colorway, men's size 10." },
          "price": { "amount": 8900, "currency": "USD" },
          "availability": { "available": true, "status": "in_stock" }
        }
      ]
    }
  ],
  "pagination": {
    "cursor": "eyJsYXN0X2lkIjoicHJvZF9hYmMxMjMifQ==",
    "has_next_page": true,
    "total_count": 5420
  }
}
```

### Key semantics

- **Page size** -- implementations SHOULD accept at least 100 (higher than
  search's 10, since list targets bulk ingestion)
- **Ordering** -- stable and deterministic within a pagination sequence
  (implementation-defined, typically by internal ID)
- **`modified_since`** -- inclusive; covers any change to product or its
  variants. Businesses that do not track modification timestamps MAY ignore
  and return the full catalog, notifying via a message
- **Deleted products** -- MAY be indicated via `messages` with
  `code: "deleted"`, or omitted entirely

## Design principles

- **Purely additive.** New operation within an existing capability -- no
  breaking changes.
- **Shared product schema.** Same Product/Variant objects used by search and
  lookup. Platforms reuse existing parsers.
- **Existing pagination primitive.** Reuses `common/types/pagination.json`
  already defined for search.
- **Open vocabulary filters.** `list_filters.json` uses
  `additionalProperties: true` for extensibility, matching `search_filters.json`.

## Files in this PR

| File                                              | Purpose                             |
| ------------------------------------------------- | ----------------------------------- |
| `source/schemas/shopping/catalog_list.json`       | Operation schema (request/response) |
| `source/schemas/shopping/types/list_filters.json` | Filter type (`modified_since`)      |
| `source/services/shopping/rest.openapi.json`      | OpenAPI -- `/catalog/list` endpoint |
| `source/services/shopping/mcp.openrpc.json`       | OpenRPC -- `list_catalog` tool      |
| `docs/specification/catalog/list.md`              | Specification page                  |
| `docs/specification/catalog/index.md`             | Capabilities table                  |
| `docs/specification/catalog/rest.md`              | REST binding (endpoint + example)   |
| `docs/specification/catalog/mcp.md`               | MCP binding (tool entry)            |
| `mkdocs.yml`                                      | Navigation                          |

## Open questions for TC

- **Scope** -- is list appropriate within `catalog`, or should it live under a
  separate capability namespace?
- **`modified_since` support** -- MUST vs MAY for businesses?
- **Deleted product signaling** -- is `messages`-based sufficient, or should
  deleted products appear with a `status` field?
- **Rate limiting** -- should the spec include normative language about
  rate-limiting list differently from search?