### PR TITLE
fix(openapi): reference request-shape schemas for checkout and cart request bodies

### DIFF
--- a/source/schemas/shopping/cart.json
+++ b/source/schemas/shopping/cart.json
@@ -26,6 +26,62 @@
           }
         }
       ]
+    },
+    "create_request": {
+      "title": "Cart Create Request",
+      "description": "Request body for create_cart. Includes only buyer-writable fields; server-assigned fields are omitted per the ucp_request annotations on the base schema, which remain the source of truth (equivalent to `ucp-schema resolve --request --op create`).",
+      "type": "object",
+      "required": [
+        "line_items"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "line_items": {
+          "$ref": "#/properties/line_items"
+        },
+        "context": {
+          "$ref": "#/properties/context"
+        },
+        "signals": {
+          "$ref": "#/properties/signals"
+        },
+        "attribution": {
+          "$ref": "#/properties/attribution"
+        },
+        "buyer": {
+          "$ref": "#/properties/buyer"
+        }
+      }
+    },
+    "update_request": {
+      "title": "Cart Update Request",
+      "description": "Request body for update_cart. Server-assigned fields are omitted per the ucp_request annotations on the base schema, which remain the source of truth (equivalent to `ucp-schema resolve --request --op update`).",
+      "type": "object",
+      "required": [
+        "id",
+        "line_items"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "$ref": "#/properties/id"
+        },
+        "line_items": {
+          "$ref": "#/properties/line_items"
+        },
+        "context": {
+          "$ref": "#/properties/context"
+        },
+        "signals": {
+          "$ref": "#/properties/signals"
+        },
+        "attribution": {
+          "$ref": "#/properties/attribution"
+        },
+        "buyer": {
+          "$ref": "#/properties/buyer"
+        }
+      }
     }
   },
   "type": "object",

--- a/source/schemas/shopping/checkout.json
+++ b/source/schemas/shopping/checkout.json
@@ -4,6 +4,86 @@
   "name": "dev.ucp.shopping.checkout",
   "title": "Checkout",
   "description": "Base checkout schema. Extensions compose onto this using allOf.",
+  "$defs": {
+    "create_request": {
+      "title": "Checkout Create Request",
+      "description": "Request body for create_checkout. Includes only buyer-writable fields; server-assigned fields are omitted per the ucp_request annotations on the base schema, which remain the source of truth (equivalent to `ucp-schema resolve --request --op create`).",
+      "type": "object",
+      "required": [
+        "line_items"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "line_items": {
+          "$ref": "#/properties/line_items"
+        },
+        "buyer": {
+          "$ref": "#/properties/buyer"
+        },
+        "context": {
+          "$ref": "#/properties/context"
+        },
+        "signals": {
+          "$ref": "#/properties/signals"
+        },
+        "attribution": {
+          "$ref": "#/properties/attribution"
+        },
+        "payment": {
+          "$ref": "#/properties/payment"
+        }
+      }
+    },
+    "update_request": {
+      "title": "Checkout Update Request",
+      "description": "Request body for update_checkout. The checkout id travels in the URL path, not the body; server-assigned fields are omitted per the ucp_request annotations on the base schema, which remain the source of truth (equivalent to `ucp-schema resolve --request --op update`).",
+      "type": "object",
+      "required": [
+        "line_items"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "line_items": {
+          "$ref": "#/properties/line_items"
+        },
+        "buyer": {
+          "$ref": "#/properties/buyer"
+        },
+        "context": {
+          "$ref": "#/properties/context"
+        },
+        "signals": {
+          "$ref": "#/properties/signals"
+        },
+        "attribution": {
+          "$ref": "#/properties/attribution"
+        },
+        "payment": {
+          "$ref": "#/properties/payment"
+        }
+      }
+    },
+    "complete_request": {
+      "title": "Checkout Complete Request",
+      "description": "Request body for complete_checkout. Line items, buyer, and context are fixed at this stage and omitted per the ucp_request annotations on the base schema, which remain the source of truth (equivalent to `ucp-schema resolve --request --op complete`).",
+      "type": "object",
+      "required": [
+        "payment"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "signals": {
+          "$ref": "#/properties/signals"
+        },
+        "attribution": {
+          "$ref": "#/properties/attribution"
+        },
+        "payment": {
+          "$ref": "#/properties/payment"
+        }
+      }
+    }
+  },
   "type": "object",
   "required": [
     "ucp",

--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -67,7 +67,7 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/checkout" }
+              "schema": { "$ref": "#/components/schemas/checkout_create_request" }
             }
           }
         },
