### PR TITLE
fix: record post-strip indices for array elision paths

### DIFF
--- a/docs/specification/catalog/lookup.md
+++ b/docs/specification/catalog/lookup.md
@@ -107,6 +107,11 @@ from the response.
 
 {{ extension_schema_fields('catalog_lookup.json#/$defs/lookup_response', 'catalog') }}
 
+Like every other operation, `lookup_catalog` MAY return the standard error
+envelope (`ucp.status: "error"` with `messages`) in place of a lookup
+response payload when the request cannot be served. See
+[Error Handling](../overview.md#error-handling).
+
 ---
 
 ## Get Product (`get_product`)

--- a/docs/specification/catalog/mcp.md
+++ b/docs/specification/catalog/mcp.md
@@ -117,6 +117,11 @@ Maps to the [Catalog Search](search.md) capability.
   'catalog_search.json#/$defs/search_response', 'catalog/mcp'
 ) }}
 
+When the request cannot be served, the tool returns a successful JSON-RPC
+result carrying the standard error envelope (`ucp.status: "error"` with
+`messages`) instead of a search response payload, mirroring
+[Product Not Found](#product-not-found) for `get_product`.
+
 #### Search Example
 
 === "Request"
@@ -276,6 +281,11 @@ The `catalog.ids` parameter accepts an array of identifiers and optional context
 {{ extension_schema_fields(
   'catalog_lookup.json#/$defs/lookup_response', 'catalog/mcp'
 ) }}
+
+When the request cannot be served, the tool returns a successful JSON-RPC
+result carrying the standard error envelope (`ucp.status: "error"` with
+`messages`) instead of a lookup response payload, mirroring
+[Product Not Found](#product-not-found) for `get_product`.
 
 #### Lookup Example
 

--- a/docs/specification/catalog/rest.md
+++ b/docs/specification/catalog/rest.md
@@ -538,6 +538,10 @@ Use HTTP status codes for protocol-level issues that prevent request processing:
 | 429 | Too Many Requests - Rate limited |
 | 500 | Internal Server Error |
 
+The REST service definition (`rest.openapi.json`) declares these as
+`4XX`/`5XX` responses carrying the standard error envelope, so clients
+generated from the service definition receive a typed error shape.
+
 ### Business Outcomes
 
 All application-level outcomes return HTTP 200 with the UCP envelope and optional
@@ -587,6 +591,14 @@ Business outcomes use the standard HTTP 200 status with messages in the response
 ### Detail Product {: #detail-product }
 
 {{ extension_schema_fields('catalog_lookup.json#/$defs/detail_product', 'catalog/rest') }}
+
+### Search Response {: #catalog-search-search-response }
+
+{{ extension_schema_fields('catalog_search.json#/$defs/search_response', 'catalog/rest') }}
+
+### Lookup Response {: #catalog-lookup-lookup-response }
+
+{{ extension_schema_fields('catalog_lookup.json#/$defs/lookup_response', 'catalog/rest') }}
 
 ### Get Product Response {: #catalog-lookup-get-product-response }
 

--- a/docs/specification/catalog/search.md
+++ b/docs/specification/catalog/search.md
@@ -35,6 +35,11 @@ queries, filtering by category and price, and pagination.
 
 {{ extension_schema_fields('catalog_search.json#/$defs/search_response', 'catalog') }}
 
+Like every other operation, `search_catalog` MAY return the standard error
+envelope (`ucp.status: "error"` with `messages`) in place of a search
+response payload when the request cannot be served. See
+[Error Handling](../overview.md#error-handling).
+
 ## Search Inputs
 
 A valid search request MUST include at least one of: a `query` string,

--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -1295,6 +1295,9 @@ operations unless otherwise noted.
     3. Return `409 Conflict` if the key is reused with a mismatched body.
     See [Message Signatures — Idempotency Key Requirements](signatures.md#replay-protection)
     for the full payload-matching contract.
+* **ETag / If-Match**: Businesses that support conditional writes return an
+    `ETag` on checkout responses; platforms echo it via `If-Match` on Update,
+    Complete, and Cancel. See [Concurrency Control](#concurrency-control).
 
 ## Protocol Mechanics
 
@@ -1311,11 +1314,113 @@ request.
 | `401 Unauthorized`          | Authentication is required and has failed or has not been provided.                |
 | `403 Forbidden`             | The request is authenticated but the user does not have the necessary permissions. |
 | `409 Conflict`              | The request could not be completed due to a conflict (e.g., idempotent key reuse). |
+| `412 Precondition Failed`   | The `If-Match` entity tag does not match the session's current state.              |
 | `422 Unprocessable Entity`  | The profile content is malformed (discovery failure).                              |
 | `424 Failed Dependency`     | The profile URL is valid but fetch failed (discovery failure).                     |
+| `428 Precondition Required` | The operation requires a conditional request (`If-Match`).                         |
 | `429 Too Many Requests`     | Rate limit exceeded.                                                               |
 | `503 Service Unavailable`   | Temporary unavailability.                                                          |
 | `500 Internal Server Error` | An unexpected condition was encountered on the server.                             |
+
+### Concurrency Control
+
+The REST binding carries the
+[Concurrency Control](checkout.md#concurrency-control) entity tag in
+standard HTTP conditional-request fields
+([RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-conditional-requests){target="_blank"}):
+
+* Businesses that support conditional writes **SHOULD** return a strong
+    `ETag` response header on every checkout response (Create, Get, Update,
+    Complete, Cancel).
+* Platforms **SHOULD** send the last observed tag in an `If-Match` request
+    header on Update, Complete, and Cancel.
+* On a tag mismatch the business **MUST NOT** apply any part of the write
+    and **MUST** respond `412 Precondition Failed` with the standard error
+    envelope and `code: "precondition_failed"`. The error is `recoverable`:
+    the platform re-reads the session via Get Checkout, reconciles its
+    intended changes with the current state, and retries with the fresh tag.
+* Businesses that require serialized writes **MAY** reject unconditional
+    writes with `428 Precondition Required`
+    ([RFC 6585](https://www.rfc-editor.org/rfc/rfc6585){target="_blank"}).
+    Platforms treat this like a mismatch: fetch the current state and its
+    tag, then retry conditionally.
+
+`If-Match` composes with `Idempotency-Key`: idempotency deduplicates retries
+of one logical write, while the precondition orders distinct writes. A
+retried request keeps both its original `Idempotency-Key` and its original
+`If-Match` value.
+
+#### Example: Conditional Update
+
+=== "Request"
+
+    <!-- ucp:example schema=shopping/checkout op=update direction=request -->
+    ```json
+    PUT /checkout-sessions/chk_1234567890 HTTP/1.1
+    UCP-Agent: profile="https://platform.example/profile"
+    If-Match: "33a64df551425fcc"
+    Content-Type: application/json
+
+    {
+      "buyer": {
+        "email": "jane@example.com"
+      },
+      "line_items": [
+        {
+          "id": "li_1",
+          "item": {
+            "id": "item_123"
+          },
+          "quantity": 3
+        }
+      ]
+    }
+    ```
+
+=== "Response (applied)"
+
+    The write matched the session's current state; the response carries the
+    new entity tag for the platform's next write.
+
+    <!-- ucp:example schema=shopping/checkout op=read -->
+    ```json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+    ETag: "5c3e9f10b74d21aa"
+
+    {
+      "ucp": "...",
+      "id": "chk_1234567890",
+      "status": "ready_for_complete",
+      "currency": "USD",
+      "line_items": ["..."],
+      "links": ["..."],
+      "totals": ["..."]
+    }
+    ```
+
+=== "Response (rejected)"
+
+    Another writer changed the session after this platform last read it.
+    Nothing was applied; the platform re-reads and retries.
+
+    <!-- ucp:example schema=common/types/error_response op=read -->
+    ```json
+    HTTP/1.1 412 Precondition Failed
+    Content-Type: application/json
+
+    {
+      "ucp": { "version": "{{ ucp_version }}", "status": "error" },
+      "messages": [
+        {
+          "type": "error",
+          "code": "precondition_failed",
+          "severity": "recoverable",
+          "content": "Checkout changed since the supplied entity tag; re-read and retry."
+        }
+      ]
+    }
+    ```
 
 ### Error Responses
 
@@ -1325,6 +1430,11 @@ code registry and transport binding examples.
 * **Protocol errors**: Return appropriate HTTP status code (401, 403, 409, 429,
     503) with JSON body containing `code` and `content`.
 * **Business outcomes**: Return HTTP 200 with UCP envelope and `messages` array.
+
+The REST service definition (`rest.openapi.json`) declares these as `4XX`/`5XX`
+responses, plus an explicit `409` on state-changing operations for
+idempotency-key conflicts, each carrying the standard error envelope, so
+clients generated from the service definition receive a typed error shape.
 
 #### Business Outcomes
 

--- a/docs/specification/checkout.md
+++ b/docs/specification/checkout.md
@@ -680,6 +680,61 @@ that is not equal to `completed` or `canceled` **SHOULD** be cancelable.
 
 {{ method_fields('cancel_checkout', 'rest.openapi.json', 'checkout') }}
 
+### Concurrency Control
+
+Update Checkout is a full replacement, and a checkout session may
+legitimately have more than one writer: the spec explicitly contemplates an
+agent and a buyer in a trusted UI driving the same session (see
+[Continue URL](#continue-url)). Without coordination, two writers that read
+the same state and then write divergent replacements silently lose one of
+the updates: last write wins, and neither party is told.
+
+`Idempotency-Key` does not address this. Idempotency collapses *identical*
+retries of the same request; it neither detects nor serializes two
+*different* replacement writes racing for the same session.
+
+UCP therefore layers optimistic concurrency onto the state-changing
+checkout operations (Update, Complete, Cancel):
+
+* The business assigns each checkout state an opaque **entity tag** that
+  changes whenever the stored session state changes, and returns it with
+  every checkout response.
+* The platform echoes the last tag it observed when it writes. If the tag
+  still matches the session's current state, the write proceeds. If it does
+  not, the business rejects the write without applying it; the platform
+  re-reads the session (Get Checkout), reconciles its intended changes with
+  the current state, and retries with the new tag.
+
+Support is discovered from responses themselves: a business that returns
+entity tags is advertising conditional-write support, and a platform that
+has never seen a tag has nothing to echo and proceeds unconditionally. No
+profile configuration is involved.
+
+Bindings define the tag carrier. The
+[REST binding](checkout-rest.md#concurrency-control) uses standard HTTP
+conditional requests (`ETag` / `If-Match`,
+[RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-conditional-requests){target="_blank"}).
+Bindings without a native metadata carrier for response tags (MCP, A2A,
+Embedded) do not define one yet; writes on those bindings remain
+unconditional.
+
+**Business:**
+
+* **SHOULD** return an entity tag with every checkout response.
+* **MUST**, when returning entity tags, change the tag whenever the stored
+  session state changes, including business-initiated changes (repricing,
+  inventory adjustments), not only platform writes.
+* **MUST** reject a conditional write whose tag does not match the
+  session's current state, without applying any part of it.
+
+**Platform:**
+
+* **SHOULD** write conditionally whenever it has observed an entity tag
+  for the session.
+* **SHOULD**, on rejection, re-read the session, reapply its intended
+  changes on top of the current state, and retry with the fresh tag rather
+  than retrying the stale write verbatim.
+
 ## Transport Bindings
 
 The abstract operations above are bound to specific transport protocols as

--- a/scripts/test_validate_examples.py
+++ b/scripts/test_validate_examples.py
@@ -209,6 +209,29 @@ def test_string_ellipsis_in_array() -> None:
   )
 
 
+def test_array_ellipsis_paths_use_stripped_indices() -> None:
+  """Elision paths inside arrays reflect post-strip positions.
+
+  Removing a `"..."` sentinel shifts later items left. Recorded paths
+  must match the stripped payload the validator sees \u2014 recording the
+  source index would fail to suppress the acknowledged elision (and
+  could suppress a real error on the sibling that shifts into that
+  index).
+  """
+  tree = {"items": ["...", {"price": "..."}]}
+  cleaned, paths = v.strip_ellipsis(tree)
+  _check(
+    "array_sentinel_removed_items_shift",
+    cleaned == {"items": [{}]},
+    f"got {cleaned!r}",
+  )
+  _check(
+    "array_ellipsis_paths_use_stripped_indices",
+    "/items/0/price" in paths and "/items/1/price" not in paths,
+    f"got {paths!r}",
+  )
+
+
 # -----------------------------------------------------------
 # Annotation parsing
 # -----------------------------------------------------------
@@ -583,6 +606,7 @@ def main() -> int:
   test_parse_example_keeps_sentinels()
   test_strip_ellipsis_records_paths()
   test_string_ellipsis_in_array()
+  test_array_ellipsis_paths_use_stripped_indices()
   test_annotation_parsing()
   test_extract_blocks()
   test_scaffold_resolution()

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -407,11 +407,15 @@ def strip_ellipsis(obj, _path="", _paths=None):
         result[k] = strip_ellipsis(v, child_path, _paths)
     return result if _path else (result, _paths)
   elif isinstance(obj, list):
+    # Child paths use the post-strip index — the position the item
+    # occupies in the payload the validator sees. Removed sentinels
+    # shift later items left, so the source index would point at the
+    # wrong element (or suppress a real error on a shifted sibling).
     items = []
-    for i, item in enumerate(obj):
+    for item in obj:
       if item == "...":
         continue
-      items.append(strip_ellipsis(item, f"{_path}/{i}", _paths))
+      items.append(strip_ellipsis(item, f"{_path}/{len(items)}", _paths))
     return items if _path else (items, _paths)
   return obj if _path else (obj, _paths)
 

--- a/source/services/shopping/mcp.openrpc.json
+++ b/source/services/shopping/mcp.openrpc.json
@@ -43,6 +43,18 @@
           { "$ref": "../../schemas/common/types/error_response.json" }
         ]
       },
+      "catalog_search_result": {
+        "oneOf": [
+          { "$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_response" },
+          { "$ref": "../../schemas/common/types/error_response.json" }
+        ]
+      },
+      "catalog_lookup_result": {
+        "oneOf": [
+          { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_response" },
+          { "$ref": "../../schemas/common/types/error_response.json" }
+        ]
+      },
       "meta": {
         "type": "object",
         "description": "Request metadata.",
@@ -301,7 +313,7 @@
       ],
       "result": {
         "name": "response",
-        "schema": {"$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_response"}
+        "schema": {"$ref": "#/components/schemas/catalog_search_result"}
       }
     },
     {
@@ -322,7 +334,7 @@
       ],
       "result": {
         "name": "response",
-        "schema": {"$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_response"}
+        "schema": {"$ref": "#/components/schemas/catalog_lookup_result"}
       }
     },
     {

--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -83,6 +83,9 @@
               },
               "Content-Digest": {
                 "$ref": "#/components/headers/content_digest"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/etag"
               }
             },
             "content": {
@@ -92,6 +95,15 @@
                 }
               }
             }
+          },
+          "409": {
+            "$ref": "#/components/responses/idempotency_conflict"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       }
@@ -151,6 +163,9 @@
               },
               "Content-Digest": {
                 "$ref": "#/components/headers/content_digest"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/etag"
               }
             },
             "content": {
@@ -160,6 +175,12 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       },
@@ -185,6 +206,9 @@
           },
           {
             "$ref": "#/components/parameters/idempotency_key"
+          },
+          {
+            "$ref": "#/components/parameters/if_match"
           },
           {
             "$ref": "#/components/parameters/request_id"
@@ -228,6 +252,9 @@
               },
               "Content-Digest": {
                 "$ref": "#/components/headers/content_digest"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/etag"
               }
             },
             "content": {
@@ -237,6 +264,18 @@
                 }
               }
             }
