### PR TITLE
docs(split-payments): validate the allowed_combinations profile example

### DIFF
--- a/docs/specification/payment/extensions/split-payments.md
+++ b/docs/specification/payment/extensions/split-payments.md
@@ -107,13 +107,18 @@ if any valid assignment exists, the combination matches.
 A business that supports (a) a card with up to 2 redeemables, (b) up to 5
 gift cards alone, and (c) two credit cards:
 
-<!-- ucp:example skip reason="illustrative business profile fragment showing allowed_combinations shape" -->
+<!-- ucp:example schema=profile def=business_schema extract=$.capabilities target=$.ucp.capabilities -->
 ```json
 {
-  "capabilities": [{
+  "capabilities": {
     "dev.ucp.common.payment.split_payments": [
       {
-        "version": "2026-01-23",
+        "version": "{{ ucp_version }}",
+        "spec": "https://ucp.dev/{{ ucp_version }}/specification/split-payments",
+        "schema": "https://ucp.dev/{{ ucp_version }}/schemas/common/payment_split_payments.json",
+        "extends": [
+          "dev.ucp.shopping.checkout"
+        ],
         "config": {
           "allowed_combinations": [
             [
@@ -130,7 +135,7 @@ gift cards alone, and (c) two credit cards:
         }
       }
     ]
-  }]
+  }
 }
 ```
 

--- a/docs/specification/payment/extensions/split-payments.md
+++ b/docs/specification/payment/extensions/split-payments.md
@@ -114,7 +114,7 @@ gift cards alone, and (c) two credit cards:
     "dev.ucp.common.payment.split_payments": [
       {
         "version": "{{ ucp_version }}",
-        "spec": "https://ucp.dev/{{ ucp_version }}/specification/split-payments",
+        "spec": "https://ucp.dev/{{ ucp_version }}/specification/payment/extensions/split-payments",
         "schema": "https://ucp.dev/{{ ucp_version }}/schemas/common/payment_split_payments.json",
         "extends": [
           "dev.ucp.shopping.checkout"

--- a/docs/specification/split-payments.md
+++ b/docs/specification/split-payments.md
@@ -107,13 +107,18 @@ if any valid assignment exists, the combination matches.
 A business that supports (a) a card with up to 2 redeemables, (b) up to 5
 gift cards alone, and (c) two credit cards:
 
-<!-- ucp:example skip reason="illustrative business profile fragment showing allowed_combinations shape" -->
+<!-- ucp:example schema=profile def=business_schema extract=$.capabilities target=$.ucp.capabilities -->
 ```json
 {
-  "capabilities": [{
+  "capabilities": {
     "dev.ucp.shopping.split_payments": [
       {
-        "version": "2026-01-23",
+        "version": "{{ ucp_version }}",
+        "spec": "https://ucp.dev/{{ ucp_version }}/specification/split-payments",
+        "schema": "https://ucp.dev/{{ ucp_version }}/schemas/shopping/split_payments.json",
+        "extends": [
+          "dev.ucp.shopping.checkout"
+        ],
         "config": {
           "allowed_combinations": [
             [
@@ -130,7 +135,7 @@ gift cards alone, and (c) two credit cards:
         }
       }
     ]
-  }]
+  }
 }
 ```
 


### PR DESCRIPTION
### Problem

The only business-profile example for the split payments extension is annotated `<!-- ucp:example skip -->`, so CI never validates it, and it does not match the profile schema in three ways:

1. `capabilities` is an array, but `ucp.json` defines it as an object map keyed by reverse-domain name.
2. The capability entry omits the required `schema` URL (`capability.json` `business_schema` requires `schema`).
3. It pins `"version": "2026-01-23"`, a release that does not contain this extension.

Validating the fragment against the profile schema fails on the `capabilities` type and then on the missing `schema` property; it passes once rewritten as a map with a `schema` URL.

### Fix

Rewrite the example in the `ucp.capabilities` map form with `spec`, `schema`, `extends`, and `{{ ucp_version }}`, mirroring the buyer-consent profile example, and replace the `skip` annotation with a validated `schema=profile def=business_schema` annotation so CI covers it going forward.

`extends: ["dev.ucp.shopping.checkout"]` reflects `split_payments.json`'s `requires` on checkout.

### Verification

`scripts/validate_examples.py` full corpus goes from 343 to 344 passing (50 to 49 skipped): the example flips from skipped to validated. `ucp-schema lint source/` unaffected.

