### PR TITLE
docs: add VAT multi-rate totals example for tax-inclusive jurisdictions

### DIFF
--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -1124,6 +1124,21 @@ when provided.
 ]
 ```
 
+**VAT, mixed rates (tax-inclusive total):**
+
+Where the buyer-facing price is tax-inclusive, `subtotal` stays net and each VAT
+rate is a separate `tax` entry; `total` is the gross amount the buyer pays.
+
+<!-- ucp:example schema=shopping/checkout target=$.totals op=read -->
+```json
+[
+  { "type": "subtotal", "display_text": "Subtotal (net)", "amount": 6000 },
+  { "type": "tax",      "display_text": "VAT 20%",        "amount": 800 },
+  { "type": "tax",      "display_text": "VAT 5.5%",       "amount": 110 },
+  { "type": "total",    "display_text": "Total",          "amount": 6910 }
+]
+```
+
 **Collapsed fees with optional breakdown:**
 
 <!-- ucp:example schema=shopping/checkout target=$.totals op=read -->


### PR DESCRIPTION
# Description

Adds one worked `totals` example to the checkout spec: a mixed-rate VAT cart for
jurisdictions where the buyer-facing price is tax-inclusive.

Every existing `totals` example uses the US sales-tax model (tax added on top,
labelled "Federal Tax" / "State Tax"). There is no example for VAT
jurisdictions, where the authoritative `total` is the gross amount the buyer pays
and a single order commonly mixes rates (for example reduced-rate books
alongside standard-rate goods). The example reuses the existing rule that `tax`
MAY appear multiple times: `subtotal` stays net and `total` is the gross.

This mirrors how other commerce data specs treat the same split. Google Merchant
Center requires the `price` attribute to be VAT-inclusive for EU targets and
tax-exclusive for US/CA, and schema.org exposes `valueAddedTaxIncluded` (from the
GoodRelations vocabulary). In the EU the tax-inclusive display is a legal
requirement under the Price Indication Directive 98/6/EC (as amended by
2019/2161).

Documentation only, no schema change. A native tax-inclusive indicator (a
per-price flag or VAT-portion breakdown, cf. schema.org `valueAddedTaxIncluded`)
is intentionally out of scope here.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Validation

- The new `<!-- ucp:example ... op=read -->` block validates against
  `source/schemas/shopping/types/totals.json` (JSON Schema Draft 2020-12, local
  `$ref`s resolved): exactly one `subtotal` and one `total`, additive `tax`
  entries with non-negative amounts, and `6000 + 800 + 110 == 6910`.
- `cspell` reports no issues on `docs/specification/checkout.md`; the added lines
  introduce no new `markdownlint` findings.
- `ucp-schema` was not available in the local environment, so the canonical
  resolver and CI (`docs.yml`) remain authoritative.

## Screenshots / Logs (if applicable)

N/A
