### PR TITLE
docs: fix checkout status lifecycle diagram to match spec prose

### DIFF
--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -79,24 +79,25 @@ platform receives messages indicating what's needed to progress.
        +------------+                         +---------------------+
        | incomplete |<----------------------->| requires_escalation |
        +-----+------+                         |   (buyer handoff    |
-             |                                |  via continue_url)  |
-             | all info collected             +----------+----------+
-             v                                           |
-    +------------------+                                 |
-    |ready_for_complete|                                 |
-    |                  |                                 |
-    | (platform can    |                                 | continue_url
-    | call Complete    |                                 |
-    |   Checkout)      |                                 |
-    +--------+---------+                                 |
-             |                                           |
-             | Complete Checkout                         |
-             v                                           |
-   +--------------------+                                |
-   |complete_in_progress|                                |
-   +---------+----------+                                |
-             |                                           |
-             +-----------------------+-------------------+
+    all info | ^                              |  via continue_url)  |
+   collected | |                              +----+-----------+----+
+             | | Update Checkout, or               ^            |
+             v | Complete Checkout (recoverable)   |            |
+    +------------------+                           |            |
+    |ready_for_complete|---------------------------+            |
+    |                  |    Complete Checkout                   |
+    | (platform can    |    (escalation needed)                 |
+    | call Complete    |                                        |
+    |   Checkout)      |                                        |
+    +--------+---------+                                        |
+             |                                                  |
+             | Complete Checkout                                |
+             v                                                  |
+   +--------------------+                                       |
+   |complete_in_progress|                                       | continue_url
+   +---------+----------+                                       |
+             |                                                  |
+             +-----------------------+--------------------------+
                                      v
                                +-------------+
                                |  completed  |
@@ -107,6 +108,12 @@ platform receives messages indicating what's needed to progress.
                                +-------------+
           (session invalid/expired - can occur from any state)
 ```
+
+> **Note:** Two transitions are omitted from the diagram above for
+> readability: `complete_in_progress` can also resolve via Buyer handoff
+> (`continue_url`) when an outstanding Action's fallback is exhausted, or via
+> cancellation per the race scenario described in
+> [Accepted completion](#accepted-completion) below.
 
 ### Status Values
 


### PR DESCRIPTION
# Description

The Checkout Status Lifecycle diagram only showed a one-way path from
`ready_for_complete` into `complete_in_progress`, with no way back to
`incomplete` and no path to `requires_escalation`. The normative prose
elsewhere in this file describes both:

- Complete Checkout's response section states that any other status
  retains its core status lifecycle semantics, explicitly naming
  `incomplete` ("for a recoverable change") and `requires_escalation`
  ("for Buyer handoff") as valid outcomes alongside `completed` and
  `complete_in_progress`.
- `ready_for_complete` can regress to `incomplete` via Update Checkout
  as well (business rules can reintroduce a missing requirement).

Update the diagram to show:

- `ready_for_complete -> requires_escalation`, labeled with the
  Complete Checkout escalation path.
- `ready_for_complete <-> incomplete` as two directional arrows: the
  existing "all info collected" transition down, and a new "Update
  Checkout, or Complete Checkout (recoverable)" transition back up.

Add a note documenting the two transitions still omitted from the
diagram for readability (`complete_in_progress` resolving via Buyer
handoff or via the cancellation race described in Accepted
completion), so the diagram's simplifications are explicit rather
than silent.

No normative or schema changes; documentation only.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None filed — found while reading the spec, opening directly as a docs fix.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

Before:
```text
       +------------+                         +---------------------+
       | incomplete |<----------------------->| requires_escalation |
       +-----+------+                         |   (buyer handoff    |
             |                                |  via continue_url)  |
             | all info collected             +----------+----------+
             v                                           |
    +------------------+                                 |
    |ready_for_complete|                                 |
```

After: see the updated diagram in `docs/specification/checkout.md`.