### PR TITLE
refactor!: migrate totals.json from array to object schema

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -490,7 +490,7 @@ image: assets/banner.png
         "description": "Defective item"
       }
     ],
-    "totals": [ ... ]
+    "totals": { ... }
   }
   ```
 

--- a/docs/specification/embedded-cart.md
+++ b/docs/specification/embedded-cart.md
@@ -344,7 +344,7 @@ Signals that cart is visible and ready for interaction. Sent after a successful
         "cart": {
             "id": "cart_123",
             "currency": "USD",
-            "totals": [ ... ],
+            "totals": { ... },
             "line_items": [ ... ],
             "buyer": { ... }
             // ...other cart fields...
@@ -379,7 +379,7 @@ proceed to initiate a checkout session based on the completed cart by issuing a
         "cart": {
             "id": "cart_123",
             "currency": "USD",
-            "totals": [ ... ],
+            "totals": { ... },
             "line_items": [ ... ],
             "buyer": { ... }
             // ...other cart fields...
@@ -415,7 +415,7 @@ Line items have been modified (quantity changed, items added/removed).
         "cart": {
             "id": "cart_123",
             // The entire cart object is provided, including the updated line items and estimated totals
-            "totals": [ ... ],
+            "totals": { ... },
             "line_items": [ ... ]
             // ...
         }

--- a/docs/specification/order.md
+++ b/docs/specification/order.md
@@ -269,12 +269,12 @@ Examples: `refund`, `return`, `credit`, `price_adjustment`, `dispute`,
       "description": "Defective item"
     }
   ],
-  "totals": [
-    { "type": "subtotal", "amount": 13000 },
-    { "type": "fulfillment", "amount": 1200 },
-    { "type": "tax", "amount": 1142 },
-    { "type": "total", "amount": 15342 }
-  ]
+  "totals": {
+    "subtotal": { "display_text": "Subtotal", "amount": 13000 },
+    "fulfillment": { "display_text": "Shipping", "amount": 1200 },
+    "tax": { "display_text": "Taxes", "amount": 1142 },
+    "total": { "display_text": "Total", "amount": 15342 }
+  }
 }
 ```
 

--- a/scripts/scaffolds/shopping_cart_response.json
+++ b/scripts/scaffolds/shopping_cart_response.json
@@ -16,8 +16,8 @@
       ]
     }
   ],
-  "totals": [
-    { "type": "subtotal", "amount": 1000 },
-    { "type": "total", "amount": 1000 }
-  ]
+  "totals": {
+    "subtotal": { "display_text": "Subtotal", "amount": 1000 },
+    "total": { "display_text": "Total", "amount": 1000 }
+  }
 }

--- a/scripts/scaffolds/shopping_checkout_response.json
+++ b/scripts/scaffolds/shopping_checkout_response.json
@@ -18,10 +18,10 @@
       ]
     }
   ],
-  "totals": [
-    { "type": "subtotal", "amount": 1000 },
-    { "type": "total", "amount": 1000 }
-  ],
+  "totals": {
+    "subtotal": { "display_text": "Subtotal", "amount": 1000 },
+    "total": { "display_text": "Total", "amount": 1000 }
+  },
   "links": [
     { "type": "terms_of_service", "url": "https://example.com/terms" }
   ]

--- a/scripts/scaffolds/shopping_order_response.json
+++ b/scripts/scaffolds/shopping_order_response.json
@@ -20,8 +20,8 @@
     }
   ],
   "fulfillment": {},
-  "totals": [
-    { "type": "subtotal", "amount": 1000 },
-    { "type": "total", "amount": 1000 }
-  ]
+  "totals": {
+    "subtotal": { "display_text": "Subtotal", "amount": 1000 },
+    "total": { "display_text": "Total", "amount": 1000 }
+  }
 }

