### PR TITLE
docs(loyalty): fix dangling reference, minor-unit amount, breakdown invariant, and code registries

### DIFF
--- a/docs/specification/common/extensions/loyalty.md
+++ b/docs/specification/common/extensions/loyalty.md
@@ -278,10 +278,10 @@ The examples below are abbreviated to focus on loyalty and discount extension fi
 complete cart and checkout responses also include base required fields such as `ucp`,
 `id`, `currency`, and `totals`.
 
-Building on the store loyalty card example from
+Building on the eligibility verification pattern from
 [Eligibility Verification at Completion](../../shopping/checkout/index.md#eligibility-verification-at-completion),
-assume the card offers one unconditional product discount and one conditional discount
-that the current checkout cart fails to satisfy. The platform can surface the first
+consider a store loyalty card that offers one unconditional product discount and one
+conditional discount that the current checkout cart fails to satisfy. The platform can surface the first
 provisional discount with disclaimers like "verified at purchase" and additionally show
 a warning message to disclose the inapplicability of the second discount.
 
@@ -313,11 +313,11 @@ a warning message to disclose the inapplicability of the second discount.
         "applied": [
           {
             "title": "Loyalty benefit 1",
-            "amount": 10,
+            "amount": 1000,
             "provisional": true,
             "eligibility": "com.example.loyalty.store_card",
             "allocations": [
-              {"path": "$.line_items[0]", "amount": 10}
+              {"path": "$.line_items[0]", "amount": 1000}
             ]
           }
         ]
@@ -382,11 +382,11 @@ non-provisional and `display_id` is returned.
         "applied": [
           {
             "title": "Loyalty benefit 1",
-            "amount": 10,
+            "amount": 1000,
             "provisional": false,
             "eligibility": "com.example.loyalty.store_card",
             "allocations": [
-              {"path": "$.line_items[0]", "amount": 10}
+              {"path": "$.line_items[0]", "amount": 1000}
             ]
           }
         ]

--- a/docs/specification/loyalty.md
+++ b/docs/specification/loyalty.md
@@ -278,10 +278,10 @@ The examples below are abbreviated to focus on loyalty and discount extension fi
 complete cart and checkout responses also include base required fields such as `ucp`,
 `id`, `currency`, and `totals`.
 
-Building on the store loyalty card example from
+Building on the eligibility verification pattern from
 [Eligibility Verification at Completion](shopping/checkout/index.md#eligibility-verification-at-completion),
-assume the card offers one unconditional product discount and one conditional discount
-that the current checkout cart fails to satisfy. The platform can surface the first
+consider a store loyalty card that offers one unconditional product discount and one
+conditional discount that the current checkout cart fails to satisfy. The platform can surface the first
 provisional discount with disclaimers like "verified at purchase" and additionally show
 a warning message to disclose the inapplicability of the second discount.
 
@@ -313,11 +313,11 @@ a warning message to disclose the inapplicability of the second discount.
         "applied": [
           {
             "title": "Loyalty benefit 1",
-            "amount": 10,
+            "amount": 1000,
             "provisional": true,
             "eligibility": "com.example.loyalty.store_card",
             "allocations": [
-              {"path": "$.line_items[0]", "amount": 10}
+              {"path": "$.line_items[0]", "amount": 1000}
             ]
           }
         ]
@@ -382,11 +382,11 @@ non-provisional and `display_id` is returned.
         "applied": [
           {
             "title": "Loyalty benefit 1",
-            "amount": 10,
+            "amount": 1000,
             "provisional": false,
             "eligibility": "com.example.loyalty.store_card",
             "allocations": [
-              {"path": "$.line_items[0]", "amount": 10}
+              {"path": "$.line_items[0]", "amount": 1000}
             ]
           }
         ]

--- a/source/schemas/common/loyalty.json
+++ b/source/schemas/common/loyalty.json
@@ -47,7 +47,7 @@
           "items": {
             "$ref": "#/$defs/earning_breakdown"
           },
-          "description": "List of breakdown of earning contributing to the total."
+          "description": "List of breakdown of earning contributing to the total. When present, the sum of the breakdown `amount` values MUST equal `earning_forecast.amount`."
         }
       }
     },

--- a/source/schemas/common/types/info_code.json
+++ b/source/schemas/common/types/info_code.json
@@ -8,6 +8,7 @@
     "identity_optional",
     "signal",
     "free_shipping",
-    "not_found"
+    "not_found",
+    "membership_benefit_eligible"
   ]
 }

--- a/source/schemas/common/types/warning_code.json
+++ b/source/schemas/common/types/warning_code.json
@@ -9,6 +9,7 @@
     "prop65",
     "fulfillment_changed",
     "payment_term_changed",
-    "age_restricted"
+    "age_restricted",
+    "membership_benefit_ineligible"
   ]
 }


### PR DESCRIPTION
### Problem

Four small loyalty corrections:

1. **Dangling example reference.** The main example says it builds on a "store loyalty card example" from the checkout Eligibility Verification at Completion section, which contains only a student-verification example.
2. **Minor-unit amount reads as major units.** The store-card discount example applies `amount: 10` ($0.10 in minor units) while the surrounding text describes a $10 benefit; sibling examples use minor units (1000).
3. **Breakdown has no sum invariant.** `earning_forecast.breakdown` amounts have no statement tying them to `earning_forecast.amount`, unlike discount allocations and totals.
4. **New codes absent from the examples registries.** `membership_benefit_eligible` and `membership_benefit_ineligible` are defined in a normative table but not in the `info_code`/`warning_code` examples arrays that tooling treats as the standard-code registry.

### Fix

- `loyalty.md`: reword to build on the eligibility-verification pattern and introduce the store-card scenario inline; correct the four discount/allocation amounts to `1000`.
- `loyalty.json`: state that the breakdown amounts MUST sum to `earning_forecast.amount`.
- `info_code.json` / `warning_code.json`: append the two codes.

### Verification

The four amount changes sit inside an `extract=$.loyalty` example, so no totals are affected; the points-earning breakdown (10 + 20 = 30) is untouched. `ucp-schema lint source/` (124 files, all passed) and `validate_examples.py` (343 passing, unchanged) re-measured 2026-09-01 on a test merge into main `1d39948`.

