### PR TITLE
fix: make Request-Signature header optional in shopping spec

### DIFF
--- a/source/services/shopping/openapi.json
+++ b/source/services/shopping/openapi.json
@@ -430,11 +430,11 @@
       "request_signature": {
         "name": "Request-Signature",
         "in": "header",
-        "required": true,
+        "required": false,
         "schema": {
           "type": "string"
         },
-        "description": "Ensure the authenticity and integrity of an HTTP message."
+        "description": "Ensure the authenticity and integrity of an HTTP message. Optional; required only when the platform authenticates with HTTP Message Signatures. Platforms MAY use alternative authentication mechanisms (API keys, OAuth, mTLS) instead, per the Message Signatures specification."
       },
       "idempotency_key": {
         "name": "Idempotency-Key",

--- a/spec/services/shopping/rest.openapi.json
+++ b/spec/services/shopping/rest.openapi.json
@@ -455,11 +455,11 @@
       "request_signature": {
         "name": "Request-Signature",
         "in": "header",
-        "required": true,
+        "required": false,
         "schema": {
           "type": "string"
         },
-        "description": "Ensure the authenticity and integrity of an HTTP message."
+        "description": "Ensure the authenticity and integrity of an HTTP message. Optional; required only when the platform authenticates with HTTP Message Signatures. Platforms MAY use alternative authentication mechanisms (API keys, OAuth, mTLS) instead, per the Message Signatures specification."
       },
       "idempotency_key": {
         "name": "Idempotency-Key",


### PR DESCRIPTION
### What

Makes the `Request-Signature` header parameter optional (`required: false`) in the shopping REST spec, in both the `source/` and generated `spec/` OpenAPI, and clarifies its description.

### Why

The shopping OpenAPI marks `Request-Signature` as `required: true` on every operation, which contradicts this release's own Message Signatures spec (`signatures.md`, "When Signatures Apply"): platforms **SHOULD** sign requests, and **MAY** use alternative authentication (API keys, OAuth, mTLS) instead. As written, the OpenAPI forces a signature header even when a platform authenticates by another mechanism, and clients/validators generated from this spec reject otherwise-valid unsigned requests.

`main` already treats request signing as optional (the header is not unconditionally required there). This backports that intent to the `2026-01-23` release with a minimal, backward-compatible change - it does not pull in main's larger RFC 9421 header restructure. Existing signed requests remain valid; the only effect is that unsigned requests using alternative auth are no longer rejected by the spec.

### Scope

- `source/services/shopping/openapi.json`
- `spec/services/shopping/rest.openapi.json`

No behavioral change for signed requests; no schema fields added or removed. Consistent with prior backports to this release branch (e.g. #212, #228).

Addresses #636.