--- a/source/schemas/shopping/types/total.json
+++ b/source/schemas/shopping/types/total.json
@@ -22,6 +22,28 @@
     "amount": {
       "$ref": "../../common/types/signed_amount.json",
       "ucp_request": "omit"
+    },
+    "lines": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "display_text",
+          "amount"
+        ],
+        "properties": {
+          "display_text": {
+            "type": "string",
+            "description": "Human-readable label for this sub-line."
+          },
+          "amount": {
+            "$ref": "../../common/types/signed_amount.json"
+          }
+        },
+        "description": "Sub-line entry. Additional metadata MAY be included."
+      },
+      "description": "Optional itemized breakdown. The parent entry is always rendered; lines are supplementary. Sum of line amounts MUST equal the parent entry amount.",
+      "ucp_request": "omit"
     }
   },
   "allOf": [

--- a/source/schemas/shopping/types/totals.json
+++ b/source/schemas/shopping/types/totals.json
@@ -2,61 +2,47 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/shopping/types/totals.json",
   "title": "Totals",
-  "description": "Pricing breakdown provided by the business. MUST contain exactly one subtotal and one total entry. Detail types (tax, fee, discount, fulfillment) may appear multiple times for itemization. Platforms MUST render all entries in order using display_text and amount.",
-  "type": "array",
-  "items": {
-    "allOf": [
-      {
-        "$ref": "total.json"
-      },
-      {
-        "type": "object",
-        "properties": {
-          "lines": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "required": [
-                "display_text",
-                "amount"
-              ],
-              "properties": {
-                "display_text": {
-                  "type": "string",
-                  "description": "Human-readable label for this sub-line."
-                },
-                "amount": {
-                  "$ref": "../../common/types/signed_amount.json"
-                }
-              },
-              "description": "Sub-line entry. Additional metadata MAY be included."
-            },
-            "description": "Optional itemized breakdown. The parent entry is always rendered; lines are supplementary. Sum of line amounts MUST equal the parent entry amount.",
-            "ucp_request": "omit"
-          }
-        }
-      },
-      {
-        "if": {
-          "properties": {
-            "type": { "not": { "enum": ["subtotal", "items_discount", "discount", "fulfillment", "tax", "fee", "total"] } }
-          },
-          "required": ["type"]
-        },
-        "then": { "required": ["display_text"] }
-      }
-    ]
-  },
-  "allOf": [
-    {
-      "contains": { "properties": { "type": { "const": "subtotal" } }, "required": ["type"] },
-      "minContains": 1,
-      "maxContains": 1
+  "description": "Pricing breakdown provided by the business. MUST contain subtotal and total entries. Detail types (tax, fee, discount, fulfillment) MAY be included. Platforms render entries according to display_order or standard receipt hierarchy.",
+  "type": "object",
+  "required": [
+    "subtotal",
+    "total"
+  ],
+  "properties": {
+    "subtotal": {
+      "$ref": "total.json",
+      "description": "Subtotal entry representing total item cost before taxes, shipping, or discounts."
     },
-    {
-      "contains": { "properties": { "type": { "const": "total" } }, "required": ["type"] },
-      "minContains": 1,
-      "maxContains": 1
+    "total": {
+      "$ref": "total.json",
+      "description": "Final total amount due for the order."
+    },
+    "discount": {
+      "$ref": "total.json",
+      "description": "Order-level discount entry."
+    },
+    "fulfillment": {
+      "$ref": "total.json",
+      "description": "Shipping, delivery, or pickup fulfillment cost entry."
+    },
+    "tax": {
+      "$ref": "total.json",
+      "description": "Total tax entry. May contain itemized sub-line breakdown in lines."
+    },
+    "fee": {
+      "$ref": "total.json",
+      "description": "Service or regulatory fee entry."
+    },
+    "display_order": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Optional ordering hint specifying exact top-to-bottom display sequence for UI receipt rendering.",
+      "ucp_request": "omit"
     }
-  ]
+  },
+  "additionalProperties": {
+    "$ref": "total.json"
+  }
 }


### PR DESCRIPTION
## Summary
While auditing downstream code generator workarounds during review of **RFC #484**, I identified that **`source/schemas/shopping/types/totals.json`** uses a **RootArray (`"type": "array"`) schema** which is responsible for much of the post processing logic our SDK generation requires.

This PR refactors `totals.json` from a top-level array into a top-level object (`"type": "object"`) which will:
1. Eliminate custom post-processing handling for the current schema in our `*-sdk` repositories.
2. Align the `totals.json` schema with modern UCP schema design guidelines.
3. Provide a more flexible API for extension in the shopping space.