+          },
+          "412": {
+            "$ref": "#/components/responses/precondition_failed"
+          },
+          "409": {
+            "$ref": "#/components/responses/idempotency_conflict"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       }
@@ -267,6 +306,9 @@
           },
           {
             "$ref": "#/components/parameters/idempotency_key"
+          },
+          {
+            "$ref": "#/components/parameters/if_match"
           },
           {
             "$ref": "#/components/parameters/request_id"
@@ -310,6 +352,9 @@
               },
               "Content-Digest": {
                 "$ref": "#/components/headers/content_digest"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/etag"
               }
             },
             "content": {
@@ -317,6 +362,18 @@
                 "schema": { "$ref": "#/components/schemas/checkout_response" }
               }
             }
+          },
+          "412": {
+            "$ref": "#/components/responses/precondition_failed"
+          },
+          "409": {
+            "$ref": "#/components/responses/idempotency_conflict"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       }
@@ -347,6 +404,9 @@
           },
           {
             "$ref": "#/components/parameters/idempotency_key"
+          },
+          {
+            "$ref": "#/components/parameters/if_match"
           },
           {
             "$ref": "#/components/parameters/request_id"
@@ -382,6 +442,9 @@
               },
               "Content-Digest": {
                 "$ref": "#/components/headers/content_digest"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/etag"
               }
             },
             "content": {
@@ -391,6 +454,18 @@
                 }
               }
             }
