### PR TITLE
fix(policies): require non-empty applies_to and fix the set-match example and coverage wording

### DIFF
--- a/docs/specification/overview/index.md
+++ b/docs/specification/overview/index.md
@@ -3018,7 +3018,7 @@ policy targets nodes in one of three forms:
   §2.3.5.1](https://www.rfc-editor.org/rfc/rfc9535#section-2.3.5.1)), e.g.
   `$.line_items[2]`.
 - **Set match** — a filter, wildcard, or slice matching a set of nodes, e.g.
-  `$.products[?@.category=='electronics']`.
+  `$.products[?@.tags[?@=='electronics']]`.
 - **Response-wide** — an omitted `applies_to`; the policy applies to the entire
   response. This is the common case: a single site-wide policy is one entry with
   no targeting, never repeated per item.
@@ -3047,8 +3047,8 @@ Every node has a canonical identity: its **Normalized Path** ([RFC 9535
 segments locating it from the root — `$.products[0].variants[3]` is `products`,
 `0`, `variants`, `3`, and the root `$` is the empty sequence. A target
 **covers** a node when a node it matches is that node or an ancestor of it —
-equivalently, when the matched node's Normalized Path is a prefix of the target
-node's. The length of that prefix is its **depth**.
+equivalently, when the matched node's Normalized Path is a prefix of that
+node's Normalized Path. The length of that prefix is its **depth**.
 
 To resolve which policy of a given `type` governs a node:
 
@@ -3186,7 +3186,7 @@ there, while other electronics keep the 2-year term:
   {
     "type": "dev.ucp.shopping.policy.warranty",
     "description": { "plain": "2-year warranty on electronics." },
-    "applies_to": ["$.products[?@.category=='electronics']"]
+    "applies_to": ["$.products[?@.tags[?@=='electronics']]"]
   },
   {
     "type": "dev.ucp.shopping.policy.warranty",

--- a/source/schemas/common/types/policy.json
+++ b/source/schemas/common/types/policy.json
@@ -20,10 +20,11 @@
     },
     "applies_to": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "string"
       },
-      "description": "RFC 9535 JSONPath expressions identifying the nodes this policy applies to, relative to the embedding response root (e.g., `$.line_items[0]` in cart/checkout, `$.products[2]` in catalog). Each target covers the node it names and everything nested under it, so a target on a product also covers its variants. A singular query (RFC 9535 Section 2.3.5.1; name and index selectors only) names a single node; filters, wildcards, and slices match a set. When omitted, the policy applies to the entire response. When policies of the same `type` contest a node, the narrowest target wins and overrides the rest. See the Policies section for how specificity resolves."
+      "description": "RFC 9535 JSONPath expressions identifying the nodes this policy applies to, relative to the embedding response root (e.g., `$.line_items[0]` in cart/checkout, `$.products[2]` in catalog). Each target covers the node it names and everything nested under it, so a target on a product also covers its variants. A singular query (RFC 9535 Section 2.3.5.1; name and index selectors only) names a single node; filters, wildcards, and slices match a set. Omit `applies_to` to apply the policy to the entire response; when present it MUST list at least one target (an empty array is not a valid way to express response-wide scope). When policies of the same `type` contest a node, the narrowest target wins and overrides the rest. See the Policies section for how specificity resolves."
     },
     "url": {
       "type": "string",


### PR DESCRIPTION
### Problem

Three small `policies[]` corrections found while reading the merged policies capability:

1. **`applies_to: []` is undefined.** An empty array is schema-valid (no `minItems` on `policy.json`) but matches none of the three defined targeting forms (singular, set, omitted). Response-wide scope is expressed by omitting `applies_to`, so an empty array has no defined meaning.
2. **The Set-match example matches nothing.** `overview/index.md` filters on `$.products[?@.category=='electronics']`, but the product schema defines `categories` (array of category objects) and `tags` (array of strings), not `category`, so the canonical example selects the empty set against a schema-conformant product.
3. **The coverage definition is circular.** "the matched node's Normalized Path is a prefix of the target node's" is self-referential (the target matches a set, not a single node); it is the covered node whose path is prefixed.

### Fix

- `policy.json`: add `minItems: 1` to `applies_to` (omit the field for response-wide scope).
- `overview/index.md`: change the example filter to `$.products[?@.tags[?@=='electronics']]`, a field products actually carry.
- `overview/index.md`: reword the coverage sentence to "a prefix of that node's Normalized Path".

### Verification

No example in `docs/` or `source/` uses `"applies_to": []`, so `minItems: 1` breaks nothing (confirmed by grep and a full `validate_examples.py` run: 343 passing, unchanged, re-measured 2026-09-01 on a test merge into main `1d39948`). `ucp-schema lint source/` passes. The new JSONPath is valid RFC 9535.