---

### **Why RootArray Schemas Cause Generator Friction**

Defining a resource as a RootArray (`"type": "array"` at schema root) causes four specific failure modes in schema-driven toolchains:

* **Loss of Named Class Emission (`RootModel` Friction)**: Generators cannot emit standard named classes (`class Totals(BaseModel)`). Instead, they emit anonymous `RootModel` / `TypeAliasType` wrappers, breaking direct JSON serialization in web frameworks (e.g., FastAPI).
* **Access Friction**: Forces developers to write array searches (`totals.find(t => t.type === "subtotal")`) instead of direct typed property access (`totals.subtotal.amount`).
* **Dropped Validation & Maintenance Hacks**: Code generators drop array `contains`/`minContains` rules entirely, forcing **180+ lines of AST post-processing** in Python ([`postprocess_models.py#L170-L346`](https://github.com/Universal-Commerce-Protocol/python-sdk/blob/main/postprocess_models.py#L170-L346)) and **8 duplicated `.superRefine` Zod callbacks** in TypeScript ([`spec_generated.ts#L677-L700`](https://github.com/Universal-Commerce-Protocol/js-sdk/blob/main/src/spec_generated.ts#L677-L700)).
* **Extensibility Deficit**: An array cannot accept top-level metadata (like a `display_order` hint) in future revisions without a breaking schema change.

---

## Developer Experience Comparison

### Python SDK:
```python
# BEFORE (clunky array search / RootModel):
subtotal = next(t.amount for t in checkout.totals if t.type == "subtotal")

# AFTER (strongly-typed property access):
subtotal = checkout.totals.subtotal.amount
```

### TypeScript SDK:
```typescript
// BEFORE (array find + optional chaining / non-null assertion):
const subtotal = checkout.totals.find(t => t.type === "subtotal")!.amount;

// AFTER (direct autocompleted property access):
const subtotal = checkout.totals.subtotal.amount;
```

---

## Conformance with UCP Schema Guidelines

The refactored `totals.json` and `total.json` schemas directly conform to official UCP authoring standards:

1. **Open String Vocabularies over Enums**:
   - **Guideline**: [`docs/documentation/schema-authoring.md#string-vocabularies-vs-enums`](https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/documentation/schema-authoring.md#string-vocabularies-vs-enums) (*"Prefer open string vocabularies with documented well-known values over closed `enum` arrays."*)
   - **Impact**: Removes the legacy conditional `"enum": ["subtotal", "tax", ...]` array from `totals.json`, preventing breaking changes when new total categories are added in future releases.
2. **Avoiding Complex Conditional Validation**:
   - **Guideline**: [`docs/documentation/schema-authoring.md#open-enumerations`](https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/documentation/schema-authoring.md#open-enumerations) (*"Avoid complex validation patterns... as they frequently confuse client-side code generators and make schemas difficult to read."*)
   - **Impact**: Replaces brittle array `contains` / `allOf` / `if`/`then` conditional rules with standard object properties (`required: ["subtotal", "total"]`), eliminating generator confusion.
3. **Consistency Across Protocol Resources**:
   - **Guideline**: [`docs/specification/overview.md`](https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/overview.md)
   - **Impact**: Brings `totals.json` into 100% architectural parity with all other core UCP resources (`cart`, `checkout`, `payment`, `fulfillment`), which are uniformly modeled as top-level objects.

---

## Receipt Rendering & Itemization
* **Display Sequence**: The optional `display_order` string array hint (`["subtotal", "discount", "fulfillment", "tax", "total"]`) preserves custom merchant receipt rendering order without requiring array schema hacks.
* **Sub-Line Breakdown**: Itemized sub-lines (e.g. multi-jurisdiction taxes) are preserved via the nested `lines` array in `total.json`.
* **Shopping Space Extensibility**: Uses open string properties backed by `additionalProperties: { "$ref": "total.json" }`. This allows businesses and platform extensions to introduce shopping line items (`gift_wrapping_fee`, `recycling_fee`, `bottle_deposit`, `tip`, `store_credit`) without requiring a breaking schema revision or version bump.
