### PR TITLE
docs(checkout-a2a): restate the complete_in_progress freeze for transport parity

### DIFF
--- a/docs/specification/shopping/checkout/a2a.md
+++ b/docs/specification/shopping/checkout/a2a.md
@@ -132,6 +132,14 @@ current `contextId` can be reused for subsequent interactions.
 Business agents must leverage the `messageId` sent as part of the A2A `Message`
 to detect duplicate messages from platform retries.
 
+While a Checkout is `complete_in_progress`, it is frozen: the platform **MUST
+NOT** send a further checkout-modifying message (for example an `add_to_checkout`
+action, which maps to [Update Checkout](index.md#update-checkout)) for that
+Checkout. If the business agent receives such a message in that state, it **MUST**
+leave the Checkout unchanged and return the current Checkout with a recoverable
+error Message. This matches the `complete_in_progress` freeze the other transport
+bindings state for Update Checkout.
+
 ## Checkout Functionality
 
 The Checkout capability allows consumers to manage items in a checkout session


### PR DESCRIPTION
### Problem

The `complete_in_progress` update-freeze MUST is stated in the core checkout lifecycle and in the REST, MCP, OpenAPI, and OpenRPC contracts, but the A2A checkout binding (`docs/specification/shopping/checkout/a2a.md`) does not restate it. It has only a `messageId`-based Request Idempotency section and uses `add_to_checkout` / `complete_checkout` action verbs, so an implementer reading only the A2A binding gets no signal about the freeze.

### Fix

Add the freeze to the A2A Request Idempotency section, adapted to the A2A action model: while a Checkout is `complete_in_progress`, the platform MUST NOT send a further checkout-modifying message (for example `add_to_checkout`), and the business agent MUST leave the Checkout unchanged and return a recoverable error Message.

### Verification

`validate_examples.py` 343 passed (unchanged), re-measured 2026-09-01 on a test merge into main `1d39948`; spellcheck clean; the `index.md#update-checkout` anchor resolves.

Raised from #665.

