### PR TITLE
fix(schema): machine-enforce the P-521/ES512 key pairing in profile.json

### DIFF
--- a/source/schemas/profile.json
+++ b/source/schemas/profile.json
@@ -18,12 +18,12 @@
         "kty": {
           "type": "string",
           "examples": ["EC", "OKP"],
-          "description": "JWK key type. Well-known values: EC for ECDSA (P-256, P-384); OKP for EdDSA (Ed25519). Open vocabulary; verifiers tolerate unrecognized types and select keys by kid."
+          "description": "JWK key type. Well-known values: EC for ECDSA (P-256, P-384, P-521); OKP for EdDSA (Ed25519). Open vocabulary; verifiers tolerate unrecognized types and select keys by kid."
         },
         "crv": {
           "type": "string",
-          "examples": ["P-256", "P-384", "Ed25519"],
-          "description": "Curve name. Well-known values: P-256, P-384 (EC); Ed25519 (OKP). Open vocabulary."
+          "examples": ["P-256", "P-384", "P-521", "Ed25519"],
+          "description": "Curve name. Well-known values: P-256, P-384, P-521 (EC); Ed25519 (OKP). Open vocabulary."
         },
         "x": {
           "type": "string",
@@ -35,8 +35,8 @@
         },
         "alg": {
           "type": "string",
-          "examples": ["ES256", "ES384", "EdDSA"],
-          "description": "JWA algorithm associated with this public key. Optional; verifiers derive the algorithm from crv when alg is omitted. When present for a well-known curve it MUST match: ES256 with P-256, ES384 with P-384, EdDSA with Ed25519."
+          "examples": ["ES256", "ES384", "ES512", "EdDSA"],
+          "description": "JWA algorithm associated with this public key. Optional; verifiers derive the algorithm from crv when alg is omitted. When present for a well-known curve it MUST match: ES256 with P-256, ES384 with P-384, ES512 with P-521, EdDSA with Ed25519."
         },
         "use": {
           "type": "string",
@@ -63,6 +63,11 @@
           "title": "P-384 pairs with ES384",
           "if": { "properties": { "crv": { "const": "P-384" } }, "required": ["crv"] },
           "then": { "properties": { "alg": { "const": "ES384" } } }
+        },
+        {
+          "title": "P-521 pairs with ES512",
+          "if": { "properties": { "crv": { "const": "P-521" } }, "required": ["crv"] },
+          "then": { "properties": { "alg": { "const": "ES512" } } }
         },
         {
           "title": "Ed25519 pairs with EdDSA",


### PR DESCRIPTION
### Problem

`profile.json` encodes the JWK curve↔algorithm binding as schema constraints — but only for three of the four curves it names. There are `if/then` rules for **P-256 → ES256**, **P-384 → ES384**, and **Ed25519 → EdDSA**, and **none for P-521**.

The effect, checked with the `ucp-schema` validator (same one CI uses):

| Key published in `keys[]` | `profile.json` validation |
| :-- | :-- |
| `crv: P-521`, `alg: ES512` (correct) | ✅ Valid |
| `crv: P-521`, `alg: ES256` (**mismatched**) | ✅ Valid — *not caught* |
| `crv: P-256`, `alg: ES384` (mismatched) | ❌ Rejected |

So a P-521 signing key can be published with an algorithm that contradicts its curve and pass validation, while the identical mistake on a P-256 key is rejected. This is the same class of gap as #571 (a schema-valid artifact depending on a curve/algorithm pairing the schema never defines), at the key-publication layer.

### Change

One `allOf` rule — `P-521 pairs with ES512` — mirroring the existing P-256/P-384 rules exactly, plus P-521/ES512 added to the `crv`/`alg` examples and the `alg` "MUST match" description. +10/−5, no reformatting.

It is **conditional well-formedness only**: it constrains a P-521 key to `ES512` *when one is published*; it does not require any party to support ES512. So it is orthogonal to whether ES512 stays AP2-scoped (#618) or becomes UCP-wide — either way, a P-521 key that is published should be correctly paired.

### Verification (`ucp-schema`)

- The mismatched P-521 key is now **rejected**; a correct P-521/ES512 key still validates; an `alg`-less P-521 key still validates (verifiers derive the algorithm from `crv`); P-256/P-384/OKP keys are unaffected.
- `ucp-schema lint source/` (124 files checked, all passed), `validate_examples.py` (343 passed, 0 failed, 50 skipped), validator unit tests (52 passed), cspell clean. Re-measured 2026-09-01 on a test merge into main `1d39948`; unchanged by this PR.

### Relation to #618

This complements #618 rather than overlapping it — different file, no conflict. #618 documents the AP2 algorithm set and the alg↔curve binding in prose and pseudocode (including a P-521/ES512 JWK example); this makes that binding **machine-enforced** at the schema layer. I verified that #618's own example JWK validates against this rule, so the two land cleanly together. Happy to defer to @ShuoRen-TT and the maintainers on how to sequence or combine them.

Relates to #571.