@@ -212,7 +212,7 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/checkout" }
+              "schema": { "$ref": "#/components/schemas/checkout_update_request" }
             }
           }
         },
@@ -294,7 +294,7 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/checkout" }
+              "schema": { "$ref": "#/components/schemas/checkout_complete_request" }
             }
           }
         },
@@ -419,7 +419,7 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/cart" }
+              "schema": { "$ref": "#/components/schemas/cart_create_request" }
             }
           }
         },
@@ -500,7 +500,7 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/cart" }
+              "schema": { "$ref": "#/components/schemas/cart_update_request" }
             }
           }
         },
@@ -1000,6 +1000,21 @@
       },
       "ucp": {
         "$ref": "../../schemas/ucp.json"
+      },
+      "checkout_create_request": {
+        "$ref": "../../schemas/shopping/checkout.json#/$defs/create_request"
+      },
+      "checkout_update_request": {
+        "$ref": "../../schemas/shopping/checkout.json#/$defs/update_request"
+      },
+      "checkout_complete_request": {
+        "$ref": "../../schemas/shopping/checkout.json#/$defs/complete_request"
+      },
+      "cart_create_request": {
+        "$ref": "../../schemas/shopping/cart.json#/$defs/create_request"
+      },
+      "cart_update_request": {
+        "$ref": "../../schemas/shopping/cart.json#/$defs/update_request"
       },
       "catalog_search_request": {
         "$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_request"


### PR DESCRIPTION
Fixes #649.

Scope per maintainer confirmation in #649: checkout + cart in one PR, same root cause.

## Problem

All five REST request bodies (`create_checkout`, `update_checkout`, `complete_checkout`, `create_cart`, `update_cart`) referenced the full base schema, so standard OpenAPI tooling (Swagger UI, Redoc, codegen) exposed every server-assigned field as writable — 12 `ucp_request: "omit"` fields on checkout and 9 on cart (`id`, `status`, `totals`, `expires_at`, `continue_url`, …), not just `checkout.id` as originally filed.

`readOnly: true` was considered and rejected: 28 `ucp_request` annotations are per-operation maps (e.g. `cart.id` is `{"create": "omit", "update": "required"}`, `checkout.payment` is required only on complete), which a binary, operation-global `readOnly` cannot express.

## Change

Follows the existing `catalog_search.json` → `$defs/search_request` convention (also used by `ask_request` in #538):

- **`checkout.json`**: add `$defs/create_request`, `$defs/update_request`, `$defs/complete_request`. Properties `$ref` the top-level definitions (`#/properties/...`) so descriptions stay single-sourced; the `ucp_request` annotations remain the source of truth.
- **`cart.json`**: add `$defs/create_request`, `$defs/update_request` alongside the existing `$defs/checkout`.
- **`rest.openapi.json`**: point the five request bodies at new `*_request` components, mirroring the catalog wiring.

Each `$defs` shape was verified byte-equivalent (properties + required) to the canonical derivation:

```
ucp-schema resolve source/schemas/shopping/checkout.json --request --op create|update|complete
ucp-schema resolve source/schemas/shopping/cart.json --request --op create|update
```

## Verification

- `ucp-schema lint source/` — 99 files, all passed
- `scripts/validate_examples.py` full corpus — 282 passed, 0 failed
- `scripts/test_validate_examples.py` — 48 passed
- `pre-commit run --all-files` — passed (stylelint fails locally on a missing node module, unrelated; no CSS touched)
- `mkdocs build` — no new warnings vs `main` (reference pages only render `$defs` via explicit macros, so schema pages are unchanged)

## Notes

- The now-unreferenced `checkout`/`cart` components are left in place (the `payment` component was already name-only) in case downstream codegen references them by name; happy to remove them if preferred.
- #633 transitions `cart.id` to omitted in update requests; if it lands first, `cart.json#/$defs/update_request` needs a two-line follow-up (drop `id` from `properties`/`required`). Current shapes reflect the annotations on `main` today.
- `mcp.openrpc.json` has the same defect (`create_checkout`/`update_checkout`/`complete_checkout` tool params reference the full `checkout.json`). Left out of scope here as filed; can follow up if wanted.
