### PR TITLE
feat(shopping): add rate_limit_exceeded error for agent retry signaling

### DIFF
--- a/source/services/shopping/mcp.openrpc.json
+++ b/source/services/shopping/mcp.openrpc.json
@@ -68,6 +68,28 @@
           }
         }
       }
+    },
+    "errors": {
+      "authentication_failed": {
+        "code": -32002,
+        "message": "Authentication failed",
+        "data": { "$ref": "../../schemas/common/types/error_response.json" }
+      },
+      "invalid_params": {
+        "code": -32602,
+        "message": "Invalid params",
+        "data": { "$ref": "../../schemas/common/types/error_response.json" }
+      },
+      "not_found": {
+        "code": -32001,
+        "message": "Resource not found",
+        "data": { "$ref": "../../schemas/common/types/error_response.json" }
+      },
+      "idempotency_conflict": {
+        "code": -32003,
+        "message": "Idempotency conflict",
+        "data": { "$ref": "../../schemas/common/types/error_response.json" }
+      }
     }
   },
   "methods": [
@@ -79,18 +101,23 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "checkout",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/checkout.json"}
+          "schema": { "$ref": "../../schemas/shopping/checkout.json" }
         }
       ],
       "result": {
         "name": "checkout",
-        "schema": {"$ref": "#/components/schemas/checkout_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/checkout_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/idempotency_conflict" }
+      ]
     },
     {
       "name": "get_checkout",
@@ -99,18 +126,24 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         }
       ],
       "result": {
         "name": "checkout",
-        "schema": {"$ref": "#/components/schemas/checkout_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/checkout_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/not_found" }
+      ]
     },
     {
       "name": "update_checkout",
@@ -120,23 +153,30 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         },
         {
           "name": "checkout",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/checkout.json"}
+          "schema": { "$ref": "../../schemas/shopping/checkout.json" }
         }
       ],
       "result": {
         "name": "checkout",
-        "schema": {"$ref": "#/components/schemas/checkout_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/checkout_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/not_found" }
+      ]
     },
     {
       "name": "complete_checkout",
@@ -147,26 +187,39 @@
           "required": true,
           "schema": {
             "allOf": [
-              {"$ref": "#/components/schemas/meta"},
-              {"required": ["ucp-agent", "idempotency-key"]}
+              { "$ref": "#/components/schemas/meta" },
+              {
+                "required": [
+                  "ucp-agent",
+                  "idempotency-key"
+                ]
+              }
             ]
           }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         },
         {
           "name": "checkout",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/checkout.json"}
+          "schema": { "$ref": "../../schemas/shopping/checkout.json" }
         }
       ],
       "result": {
         "name": "checkout",
-        "schema": {"$ref": "#/components/schemas/checkout_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/checkout_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/not_found" },
+        { "$ref": "#/components/errors/idempotency_conflict" }
+      ]
     },
     {
       "name": "cancel_checkout",
@@ -177,21 +230,34 @@
           "required": true,
           "schema": {
             "allOf": [
-              {"$ref": "#/components/schemas/meta"},
-              {"required": ["ucp-agent", "idempotency-key"]}
+              { "$ref": "#/components/schemas/meta" },
+              {
+                "required": [
+                  "ucp-agent",
+                  "idempotency-key"
+                ]
+              }
             ]
           }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         }
       ],
       "result": {
         "name": "checkout",
-        "schema": {"$ref": "#/components/schemas/checkout_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/checkout_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/not_found" },
+        { "$ref": "#/components/errors/idempotency_conflict" }
+      ]
     },
     {
       "name": "create_cart",
@@ -201,18 +267,23 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "cart",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/cart.json"}
+          "schema": { "$ref": "../../schemas/shopping/cart.json" }
         }
       ],
       "result": {
         "name": "cart",
-        "schema": {"$ref": "#/components/schemas/cart_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/cart_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/idempotency_conflict" }
+      ]
     },
     {
       "name": "get_cart",
@@ -221,18 +292,24 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         }
       ],
       "result": {
         "name": "cart",
-        "schema": {"$ref": "#/components/schemas/cart_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/cart_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/not_found" }
+      ]
     },
     {
       "name": "update_cart",
@@ -241,23 +318,30 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         },
         {
           "name": "cart",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/cart.json"}
+          "schema": { "$ref": "../../schemas/shopping/cart.json" }
         }
       ],
       "result": {
         "name": "cart",
-        "schema": {"$ref": "#/components/schemas/cart_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/cart_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/not_found" }
+      ]
     },
     {
       "name": "cancel_cart",
@@ -268,21 +352,34 @@
           "required": true,
           "schema": {
             "allOf": [
-              {"$ref": "#/components/schemas/meta"},
-              {"required": ["ucp-agent", "idempotency-key"]}
+              { "$ref": "#/components/schemas/meta" },
+              {
+                "required": [
+                  "ucp-agent",
+                  "idempotency-key"
+                ]
+              }
             ]
           }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string"}
+          "schema": {
+            "type": "string"
+          }
         }
       ],
       "result": {
         "name": "cart",
-        "schema": {"$ref": "#/components/schemas/cart_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/cart_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/not_found" },
+        { "$ref": "#/components/errors/idempotency_conflict" }
+      ]
     },
     {
       "name": "search_catalog",
@@ -292,18 +389,22 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "catalog",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_request"}
+          "schema": { "$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_request" }
         }
       ],
       "result": {
         "name": "response",
-        "schema": {"$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_response"}
-      }
+        "schema": { "$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_response" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" }
+      ]
     },
     {
       "name": "lookup_catalog",
@@ -313,18 +414,22 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "catalog",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_request"}
+          "schema": { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_request" }
         }
       ],
       "result": {
         "name": "response",
-        "schema": {"$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_response"}
-      }
+        "schema": { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_response" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" }
+      ]
     },
     {
       "name": "get_order",
@@ -334,18 +439,25 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "id",
           "required": true,
-          "schema": {"type": "string", "description": "The unique identifier of the order."}
+          "schema": {
+            "type": "string",
+            "description": "The unique identifier of the order."
+          }
         }
       ],
       "result": {
         "name": "order",
-        "schema": {"$ref": "#/components/schemas/order_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/order_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/not_found" }
+      ]
     },
     {
       "name": "get_product",
@@ -355,18 +467,22 @@
         {
           "name": "meta",
           "required": true,
-          "schema": {"$ref": "#/components/schemas/meta"}
+          "schema": { "$ref": "#/components/schemas/meta" }
         },
         {
           "name": "catalog",
           "required": true,
-          "schema": {"$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/get_product_request"}
+          "schema": { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/get_product_request" }
         }
       ],
       "result": {
         "name": "response",
-        "schema": {"$ref": "#/components/schemas/catalog_get_product_result"}
-      }
+        "schema": { "$ref": "#/components/schemas/catalog_get_product_result" }
+      },
+      "errors": [
+        { "$ref": "#/components/errors/authentication_failed" },
+        { "$ref": "#/components/errors/invalid_params" }
+      ]
     }
   ]
 }

