### PR TITLE
fix: record post-strip indices for array elision paths

### DIFF
--- a/scripts/test_validate_examples.py
+++ b/scripts/test_validate_examples.py
@@ -209,6 +209,29 @@ def test_string_ellipsis_in_array() -> None:
   )
 
 
+def test_array_ellipsis_paths_use_stripped_indices() -> None:
+  """Elision paths inside arrays reflect post-strip positions.
+
+  Removing a `"..."` sentinel shifts later items left. Recorded paths
+  must match the stripped payload the validator sees \u2014 recording the
+  source index would fail to suppress the acknowledged elision (and
+  could suppress a real error on the sibling that shifts into that
+  index).
+  """
+  tree = {"items": ["...", {"price": "..."}]}
+  cleaned, paths = v.strip_ellipsis(tree)
+  _check(
+    "array_sentinel_removed_items_shift",
+    cleaned == {"items": [{}]},
+    f"got {cleaned!r}",
+  )
+  _check(
+    "array_ellipsis_paths_use_stripped_indices",
+    "/items/0/price" in paths and "/items/1/price" not in paths,
+    f"got {paths!r}",
+  )
+
+
 # -----------------------------------------------------------
 # Annotation parsing
 # -----------------------------------------------------------
@@ -583,6 +606,7 @@ def main() -> int:
   test_parse_example_keeps_sentinels()
   test_strip_ellipsis_records_paths()
   test_string_ellipsis_in_array()
+  test_array_ellipsis_paths_use_stripped_indices()
   test_annotation_parsing()
   test_extract_blocks()
   test_scaffold_resolution()

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -407,11 +407,15 @@ def strip_ellipsis(obj, _path="", _paths=None):
         result[k] = strip_ellipsis(v, child_path, _paths)
     return result if _path else (result, _paths)
   elif isinstance(obj, list):
+    # Child paths use the post-strip index — the position the item
+    # occupies in the payload the validator sees. Removed sentinels
+    # shift later items left, so the source index would point at the
+    # wrong element (or suppress a real error on a shifted sibling).
     items = []
-    for i, item in enumerate(obj):
+    for item in obj:
       if item == "...":
         continue
-      items.append(strip_ellipsis(item, f"{_path}/{i}", _paths))
+      items.append(strip_ellipsis(item, f"{_path}/{len(items)}", _paths))
     return items if _path else (items, _paths)
   return obj if _path else (obj, _paths)
 


### PR DESCRIPTION
# Description

Fixes a path-accounting bug in `strip_ellipsis` in `scripts/validate_examples.py`.

When an example uses partial array elision (`["...", {...}]`, the string form documented in the validator contract), the `"..."` sentinel is removed and later items shift left. But nested elision paths were recorded with **source** indices, while `ucp-schema validate` reports error paths against the **stripped** payload. Two consequences:

- An acknowledged elision inside an array item after a sentinel was not suppressed, so a correctly-annotated example failed validation (e.g. recorded `/items/1/price` while the validator reports `/items/0/price`).
- Conversely, a real validation error on the sibling that shifts into the recorded index could be wrongly suppressed.

The fix records child paths at their post-strip positions (the index the item occupies in the payload the validator sees) and pins the behavior with a contract test in `scripts/test_validate_examples.py`. The new test fails on the previous implementation and passes with the fix.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [x] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

No schemas or documentation content change; the fix is internal to the validation tooling. Verification: validator unit tests 50/50 (`scripts/test_validate_examples.py`, with `ucp-schema` installed), full doc example corpus 292 passed / 0 failed, `pre-commit` hooks for the changed files all pass, `ruff check` and `ruff format` clean.

## Screenshots / Logs (if applicable)

New contract test against the previous implementation:

```
FAIL  array_ellipsis_paths_use_stripped_indices — got {'/items/1/price'}
49 passed, 1 failed
```

With the fix:

```
PASS  array_ellipsis_paths_use_stripped_indices
50 passed, 0 failed
```