+          },
+          "412": {
+            "$ref": "#/components/responses/precondition_failed"
+          },
+          "409": {
+            "$ref": "#/components/responses/idempotency_conflict"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       }
@@ -436,6 +511,15 @@
                 "schema": { "$ref": "#/components/schemas/cart_response" }
               }
             }
+          },
+          "409": {
+            "$ref": "#/components/responses/idempotency_conflict"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       }
@@ -474,6 +558,12 @@
                 "schema": { "$ref": "#/components/schemas/cart_response" }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       },
@@ -517,6 +607,15 @@
                 "schema": { "$ref": "#/components/schemas/cart_response" }
               }
             }
+          },
+          "409": {
+            "$ref": "#/components/responses/idempotency_conflict"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       }
@@ -557,6 +656,15 @@
                 "schema": { "$ref": "#/components/schemas/cart_response" }
               }
             }
+          },
+          "409": {
+            "$ref": "#/components/responses/idempotency_conflict"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       }
@@ -601,6 +709,12 @@
                 "schema": { "$ref": "#/components/schemas/catalog_search_response" }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       }
@@ -645,6 +759,12 @@
                 "schema": { "$ref": "#/components/schemas/catalog_lookup_response" }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       }
@@ -683,6 +803,12 @@
                 "schema": { "$ref": "#/components/schemas/order_response" }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       }