--- a/source/services/shopping/mcp.openrpc.json
+++ b/source/services/shopping/mcp.openrpc.json
@@ -89,6 +89,11 @@
         "code": -32003,
         "message": "Idempotency conflict",
         "data": { "$ref": "../../schemas/common/types/error_response.json" }
+      },
+      "rate_limit_exceeded": {
+        "code": -32004,
+        "message": "Rate limit exceeded",
+        "data": { "$ref": "../../schemas/common/types/error_response.json" }
       }
     }
   },
@@ -116,7 +121,8 @@
       "errors": [
         { "$ref": "#/components/errors/authentication_failed" },
         { "$ref": "#/components/errors/invalid_params" },
-        { "$ref": "#/components/errors/idempotency_conflict" }
+        { "$ref": "#/components/errors/idempotency_conflict" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     },
     {
@@ -142,7 +148,8 @@
       },
       "errors": [
         { "$ref": "#/components/errors/authentication_failed" },
-        { "$ref": "#/components/errors/not_found" }
+        { "$ref": "#/components/errors/not_found" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     },
     {
@@ -175,7 +182,8 @@
       "errors": [
         { "$ref": "#/components/errors/authentication_failed" },
         { "$ref": "#/components/errors/invalid_params" },
-        { "$ref": "#/components/errors/not_found" }
+        { "$ref": "#/components/errors/not_found" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     },
     {
@@ -218,7 +226,8 @@
         { "$ref": "#/components/errors/authentication_failed" },
         { "$ref": "#/components/errors/invalid_params" },
         { "$ref": "#/components/errors/not_found" },
-        { "$ref": "#/components/errors/idempotency_conflict" }
+        { "$ref": "#/components/errors/idempotency_conflict" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     },
     {
@@ -256,7 +265,8 @@
         { "$ref": "#/components/errors/authentication_failed" },
         { "$ref": "#/components/errors/invalid_params" },
         { "$ref": "#/components/errors/not_found" },
-        { "$ref": "#/components/errors/idempotency_conflict" }
+        { "$ref": "#/components/errors/idempotency_conflict" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     },
     {
@@ -282,7 +292,8 @@
       "errors": [
         { "$ref": "#/components/errors/authentication_failed" },
         { "$ref": "#/components/errors/invalid_params" },
-        { "$ref": "#/components/errors/idempotency_conflict" }
+        { "$ref": "#/components/errors/idempotency_conflict" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     },
     {
@@ -308,7 +319,8 @@
       },
       "errors": [
         { "$ref": "#/components/errors/authentication_failed" },
-        { "$ref": "#/components/errors/not_found" }
+        { "$ref": "#/components/errors/not_found" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     },
     {
@@ -340,7 +352,8 @@
       "errors": [
         { "$ref": "#/components/errors/authentication_failed" },
         { "$ref": "#/components/errors/invalid_params" },
-        { "$ref": "#/components/errors/not_found" }
+        { "$ref": "#/components/errors/not_found" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     },
     {
@@ -378,7 +391,8 @@
         { "$ref": "#/components/errors/authentication_failed" },
         { "$ref": "#/components/errors/invalid_params" },
         { "$ref": "#/components/errors/not_found" },
-        { "$ref": "#/components/errors/idempotency_conflict" }
+        { "$ref": "#/components/errors/idempotency_conflict" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     },
     {
@@ -403,7 +417,8 @@
       },
       "errors": [
         { "$ref": "#/components/errors/authentication_failed" },
-        { "$ref": "#/components/errors/invalid_params" }
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     },
     {
@@ -428,7 +443,8 @@
       },
       "errors": [
         { "$ref": "#/components/errors/authentication_failed" },
-        { "$ref": "#/components/errors/invalid_params" }
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     },
     {
@@ -456,7 +472,8 @@
       },
       "errors": [
         { "$ref": "#/components/errors/authentication_failed" },
-        { "$ref": "#/components/errors/not_found" }
+        { "$ref": "#/components/errors/not_found" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     },
     {
@@ -481,7 +498,8 @@
       },
       "errors": [
         { "$ref": "#/components/errors/authentication_failed" },
-        { "$ref": "#/components/errors/invalid_params" }
+        { "$ref": "#/components/errors/invalid_params" },
+        { "$ref": "#/components/errors/rate_limit_exceeded" }
       ]
     }
   ]

--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -92,6 +92,36 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -157,6 +187,26 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/checkout_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
                 }
               }
             }
@@ -234,6 +284,46 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/checkout_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
                 }
               }
             }
@@ -317,6 +407,46 @@
                 "schema": { "$ref": "#/components/schemas/checkout_response" }
               }
             }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -391,6 +521,36 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -436,6 +596,36 @@
                 "schema": { "$ref": "#/components/schemas/cart_response" }
               }
             }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -472,6 +662,26 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/cart_response" }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
               }
             }
           }
