### PR TITLE
feat: link fulfillment events to checkout fulfillment selections

### DIFF
--- a/source/schemas/shopping/types/fulfillment_event.json
+++ b/source/schemas/shopping/types/fulfillment_event.json
@@ -4,12 +4,7 @@
   "title": "Fulfillment Event",
   "description": "Append-only fulfillment event representing an actual shipment. References line items by ID.",
   "type": "object",
-  "required": [
-    "id",
-    "occurred_at",
-    "type",
-    "line_items"
-  ],
+  "required": ["id", "occurred_at", "type", "line_items"],
   "properties": {
     "id": {
       "type": "string",
@@ -59,6 +54,30 @@
     "description": {
       "type": "string",
       "description": "Human-readable description of the shipment status or delivery information (e.g., 'Delivered to front door', 'Out for delivery')."
+    },
+    "fulfillment_method_id": {
+      "type": "string",
+      "description": "References the fulfillment method selected at checkout. Matches the id in fulfillment_method."
+    },
+    "fulfillment_option_id": {
+      "type": "string",
+      "description": "References the fulfillment option selected at checkout (e.g., 'express', 'standard'). Matches the id in fulfillment_option."
+    },
+    "estimated_delivery": {
+      "type": "object",
+      "description": "Estimated delivery window. Business MAY revise as the shipment progresses.",
+      "properties": {
+        "earliest": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Earliest estimated delivery date (RFC 3339)."
+        },
+        "latest": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Latest estimated delivery date (RFC 3339)."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #347

## Summary

Adds fields to fulfillment events that link back to the fulfillment method and option selected at checkout, plus a delivery estimate window.

## Changes

- `source/schemas/shopping/types/fulfillment_event.json`:
  - Added `fulfillment_method_id` — references the method selected at checkout
  - Added `fulfillment_option_id` — references the specific option (e.g., 'express')
  - Added `estimated_delivery` object with `earliest` and `latest` timestamps

## Motivation

Currently, fulfillment events (shipped, delivered, etc.) have no connection to the fulfillment options selected at checkout. An agent cannot tell the buyer "your **express** order shipped" vs "your **standard** order shipped" because the event doesn't reference the fulfillment group or option.

These fields close the loop between checkout fulfillment selections and post-purchase tracking.

## Design decisions

- All new fields are optional — backwards compatible
- `estimated_delivery` uses a range (earliest/latest) rather than a single date
- Business MAY revise `estimated_delivery` as the shipment progresses
- Carrier and tracking fields already existed; the new fields complement them