### PR TITLE
feat: add optional media to option_value

### DIFF
--- a/source/schemas/shopping/types/option_value.json
+++ b/source/schemas/shopping/types/option_value.json
@@ -15,6 +15,10 @@
     "label": {
       "type": "string",
       "description": "Display text for this option value (e.g., 'Small', 'Blue')."
+    },
+    "media": {
+      "$ref": "../../common/types/media.json",
+      "description": "Optional media representing this option value (e.g., a color sample or product photo for a Color option). Reuses the standard Media type."
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds an optional `media` property to `option_value.json`, reusing the existing **Media** type (`common/types/media.json`) via `$ref`. This lets an option value carry a representative image — most importantly a color sample for `Color` options, which the catalog model already treats as a first-class option type (`product_option`: "size, color, or material") but cannot currently render visually.

```diff
   "label": {
     "type": "string",
     "description": "Display text for this option value (e.g., 'Small', 'Blue')."
-  }
+  },
+  "media": {
+    "$ref": "../../common/types/media.json",
+    "description": "Optional media representing this option value (e.g., a color sample or product photo for a Color option). Reuses the standard Media type."
+  }
```

## Motivation

`option_value` today carries only `id` and `label` (display text). For a `Color` option, a platform can show the text "Red" but **not** the color sample or the product photo for that color — a gap on a feature every major storefront supports. `variant.media[]` holds the full gallery, but there is no per-option-value visual to drive a color/material picker. This is a universal, cross-party display primitive (not business-specific data), so it belongs in the shared schema rather than `metadata` or a vendor extension.

## Changes

- `source/schemas/shopping/types/option_value.json`: add optional `media` (`$ref ../../common/types/media.json`). No change to `media.json`; no new types; `label` stays the only required field.

### Blast radius — one edit, two contexts

Because `detail_option_value.json` composes via `allOf: [{ "$ref": "option_value.json" }]`, this single addition makes option-value media available in both places:

- `product_option.values[]` → option pickers (browse/search)
- `catalog_lookup` `get_product` → `detail_option_value` (contextual detail view)

No transport, operation, or behavioral change. `media` is optional; platforms MUST tolerate its absence (and already MUST ignore unrecognized fields per the protocol's forward-compatibility rule).

### Design notes

- **Single `media`, not an array**: option-value media is *the* representative visual (e.g., one color sample). Full galleries live on `variant.media[]`; an option value needs a single representative, not a set.
- **Generic `media` over a bespoke field**: reuses the protocol's existing Media vocabulary and supports non-image types (e.g., a material video), consistent with `product.media` / `variant.media`.
- **Accessibility**: `media.alt_text` provides a text fallback, with `label` as a secondary fallback.

## Validation

- `ucp-schema lint source/` → **98 files, all passed**.
- Additive and non-breaking; no breaking-change (`!`) prefix warranted.
- Not run locally: `pre-commit` / super-linter (left to CI).

## Relationship to other work

Complements #674 (`seller.logo`) — both complete the visual identity of catalog entities (option values and sellers). No overlap with #595 (`brand`) or #401 (structured attributes), which carry product identity / machine-readable attributes rather than per-option visuals.

This is a core schema modification. Happy to also open an Enhancement Proposal issue or carry a `gov:needs-tc-review` label if maintainers prefer that track (consistent with #401 / #595).