@@ -517,6 +727,46 @@
                 "schema": { "$ref": "#/components/schemas/cart_response" }
               }
             }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -555,6 +805,36 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/cart_response" }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict. A request with this Idempotency-Key was already processed with different parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
               }
             }
           }
@@ -601,6 +881,26 @@
                 "schema": { "$ref": "#/components/schemas/catalog_search_response" }
               }
             }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -645,6 +945,26 @@
                 "schema": { "$ref": "#/components/schemas/catalog_lookup_response" }
               }
             }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
           }
         }
       }
@@ -681,6 +1001,26 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/order_response" }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
               }
             }
           }
@@ -725,6 +1065,26 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/catalog_get_product_response" }
+              }
+            }
+          },
+          "400": {
+            "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or missing credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
               }
             }
           }
@@ -1021,6 +1381,9 @@
           { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/get_product_response" },
           { "$ref": "../../schemas/common/types/error_response.json" }
         ]
+      },
+      "error_response": {
+        "$ref": "../../schemas/common/types/error_response.json"
       }
     }
   }


### PR DESCRIPTION
## Summary

Add rate_limit_exceeded error (code -32004) to the MCP Shopping service and declare it on all 13 methods. Any method can be rate-limited; agents need a structured signal to distinguish "slow down" from "your request is broken."

## Why this matters

UCP is agent-native. Agents operating in automated loops will hit rate limits from merchant implementations. Without a declared error code, agents cannot distinguish retriable throttling from permanent failures, leading to either blind retries (hammering the merchant) or premature abandonment (degraded UX).

Code -32004 follows MCP conventions: implementation-defined range (-32000 to -32019) for server-specific conditions that clients must act on distinctly (ref: MCP spec schema.ts allocates -32020+ for protocol-defined codes, leaving -32000 to -32019 for implementations like UCP).

The data payload uses existing error_response.json, consistent with all other MCP errors. The content field can carry retry-after hints in human-readable form; a structured retry_after field can be proposed separately if the TC wants machine-readable backoff.

## Test plan

- [x] Valid OpenRPC 1.3.2 JSON
- [x] Code -32004 does not conflict with existing codes (-32002, -32003)
- [x] All 13 methods reference the new error
- [ ] Declaration-only; no behavioral change