### PR TITLE
feat: event_feed capability and agent_hints on fulfillment events

### DIFF
--- a/source/schemas/common/types/agent_hint.json
+++ b/source/schemas/common/types/agent_hint.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/types/agent_hint.json",
+  "title": "Agent Hint",
+  "description": "An advisory hint from a business to a consuming agent, carried inside commerce event payloads. Hints are non-normative suggestions — agents decide whether and how to act on them.",
+
+  "type": "object",
+  "required": ["action"],
+  "additionalProperties": false,
+
+  "properties": {
+    "action": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short verb identifying the suggested action (e.g. notify_user, reorder, escalate, summarize)."
+    },
+
+    "condition": {
+      "type": "string",
+      "description": "Human-readable condition under which this hint applies. Informational only — not a machine-executable expression.",
+      "examples": [
+        "status == 'delayed'",
+        "user.auto_reorder == true"
+      ]
+    },
+
+    "priority": {
+      "type": "string",
+      "enum": ["low", "normal", "high"],
+      "default": "normal",
+      "description": "Advisory priority. Does not override agent judgment."
+    },
+
+    "meta": {
+      "type": "object",
+      "description": "Additional free-form context the business wants to pass with this hint.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/source/schemas/common/types/event_feed.json
+++ b/source/schemas/common/types/event_feed.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/types/event_feed.json",
+  "title": "Event Feed",
+  "description": "Declares a business's agent-subscribable commerce event feed. Agents discover this via the profile and choose a supported transport to receive typed commerce events without out-of-band configuration.",
+
+  "type": "object",
+  "required": ["url", "event_types"],
+  "additionalProperties": false,
+
+  "properties": {
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Base URL for the event feed endpoint."
+    },
+
+    "event_types": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "description": "Commerce event types this business emits. Use reverse-domain notation (e.g. dev.ucp.order.status_changed).",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "examples": [
+        ["dev.ucp.order.status_changed", "dev.ucp.order.shipped", "dev.ucp.cart.price_changed"]
+      ]
+    },
+
+    "transports": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "description": "Supported delivery transports for this feed. At least one must be present.",
+      "items": {
+        "type": "string",
+        "enum": ["webhook", "sse", "poll"],
+        "description": "webhook: business pushes to a caller-registered URL. sse: caller opens a long-lived GET. poll: caller GETs the url with optional cursor."
+      },
+      "default": ["poll"]
+    },
+
+    "poll_cursor_param": {
+      "type": "string",
+      "description": "Query parameter name for the cursor token when transport includes 'poll'. Defaults to 'after' if omitted.",
+      "default": "after"
+    }
+  }
+}

--- a/source/schemas/shopping/types/fulfillment_event.json
+++ b/source/schemas/shopping/types/fulfillment_event.json
@@ -59,6 +59,13 @@
     "description": {
       "type": "string",
       "description": "Human-readable description of the shipment status or delivery information (e.g., 'Delivered to front door', 'Out for delivery')."
+    },
+    "agent_hints": {
+      "type": "array",
+      "description": "Advisory hints for agents consuming this event. Non-normative — agents decide whether to act. Businesses use this to suggest contextually appropriate follow-up actions without prescribing behaviour.",
+      "items": {
+        "$ref": "../../common/types/agent_hint.json"
+      }
     }
   }
 }

--- a/source/schemas/ucp.json
+++ b/source/schemas/ucp.json
@@ -115,6 +115,10 @@
             "type": "array",
             "items": { "$ref": "payment_handler.json#/$defs/base" }
           }
+        },
+        "event_feed": {
+          "$ref": "common/types/event_feed.json",
+          "description": "Agent-subscribable commerce event feed advertised by this party. When present, agents MAY subscribe to receive typed commerce events (order updates, price changes, low stock) without out-of-band configuration."
         }
       }
     },
@@ -204,6 +208,9 @@
                   "$ref": "payment_handler.json#/$defs/business_schema"
                 }
               }
+            },
+            "event_feed": {
+              "$ref": "common/types/event_feed.json"
             }
           }
         }


### PR DESCRIPTION
Right now agents have no standard way to know what commerce events a business emits or how to receive them, leaving integrations wired up outside the protocol. Pairing discoverable feeds with per-event hints closes that gap and makes UCP events first-class for agentic workflows, without touching any required fields or existing transports.

`event_feed` on the business profile lets a business advertise a typed event stream (order updates, price changes, low stock). Agents read the profile, pick a transport (`webhook` / `sse` / `poll`), and subscribe.

`agent_hints` on `fulfillment_event` lets a business attach advisory action suggestions to shipment events (e.g. `notify_user` on delay, `escalate` on `undeliverable`). Non-normative — the agent decides whether to act.

## Example

```json
{
  "event_feed": {
    "url": "https://store.example.com/ucp/events",
    "event_types": ["dev.ucp.order.shipped", "dev.ucp.order.status_changed"],
    "transports": ["sse", "poll"]
  }
}
```

```json
{
  "type": "failed_attempt",
  "agent_hints": [
    { "action": "notify_user", "priority": "high" },
    { "action": "escalate", "condition": "attempts > 2" }
  ]
}
```

## Category
- [ ] Core Protocol
- [x] Capability
- [ ] Documentation