@@ -727,6 +853,12 @@
                 "schema": { "$ref": "#/components/schemas/catalog_get_product_response" }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/error"
           }
         }
       }
@@ -771,6 +903,12 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "description": "Delivery rejected. Any non-2xx response is a failed delivery that the business retries."
+          },
+          "5XX": {
+            "description": "Delivery failed. Any non-2xx response is a failed delivery that the business retries."
           }
         }
       }
@@ -859,6 +997,15 @@
           "format": "uuid"
         },
         "description": "Ensures duplicate operations don't happen during retries."
+      },
+      "if_match": {
+        "name": "If-Match",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Entity tag of the checkout state this write is based on (RFC 9110 conditional request). On mismatch the business rejects the write with 412 Precondition Failed. See Checkout REST - Concurrency Control."
       },
       "request_id": {
         "name": "Request-Id",
@@ -965,6 +1112,78 @@
           "type": "string"
         },
         "description": "JCS-canonicalized body digest per RFC 8785. Format: `sha-256=:<base64-digest>:`."
+      },
+      "etag": {
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Strong entity tag for the returned checkout state (RFC 9110). Echo via If-Match on Update, Complete, and Cancel to write conditionally. See Checkout REST - Concurrency Control."
+      }
+    },
+    "responses": {
+      "error": {
+        "description": "Error. The body carries the standard UCP error envelope (`ucp.status: \"error\"` plus `messages`). See the transport specification's Status Codes section for which HTTP status codes apply to each failure class.",
+        "headers": {
+          "Signature": {
+            "$ref": "#/components/headers/signature"
+          },
+          "Signature-Input": {
+            "$ref": "#/components/headers/signature_input"
+          },
+          "Content-Digest": {
+            "$ref": "#/components/headers/content_digest"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "../../schemas/common/types/error_response.json"
+            }
+          }
+        }
+      },
+      "precondition_failed": {
+        "description": "Precondition failed. The If-Match entity tag does not match the session's current state; no part of the write is applied. The platform re-reads the session, reconciles, and retries with the fresh tag. See Checkout REST - Concurrency Control.",
+        "headers": {
+          "Signature": {
+            "$ref": "#/components/headers/signature"
+          },
+          "Signature-Input": {
+            "$ref": "#/components/headers/signature_input"
+          },
+          "Content-Digest": {
+            "$ref": "#/components/headers/content_digest"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "../../schemas/common/types/error_response.json"
+            }
+          }
+        }
+      },
+      "idempotency_conflict": {
+        "description": "Idempotency-Key conflict. The key was reused with a request body that does not match the original request; the operation is not executed. See Message Signatures - Replay Protection.",
+        "headers": {
+          "Signature": {
+            "$ref": "#/components/headers/signature"
+          },
+          "Signature-Input": {
+            "$ref": "#/components/headers/signature_input"
+          },
+          "Content-Digest": {
+            "$ref": "#/components/headers/content_digest"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "../../schemas/common/types/error_response.json"
+            }
+          }
+        }
       }
     },
     "schemas": {
@@ -1005,13 +1224,19 @@
         "$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_request"
       },
       "catalog_search_response": {
-        "$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_response"
+        "oneOf": [
+          { "$ref": "../../schemas/shopping/catalog_search.json#/$defs/search_response" },
+          { "$ref": "../../schemas/common/types/error_response.json" }
+        ]
       },
       "catalog_lookup_request": {
         "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_request"
       },
       "catalog_lookup_response": {
-        "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_response"
+        "oneOf": [
+          { "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/lookup_response" },
+          { "$ref": "../../schemas/common/types/error_response.json" }
+        ]
       },
       "catalog_get_product_request": {
         "$ref": "../../schemas/shopping/catalog_lookup.json#/$defs/get_product_request"


### PR DESCRIPTION
# Description

Fixes a path-accounting bug in `strip_ellipsis` in `scripts/validate_examples.py`.

When an example uses partial array elision (`["...", {...}]`, the string form documented in the validator contract), the `"..."` sentinel is removed and later items shift left. But nested elision paths were recorded with **source** indices, while `ucp-schema validate` reports error paths against the **stripped** payload. Two consequences:

- An acknowledged elision inside an array item after a sentinel was not suppressed, so a correctly-annotated example failed validation (e.g. recorded `/items/1/price` while the validator reports `/items/0/price`).
- Conversely, a real validation error on the sibling that shifts into the recorded index could be wrongly suppressed.

The fix records child paths at their post-strip positions (the index the item occupies in the payload the validator sees) and pins the behavior with a contract test in `scripts/test_validate_examples.py`. The new test fails on the previous implementation and passes with the fix.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [x] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

No schemas or documentation content change; the fix is internal to the validation tooling. Verification: validator unit tests 50/50 (`scripts/test_validate_examples.py`, with `ucp-schema` installed), full doc example corpus 295 passed / 0 failed, `pre-commit` hooks for the changed files all pass, `ruff check` and `ruff format` clean.

## Screenshots / Logs (if applicable)

New contract test against the previous implementation:

```
FAIL  array_ellipsis_paths_use_stripped_indices — got {'/items/1/price'}
49 passed, 1 failed
```

With the fix:

```
PASS  array_ellipsis_paths_use_stripped_indices
50 passed, 0 failed
```