### PR TITLE
docs: remove deprecated id field from checkout update request examples

### DIFF
--- a/docs/specification/shopping/checkout/rest.md
+++ b/docs/specification/shopping/checkout/rest.md
@@ -253,7 +253,6 @@ include all previously set fields it intends to retain.
     Content-Type: application/json
 
     {
-      "id": "chk_123456789", // deprecated: id is provided in URL path
       "buyer": {
         "email": "jane@example.com",
         "first_name": "Jane",
@@ -385,7 +384,6 @@ state.
     Content-Type: application/json
 
     {
-      "id": "chk_123456789", // deprecated: id is provided in URL path
       "buyer": {
         "email": "jane@example.com",
         "first_name": "Jane",
@@ -588,7 +586,6 @@ Follow-up calls after initial `fulfillment` data to update selection.
     Content-Type: application/json
 
     {
-      "id": "chk_123456789", // deprecated: id is provided in URL path
       "buyer": {
         "email": "jane@example.com",
         "first_name": "Jane",


### PR DESCRIPTION
# Description

We cemented our transition from required -> omit on this id the other month, but forgot to cleanup the deprecated doc markers. Now removed! https://github.com/Universal-Commerce-Protocol/ucp/pull/341

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

