### PR TITLE
fix(schema): require the actions map to be non-empty

### DIFF
--- a/source/schemas/common/types/actions.json
+++ b/source/schemas/common/types/actions.json
@@ -26,6 +26,7 @@
     }
   },
   "type": "object",
+  "minProperties": 1,
   "propertyNames": {
     "$ref": "reverse_domain_name.json"
   },


### PR DESCRIPTION
### Problem

`docs/specification/overview/index.md` requires the Business to omit the `actions` map when nothing is outstanding:

> the Business **MUST** include every outstanding Action and **MUST** omit `actions` when none are outstanding.

But `source/schemas/common/types/actions.json` placed no `minProperties` on the map (only `minItems: 1` on the array values), so an empty `"actions": {}` validated while violating that MUST.

### Fix

Add `minProperties: 1` to the map. The map should be absent, not empty, when there is no outstanding work, and a schema-driven validator now catches the empty case.

### Verification

`ucp-schema lint source/` clean (124 files); `validate_examples.py` 343 passed (unchanged). Re-measured 2026-09-01 on a test merge into main `1d39948`. No example emits an empty actions map. Verified with a JSON Schema validator that `{}` is now rejected and a non-empty map still passes.

Raised from #665.

