### PR TITLE
fix!: define deterministic operating hours for Location service

### DIFF
--- a/docs/specification/location/index.md
+++ b/docs/specification/location/index.md
@@ -95,9 +95,10 @@ interpreted using its IANA timezone.
 
 ### Evaluation
 
-Timed intervals ordinarily include the opening time and exclude the closing
-time. If `closes` is earlier than `opens`, the interval continues into the next
-local date. As a reserved exception to those half-open semantics, the exact
+Timed intervals are open at `opens` and closed at `closes`. For example,
+`10:00`–`17:00` is open immediately before `17:00` and closed at `17:00`. If
+`closes` is earlier than `opens`, the interval continues into the next local
+date. As a reserved exception to this closing-boundary rule, the exact
 `00:00`–`23:59` pair represents the entire local civil date, including daylight
 saving time transitions. Every pair with equal `opens` and `closes` is invalid,
 including `00:00`–`00:00`.
@@ -169,8 +170,10 @@ to the requesting Platform's or Buyer's timezone. Because JSON Schema does not
 enforce every semantic constraint, a Business **MUST** emit only schedules that
 follow the rules above, including unequal `opens` and `closes`, a `valid_from`
 value no later than `valid_through`, and valid exception-range intersections.
-When a request provides a language preference, a Business **SHOULD** localize
-`title` accordingly, unless that language is unavailable.
+A Business **SHOULD** omit an `exception_hours` entry once it can no longer
+affect the schedule at any current or future instant. It **SHOULD** publish
+known future exceptions through the planning horizon for which its schedule is
+authoritative.
 
 #### Platform
 

--- a/docs/specification/location/index.md
+++ b/docs/specification/location/index.md
@@ -77,9 +77,8 @@ other capabilities (like Catalog, Cart, and Checkout in Shopping):
 ### Representation
 
 The hours filter's [`open_at`](search.md#hours-based-filter) value is an exact
-instant. By contrast, `day`, `opens`, `closes`, `valid_from`, and
-`valid_through` are canonical local civil values interpreted in the containing
-Location's `timezone`; they are not timestamps.
+instant. Operating hours use the Location's local date and clock time,
+interpreted using its IANA timezone.
 
 * `hours` is a list of regular weekly intervals. Each item contains `day`,
     `opens`, and `closes`. `day` is a stable UCP day-of-week identifier for the
@@ -114,7 +113,9 @@ current schedule shape cannot distinguish the two fold occurrences.
 Multiple `hours` items for the same `day` combine as split shifts. An omitted
 day means no regular interval begins that day, but an interval from the
 preceding day can carry into it. Absent `hours` means the regular schedule is
-unknown, not closed.
+unknown, not closed. To represent a temporary full closure, a Business retains
+its regular `hours` and adds an `exception_hours` entry for the affected dates
+without `opens` or `closes`.
 
 An exception schedule replaces the regular schedule on every covered local
 date. If an interval carries into a local date governed by an exception, that

--- a/docs/specification/location/index.md
+++ b/docs/specification/location/index.md
@@ -47,8 +47,9 @@ This is vertical-agnostic and enables key commerce flows such as:
     This is used to determine if a location can serve a specific user (e.g., delivery area check).
     Clients can perform proximity searches (`distance` filter) or coverage checks (`geofence_point` filter)
     using the filter.
-* **Operating Hours**: Weekly schedules (`hours`) and date-specific overrides
-    (`exception_hours` - e.g., holidays, temporary closures) associated with a timezone.
+* **Operating Hours**: Regular weekly schedules (`hours`) and date-specific
+    exceptions (`exception_hours`), interpreted in the Location's `timezone`.
+    See [Operating Hours](#operating-hours).
 
 ### Relationship to Other Capabilities
 
@@ -70,6 +71,115 @@ other capabilities (like Catalog, Cart, and Checkout in Shopping):
     * *Checkout Phase (Authoritative)*: Final transaction terms that depend on a location (e.g., pickup)
         **MUST** be negotiated and finalized authoritatively. Discovery signals **SHOULD NOT** be cached
         or reused across sessions without re-validation.
+
+## Operating Hours
+
+### Representation
+
+The hours filter's [`open_at`](search.md#hours-based-filter) value is an exact
+instant. By contrast, `day`, `opens`, `closes`, `valid_from`, and
+`valid_through` are canonical local civil values interpreted in the containing
+Location's `timezone`; they are not timestamps.
+
+* `hours` is a list of regular weekly intervals. Each item contains `day`,
+    `opens`, and `closes`. `day` is a stable UCP weekday identifier for the day
+    on which the interval begins, not localized display text. A Platform
+    **MAY** localize it for presentation. Times use 24-hour `HH:MM` form.
+* `exception_hours` is a list of date-specific timed intervals or full
+    closures. Each item contains inclusive local-date bounds `valid_from` and
+    `valid_through` in `YYYY-MM-DD` form; equal bounds select one date. Both
+    `opens` and `closes` define a timed interval, while omitting both defines a
+    full closure. The optional `title` is a short, human-readable heading. It is
+    presentation metadata and does not affect schedule evaluation.
+* `timezone` identifies the Business-owned canonical local civil-time frame for
+    both schedules.
+
+### Evaluation
+
+Timed intervals ordinarily include the opening time and exclude the closing
+time. If `closes` is earlier than `opens`, the interval continues into the next
+local date. As a reserved exception to those half-open semantics, the exact
+`00:00`–`23:59` pair represents the entire local civil date, including daylight
+saving time transitions. Every pair with equal `opens` and `closes` is invalid,
+including `00:00`–`00:00`.
+
+Schedule evaluation is deterministic for each instant: convert the instant to
+the Location's local date, weekday, and time using `timezone`, then apply the
+effective schedule to those local values. During a forward daylight saving time
+(DST) transition, local clock labels in the gap correspond to no instants and
+are not shifted. During a backward DST transition, both instants in the fold
+that map to the same repeated local time receive the same schedule result. The
+current schedule shape cannot distinguish the two fold occurrences.
+
+Multiple `hours` items for the same `day` combine as split shifts. An omitted
+weekday means no regular interval begins that day, but an interval from the
+preceding day can carry into it. Absent `hours` means the regular schedule is
+unknown, not closed.
+
+An exception schedule replaces the regular schedule on every covered local
+date. If an interval carries into a local date governed by an exception, that
+exception takes authority at local midnight. Intersecting non-identical
+exception ranges are invalid, including when one contains another. Timed
+entries with identical bounds can coexist as split shifts, but a full closure
+stands alone for its bounds. Array order establishes no precedence.
+
+#### Exception hours example
+
+<!-- ucp:example schema=common/types/location op=read direction=response -->
+```json
+{
+  "id": "loc_downtown",
+  "name": "Downtown Store",
+  "timezone": "America/New_York",
+  "exception_hours": [
+    {
+      "title": "Holiday hours",
+      "valid_from": "2026-12-24",
+      "valid_through": "2026-12-26",
+      "opens": "10:00",
+      "closes": "14:00"
+    },
+    {
+      "title": "Holiday hours",
+      "valid_from": "2026-12-24",
+      "valid_through": "2026-12-26",
+      "opens": "16:00",
+      "closes": "18:00"
+    }
+  ]
+}
+```
+
+The two entries share date bounds, so they define split shifts that apply
+independently on each date in the inclusive range. A full closure instead uses
+one item that omits both `opens` and `closes`.
+
+### Guidelines
+
+#### Business
+
+A Business owns each Location's canonical schedule frame. When a Business
+emits `hours` or `exception_hours`, it **MUST** express every `day`, `opens`,
+`closes`, `valid_from`, and `valid_through` value in that frame and **MUST**
+include `timezone` as a valid
+[Internet Assigned Numbers Authority (IANA) Time Zone Database](https://www.iana.org/time-zones)
+identifier. A Business **MUST NOT** vary the canonical schedule frame according
+to the requesting Platform's or Buyer's timezone. Because JSON Schema does not
+enforce every semantic constraint, a Business **MUST** emit only schedules that
+follow the rules above, including unequal `opens` and `closes`, a `valid_from`
+value no later than `valid_through`, and valid exception-range intersections.
+When a request provides a language preference, a Business **SHOULD** localize
+`title` accordingly, unless that language is unavailable.
+
+#### Platform
+
+When evaluating a returned schedule, a Platform **MUST** use the returned
+Location's `timezone`. A Platform **MAY** convert concrete dated occurrences to
+another timezone for presentation, but it **MUST NOT** reinterpret the canonical
+schedule values in another timezone. A Platform **MUST NOT** infer that a
+Location with absent, invalid, or otherwise unusable schedule data is open. A
+Platform **MAY** present `title` according to its presentation policy and
+**MUST NOT** use it to determine whether a Location is open or closed.
 
 ## Shared Entities
 

--- a/docs/specification/location/index.md
+++ b/docs/specification/location/index.md
@@ -82,8 +82,8 @@ instant. By contrast, `day`, `opens`, `closes`, `valid_from`, and
 Location's `timezone`; they are not timestamps.
 
 * `hours` is a list of regular weekly intervals. Each item contains `day`,
-    `opens`, and `closes`. `day` is a stable UCP weekday identifier for the day
-    on which the interval begins, not localized display text. A Platform
+    `opens`, and `closes`. `day` is a stable UCP day-of-week identifier for the
+    day on which the interval begins, not localized display text. A Platform
     **MAY** localize it for presentation. Times use 24-hour `HH:MM` form.
 * `exception_hours` is a list of date-specific timed intervals or full
     closures. Each item contains inclusive local-date bounds `valid_from` and
@@ -104,7 +104,7 @@ saving time transitions. Every pair with equal `opens` and `closes` is invalid,
 including `00:00`–`00:00`.
 
 Schedule evaluation is deterministic for each instant: convert the instant to
-the Location's local date, weekday, and time using `timezone`, then apply the
+the Location's local date, day of week, and time using `timezone`, then apply the
 effective schedule to those local values. During a forward daylight saving time
 (DST) transition, local clock labels in the gap correspond to no instants and
 are not shifted. During a backward DST transition, both instants in the fold
@@ -112,7 +112,7 @@ that map to the same repeated local time receive the same schedule result. The
 current schedule shape cannot distinguish the two fold occurrences.
 
 Multiple `hours` items for the same `day` combine as split shifts. An omitted
-weekday means no regular interval begins that day, but an interval from the
+day means no regular interval begins that day, but an interval from the
 preceding day can carry into it. Absent `hours` means the regular schedule is
 unknown, not closed.
 

--- a/docs/specification/location/lookup.md
+++ b/docs/specification/location/lookup.md
@@ -55,12 +55,14 @@ Optional `filters` (hours, offerings/inventory, geo) are accepted
 to narrow down the returned locations.
 Filters use the same schema and AND semantics as [Search Filters](search.md#search-filters).
 
-Filters apply **after** identifier resolution. For example, if a client requests
-`["loc_downtown", "loc_uptown"]` with a filter of `open_now: true`:
+Filters apply **after** identifier resolution. For example, if a Platform
+requests `["loc_downtown", "loc_uptown"]` with an hours filter of
+`{"open_at": "2026-05-18T17:00:00Z"}`:
 
-1. The server first resolves both identifiers to their respective locations.
-2. The server then evaluates the `open_now` hour filter against each resolved location.
-3. If `loc_uptown` is currently closed, it is excluded, and only `loc_downtown` is returned.
+1. The Business first resolves both identifiers to their respective Locations.
+2. The Business evaluates the supplied instant against each resolved Location.
+3. If `loc_uptown` is closed at that instant, the Business excludes it and
+    returns only `loc_downtown`.
 
 ### Request
 
@@ -69,6 +71,121 @@ Filters apply **after** identifier resolution. For example, if a client requests
 ### Response
 
 {{ extension_schema_fields('location_lookup.json#/$defs/lookup_response', 'location') }}
+
+## Examples {: #examples }
+
+The following request and response are transport-neutral UCP payloads.
+
+### Downtown Store schedule
+
+=== "Request"
+
+    <!-- ucp:example schema=common/location_lookup op=lookup direction=request -->
+    ```json
+    {
+      "ids": ["loc_downtown"]
+    }
+    ```
+
+=== "Response"
+
+    <!-- ucp:example schema=common/location_lookup op=lookup direction=response -->
+    ```json
+    {
+      "ucp": {
+        "version": "{{ ucp_version }}",
+        "capabilities": {
+          "dev.ucp.common.location.lookup": [
+            {"version": "{{ ucp_version }}"}
+          ]
+        }
+      },
+      "locations": [
+        {
+          "id": "loc_downtown",
+          "name": "Downtown Store",
+          "address": {
+            "street_address": "100 Broadway",
+            "address_locality": "New York",
+            "address_region": "NY",
+            "address_country": "US",
+            "postal_code": "10005"
+          },
+          "geo": {
+            "latitude": 40.707,
+            "longitude": -74.011
+          },
+          "amenities": ["curbside_pickup", "in_store_pickup", "parking"],
+          "timezone": "America/New_York",
+          "hours": [
+            {"day": "monday", "opens": "09:00", "closes": "21:00"},
+            {"day": "tuesday", "opens": "09:00", "closes": "12:00"},
+            {"day": "tuesday", "opens": "13:00", "closes": "21:00"},
+            {"day": "wednesday", "opens": "09:00", "closes": "21:00"},
+            {"day": "thursday", "opens": "09:00", "closes": "21:00"},
+            {"day": "friday", "opens": "09:00", "closes": "22:00"},
+            {"day": "saturday", "opens": "10:00", "closes": "20:00"}
+          ],
+          "exception_hours": [
+            {
+              "title": "Thanksgiving",
+              "valid_from": "2026-11-26",
+              "valid_through": "2026-11-26"
+            }
+          ]
+        }
+      ]
+    }
+    ```
+
+Tuesday's two `hours` entries form a split shift. Sunday has no `hours` entry,
+meaning no regular interval begins that day. The `exception_hours` entry omits
+`opens` and `closes`, making it a full closure.
+See [Operating Hours](index.md#operating-hours) for schedule representation and
+evaluation rules.
+
+### Partial success
+
+=== "Request"
+
+    <!-- ucp:example schema=common/location_lookup op=lookup direction=request -->
+    ```json
+    {
+      "ids": ["loc_downtown", "loc_invalid_id"]
+    }
+    ```
+
+=== "Response"
+
+    <!-- ucp:example schema=common/location_lookup op=lookup direction=response -->
+    ```json
+    {
+      "ucp": {
+        "version": "{{ ucp_version }}",
+        "capabilities": {
+          "dev.ucp.common.location.lookup": [
+            {"version": "{{ ucp_version }}"}
+          ]
+        }
+      },
+      "locations": [
+        {
+          "id": "loc_downtown",
+          "name": "Downtown Store"
+        }
+      ],
+      "messages": [
+        {
+          "type": "info",
+          "code": "not_found",
+          "content": "Unable to find the location associated with loc_invalid_id."
+        }
+      ]
+    }
+    ```
+
+The request succeeds with the Locations that resolve. A Business can use an
+informational `not_found` message to identify an unresolved ID.
 
 ## Transport Bindings
 

--- a/docs/specification/location/mcp.md
+++ b/docs/specification/location/mcp.md
@@ -59,38 +59,11 @@ Businesses advertise MCP transport availability for the Common service and Locat
 
 ### Request Metadata
 
-MCP clients **MUST** include a `meta` object in every request containing
-protocol metadata:
-
-<!-- ucp:example schema=common/location_search op=search direction=request extract=$.params.arguments.location -->
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "search_locations",
-    "arguments": {
-      "meta": {
-        "ucp-agent": {
-          "profile": "https://platform.example/profiles/v2026-01/agent.json"
-        }
-      },
-      "location": {
-        "query": "grocery store open now",
-        "filters": {
-          "hours": {
-            "open_now": true
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-The `meta["ucp-agent"]` field is **required** on all requests to enable
-version compatibility checking and capability negotiation.
+A Platform using MCP **MUST** include a `meta` object with
+`meta["ucp-agent"].profile` in every request. The field identifies the
+Platform's UCP profile for version compatibility checks and capability
+negotiation. Protocol metadata remains in `meta`, separate from the domain
+request in `location`.
 
 ## Tools
 
@@ -101,7 +74,8 @@ version compatibility checking and capability negotiation.
 
 ### `search_locations`
 
-Maps to the [Location Search](search.md) capability.
+Maps to the [Location Search](search.md) capability. See the
+[complete transport-neutral Search example](search.md#examples).
 
 #### Request Arguments
 
@@ -111,7 +85,7 @@ Maps to the [Location Search](search.md) capability.
 
 {{ extension_schema_fields('location_search.json#/$defs/search_response', 'location/mcp') }}
 
-#### Example
+#### Binding envelope example
 
 === "Request"
 
@@ -130,26 +104,7 @@ Maps to the [Location Search](search.md) capability.
             }
           },
           "location": {
-            "query": "grocery store near me",
-            "context": {
-              "address_country": "US",
-              "address_region": "CA",
-              "postal_code": "94043"
-            },
-            "filters": {
-              "hours": {
-                "open_now": true
-              },
-              "amenities": ["curbside_pickup"],
-              "geo": {
-                "serves": {
-                  "point": {
-                    "latitude": 37.422,
-                    "longitude": -122.084
-                  }
-                }
-              }
-            }
+            "query": "grocery store"
           }
         }
       }
@@ -176,20 +131,7 @@ Maps to the [Location Search](search.md) capability.
           "locations": [
             {
               "id": "loc_valley_grocers",
-              "name": "Valley Grocers",
-              "address": {
-                "street_address": "789 Maple Ave",
-                "address_locality": "Mountain View",
-                "address_region": "CA",
-                "address_country": "US",
-                "postal_code": "94043"
-              },
-              "geo": {
-                "latitude": 37.420,
-                "longitude": -122.080
-              },
-              "amenities": ["curbside_pickup", "in_store_pickup", "parking"],
-              "timezone": "America/Los_Angeles"
+              "name": "Valley Grocers"
             }
           ]
         }
@@ -199,7 +141,8 @@ Maps to the [Location Search](search.md) capability.
 
 ### `lookup_locations`
 
-Maps to the [Location Lookup](lookup.md) capability.
+Maps to the [Location Lookup](lookup.md) capability. See the
+[complete transport-neutral Lookup example](lookup.md#examples).
 
 #### Request Arguments
 
@@ -209,11 +152,11 @@ Maps to the [Location Lookup](lookup.md) capability.
 
 {{ extension_schema_fields('location_lookup.json#/$defs/lookup_response', 'location/mcp') }}
 
-#### Example
+#### Binding envelope example
 
 === "Request"
 
-     <!-- ucp:example schema=common/location_lookup op=lookup direction=request extract=$.params.arguments.location -->
+    <!-- ucp:example schema=common/location_lookup op=lookup direction=request extract=$.params.arguments.location -->
     ```json
     {
       "jsonrpc": "2.0",
@@ -228,7 +171,7 @@ Maps to the [Location Lookup](lookup.md) capability.
             }
           },
           "location": {
-            "ids": ["loc_downtown", "loc_uptown"]
+            "ids": ["loc_downtown"]
           }
         }
       }
@@ -255,27 +198,7 @@ Maps to the [Location Lookup](lookup.md) capability.
           "locations": [
             {
               "id": "loc_downtown",
-              "name": "Downtown Store",
-              "address": {
-                "street_address": "100 Broadway",
-                "address_locality": "New York",
-                "address_region": "NY",
-                "address_country": "US",
-                "postal_code": "10005"
-              },
-              "geo": {
-                "latitude": 40.707,
-                "longitude": -74.011
-              },
-              "amenities": ["curbside_pickup", "in_store_pickup", "parking"],
-              "timezone": "America/New_York"
-            }
-          ],
-          "messages": [
-            {
-              "type": "info",
-              "code": "not_found",
-              "content": "Unable to find the location associated with loc_uptown"
+              "name": "Downtown Store"
             }
           ]
         }

--- a/docs/specification/location/rest.md
+++ b/docs/specification/location/rest.md
@@ -67,11 +67,12 @@ Location capabilities through their UCP profile at `/.well-known/ucp`.
 
 ### `POST /locations/search`
 
-Maps to the [Location Search](search.md) capability.
+Maps to the [Location Search](search.md) capability. See the
+[complete transport-neutral Search example](search.md#examples).
 
 {{ method_fields('search_locations', 'common/rest.openapi.json', 'location/rest') }}
 
-#### Example: Search for Grocery Stores with Local Delivery Coverage (Geofencing)
+#### Binding envelope example
 
 === "Request"
 
@@ -84,26 +85,7 @@ Maps to the [Location Search](search.md) capability.
     UCP-Agent: profile="https://platform.example/profiles/v2026-01/agent.json"
 
     {
-      "query": "grocery store near me",
-      "context": {
-        "address_country": "US",
-        "address_region": "CA",
-        "postal_code": "94043"
-      },
-      "filters": {
-        "hours": {
-          "open_now": true
-        },
-        "amenities": ["curbside_pickup"],
-        "geo": {
-          "serves": {
-            "point": {
-              "latitude": 37.422,
-              "longitude": -122.084
-            }
-          }
-        }
-      }
+      "query": "grocery store"
     }
     ```
 
@@ -127,97 +109,7 @@ Maps to the [Location Search](search.md) capability.
       "locations": [
         {
           "id": "loc_valley_grocers",
-          "name": "Valley Grocers",
-          "address": {
-            "street_address": "789 Maple Ave",
-            "address_locality": "Mountain View",
-            "address_region": "CA",
-            "address_country": "US",
-            "postal_code": "94043"
-          },
-          "geo": {
-            "latitude": 37.420,
-            "longitude": -122.080
-          },
-          "amenities": ["curbside_pickup", "in_store_pickup", "parking"],
-          "timezone": "America/Los_Angeles"
-        }
-      ]
-    }
-    ```
-
-#### Example: Search for Electronics Stores with Phone In-stock (Store Finder)
-
-=== "Request"
-
-    <!-- ucp:example schema=common/location_search op=search direction=request -->
-    ```json
-    POST /locations/search HTTP/1.1
-    Host: business.example.com
-    Content-Type: application/json
-    Request-Id: 9ef9b0c2-78d1-4e4b-91c2-3e2ef0d3ab9f
-    UCP-Agent: profile="https://platform.example/profiles/v2026-01/agent.json"
-
-    {
-      "context": {
-        "address_country": "US"
-      },
-      "filters": {
-        "hours": {
-          "open_now": true
-        },
-        "inventory": [
-          {
-            "id": "item_id_phone_15_pro",
-            "availability_status": "in_stock"
-          }
-        ],
-        "geo": {
-          "distance": {
-            "center": {
-              "latitude": 40.707,
-              "longitude": -74.011
-            },
-            "max_distance": 10000
-          }
-        }
-      }
-    }
-    ```
-
-=== "Response"
-
-    <!-- ucp:example schema=common/location_search op=search direction=response -->
-    ```json
-    HTTP/1.1 200 OK
-    Content-Type: application/json
-
-    {
-      "ucp": {
-        "version": "{{ ucp_version }}",
-        "capabilities": {
-          "dev.ucp.common.location.search": [
-            {"version": "{{ ucp_version }}"}
-          ]
-        }
-      },
-      "locations": [
-        {
-          "id": "loc_downtown_electronics",
-          "name": "Downtown Electronics",
-          "address": {
-            "street_address": "100 Broadway",
-            "address_locality": "New York",
-            "address_region": "NY",
-            "address_country": "US",
-            "postal_code": "10005"
-          },
-          "geo": {
-            "latitude": 40.709,
-            "longitude": -74.008
-          },
-          "amenities": ["curbside_pickup", "in_store_pickup", "parking"],
-          "timezone": "America/New_York"
+          "name": "Valley Grocers"
         }
       ]
     }
@@ -225,11 +117,12 @@ Maps to the [Location Search](search.md) capability.
 
 ### `POST /locations/lookup`
 
-Maps to the [Location Lookup](lookup.md) capability.
+Maps to the [Location Lookup](lookup.md) capability. See the
+[complete transport-neutral Lookup example](lookup.md#examples).
 
 {{ method_fields('lookup_locations', 'common/rest.openapi.json', 'location/rest') }}
 
-#### Example: Simple Lookup
+#### Binding envelope example
 
 === "Request"
 
@@ -242,7 +135,7 @@ Maps to the [Location Lookup](lookup.md) capability.
     UCP-Agent: profile="https://platform.example/profiles/v2026-01/agent.json"
 
     {
-      "ids": ["loc_downtown", "loc_uptown"]
+      "ids": ["loc_downtown"]
     }
     ```
 
@@ -265,222 +158,7 @@ Maps to the [Location Lookup](lookup.md) capability.
       "locations": [
         {
           "id": "loc_downtown",
-          "name": "Downtown Store",
-          "address": {
-            "street_address": "100 Broadway",
-            "address_locality": "New York",
-            "address_region": "NY",
-            "address_country": "US",
-            "postal_code": "10005"
-          },
-          "geo": {
-            "latitude": 40.707,
-            "longitude": -74.011
-          },
-          "amenities": ["curbside_pickup", "in_store_pickup", "parking"],
-          "timezone": "America/New_York",
-          "hours": [
-            {
-              "day": "monday",
-              "open": "09:00",
-              "close": "21:00"
-            },
-            {
-              "day": "tuesday",
-              "open": "09:00",
-              "close": "12:00"
-            },
-            {
-              "day": "tuesday",
-              "open": "13:00",
-              "close": "21:00"
-            },
-            {
-              "day": "wednesday",
-              "open": "09:00",
-              "close": "21:00"
-            },
-            {
-              "day": "thursday",
-              "open": "09:00",
-              "close": "21:00"
-            },
-            {
-              "day": "friday",
-              "open": "09:00",
-              "close": "22:00"
-            },
-            {
-              "day": "saturday",
-              "open": "10:00",
-              "close": "20:00"
-            }
-          ],
-          "exception_hours": [
-            {
-              "from": "2026-11-26",
-              "through": "2026-11-27",
-              "label": "Thanksgiving",
-              "open": "00:00",
-              "close": "00:00"
-            }
-          ]
-        },
-        {
-          "id": "loc_uptown",
-          "name": "Uptown Boutique",
-          "address": {
-            "street_address": "2000 Madison Ave",
-            "address_locality": "New York",
-            "address_region": "NY",
-            "address_country": "US",
-            "postal_code": "10035"
-          },
-          "geo": {
-            "latitude": 40.790,
-            "longitude": -73.950
-          },
-          "amenities": ["in_store_pickup"],
-          "timezone": "America/New_York",
-          "hours": [
-            {
-              "day": "monday",
-              "open": "09:00",
-              "close": "21:00"
-            },
-            {
-              "day": "tuesday",
-              "open": "09:00",
-              "close": "21:00"
-            },
-            {
-              "day": "wednesday",
-              "open": "09:00",
-              "close": "21:00"
-            },
-            {
-              "day": "thursday",
-              "open": "09:00",
-              "close": "21:00"
-            },
-            {
-              "day": "friday",
-              "open": "09:00",
-              "close": "22:00"
-            }
-          ],
-          "exception_hours": [
-            {
-              "from": "2026-11-26",
-              "through": "2026-11-27",
-              "label": "Thanksgiving",
-              "open": "00:00",
-              "close": "00:00"
-            }
-          ]
-        }
-      ]
-    }
-    ```
-
-#### Example: Partial Success (Some Locations Not Found)
-
-=== "Request"
-
-    <!-- ucp:example schema=common/location_lookup op=lookup direction=request -->
-    ```json
-    POST /locations/lookup HTTP/1.1
-    Host: business.example.com
-    Content-Type: application/json
-    Request-Id: 2c9b0c2a-18d1-4e4b-91c2-3e2ef0d3ab9f
-    UCP-Agent: profile="https://platform.example/profiles/v2026-01/agent.json"
-
-    {
-      "ids": ["loc_downtown", "loc_invalid_id"]
-    }
-    ```
-
-=== "Response"
-
-    <!-- ucp:example schema=common/location_lookup op=lookup direction=response -->
-    ```json
-    HTTP/1.1 200 OK
-    Content-Type: application/json
-
-    {
-      "ucp": {
-        "version": "{{ ucp_version }}",
-        "capabilities": {
-          "dev.ucp.common.location.lookup": [
-            {"version": "{{ ucp_version }}"}
-          ]
-        }
-      },
-      "locations": [
-        {
-          "id": "loc_downtown",
-          "name": "Downtown Store",
-          "address": {
-            "street_address": "100 Broadway",
-            "address_locality": "New York",
-            "address_region": "NY",
-            "address_country": "US",
-            "postal_code": "10005"
-          },
-          "geo": {
-            "latitude": 40.707,
-            "longitude": -74.011
-          },
-          "amenities": ["curbside_pickup", "in_store_pickup", "parking"],
-          "timezone": "America/New_York",
-          "hours": [
-            {
-              "day": "monday",
-              "open": "09:00",
-              "close": "21:00"
-            },
-            {
-              "day": "tuesday",
-              "open": "09:00",
-              "close": "21:00"
-            },
-            {
-              "day": "wednesday",
-              "open": "09:00",
-              "close": "21:00"
-            },
-            {
-              "day": "thursday",
-              "open": "09:00",
-              "close": "21:00"
-            },
-            {
-              "day": "friday",
-              "open": "09:00",
-              "close": "22:00"
-            },
-            {
-              "day": "saturday",
-              "open": "10:00",
-              "close": "20:00"
-            }
-          ],
-          "exception_hours": [
-            {
-              "from": "2026-11-26",
-              "through": "2026-11-27",
-              "label": "Thanksgiving",
-              "open": "00:00",
-              "close": "00:00"
-            }
-          ]
-        }
-      ],
-      "messages": [
-        {
-          "type": "info",
-          "code": "not_found",
-          "content": "Unable to find the location associated with loc_invalid_id."
+          "name": "Downtown Store"
         }
       ]
     }

--- a/docs/specification/location/search.md
+++ b/docs/specification/location/search.md
@@ -83,7 +83,7 @@ Businesses **MUST NOT** treat the offset as the Internet Assigned Numbers
 Authority (IANA) Time Zone Database identifier of a Platform, Business, Buyer,
 or Location. For each candidate Location, a Business **MUST** use that
 Location's authoritative `timezone` to convert `open_at` to the local date,
-weekday, and time, then evaluate the effective schedule under
+day of week, and time, then evaluate the effective schedule under
 [Operating Hours](index.md#operating-hours). A Business **MUST** treat absent,
 invalid, or otherwise unusable schedule data as not matching the supplied
 instant.

--- a/docs/specification/location/search.md
+++ b/docs/specification/location/search.md
@@ -70,12 +70,23 @@ custom filters via `additionalProperties`.
 
 ### Hours-Based Filter
 
-Filters locations based on their operating hours:
+The standard `filters.hours` object requires `open_at`, an exact RFC 3339
+instant expressed with `Z` or a numeric offset, and can include
+extension-defined fields. Before sending a Buyer-local wall time, a Platform
+**MUST** resolve it to an exact instant for `open_at`. When asking which
+Locations are open now, a Platform **MUST** supply the current instant. No
+timezone field is needed in the standard `context` object because `open_at`
+already identifies the instant.
 
-* `open_now`: A quick boolean filter to find locations currently open.
-* `open_at`: An RFC 3339 date-time string to find locations open at a
-    specific future time (e.g., planning a visit or ordering ahead).
-    The business resolves this against the location's local time and timezone.
+The `Z` or numeric offset identifies only that instant. Platforms and
+Businesses **MUST NOT** treat the offset as the Internet Assigned Numbers
+Authority (IANA) Time Zone Database identifier of a Platform, Business, Buyer,
+or Location. For each candidate Location, a Business **MUST** use that
+Location's authoritative `timezone` to convert `open_at` to the local date,
+weekday, and time, then evaluate the effective schedule under
+[Operating Hours](index.md#operating-hours). A Business **MUST** treat absent,
+invalid, or otherwise unusable schedule data as not matching the supplied
+instant.
 
 ### Offerings-Based Filter
 
@@ -140,6 +151,144 @@ error. Clients MUST NOT assume the response size equals the requested limit.
 ### Pagination Response
 
 {{ extension_schema_fields('types/pagination.json#/$defs/response', 'location') }}
+
+## Examples {: #examples }
+
+The following requests and responses are transport-neutral UCP payloads.
+
+### Grocery stores serving a point and open at an instant
+
+=== "Request"
+
+    <!-- ucp:example schema=common/location_search op=search direction=request -->
+    ```json
+    {
+      "query": "grocery store near me",
+      "context": {
+        "address_country": "US",
+        "address_region": "CA",
+        "postal_code": "94043"
+      },
+      "filters": {
+        "hours": {
+          "open_at": "2026-05-18T17:00:00Z"
+        },
+        "amenities": ["curbside_pickup"],
+        "geo": {
+          "serves": {
+            "point": {
+              "latitude": 37.422,
+              "longitude": -122.084
+            }
+          }
+        }
+      }
+    }
+    ```
+
+=== "Response"
+
+    <!-- ucp:example schema=common/location_search op=search direction=response -->
+    ```json
+    {
+      "ucp": {
+        "version": "{{ ucp_version }}",
+        "capabilities": {
+          "dev.ucp.common.location.search": [
+            {"version": "{{ ucp_version }}"}
+          ]
+        }
+      },
+      "locations": [
+        {
+          "id": "loc_valley_grocers",
+          "name": "Valley Grocers",
+          "address": {
+            "street_address": "789 Maple Ave",
+            "address_locality": "Mountain View",
+            "address_region": "CA",
+            "address_country": "US",
+            "postal_code": "94043"
+          },
+          "geo": {
+            "latitude": 37.420,
+            "longitude": -122.080
+          },
+          "amenities": ["curbside_pickup", "in_store_pickup", "parking"],
+          "timezone": "America/Los_Angeles",
+          "hours": [
+            {"day": "monday", "opens": "08:00", "closes": "21:00"}
+          ]
+        }
+      ]
+    }
+    ```
+
+At the supplied instant, it is Monday at `10:00` in
+`America/Los_Angeles`, within the returned interval. See
+[Operating Hours](index.md#operating-hours) for complete schedule evaluation
+rules.
+
+### Locations with an inventory item within a distance
+
+=== "Request"
+
+    <!-- ucp:example schema=common/location_search op=search direction=request -->
+    ```json
+    {
+      "filters": {
+        "inventory": [
+          {
+            "id": "item_id_phone_15_pro",
+            "availability_status": "in_stock"
+          }
+        ],
+        "geo": {
+          "distance": {
+            "center": {
+              "latitude": 40.707,
+              "longitude": -74.011
+            },
+            "max_distance": 10000
+          }
+        }
+      }
+    }
+    ```
+
+=== "Response"
+
+    <!-- ucp:example schema=common/location_search op=search direction=response -->
+    ```json
+    {
+      "ucp": {
+        "version": "{{ ucp_version }}",
+        "capabilities": {
+          "dev.ucp.common.location.search": [
+            {"version": "{{ ucp_version }}"}
+          ]
+        }
+      },
+      "locations": [
+        {
+          "id": "loc_downtown_electronics",
+          "name": "Downtown Electronics",
+          "address": {
+            "street_address": "100 Broadway",
+            "address_locality": "New York",
+            "address_region": "NY",
+            "address_country": "US",
+            "postal_code": "10005"
+          },
+          "geo": {
+            "latitude": 40.709,
+            "longitude": -74.008
+          },
+          "amenities": ["curbside_pickup", "in_store_pickup"]
+        }
+      ]
+    }
+    ```
 
 ## Transport Bindings
 

--- a/docs/specification/location/search.md
+++ b/docs/specification/location/search.md
@@ -72,10 +72,11 @@ custom filters via `additionalProperties`.
 
 The standard `filters.hours` object requires `open_at`, an exact RFC 3339
 instant expressed with `Z` or a numeric offset, and can include
-extension-defined fields. Before sending a Buyer-local wall time, a Platform
-**MUST** resolve it to an exact instant for `open_at`. When asking which
-Locations are open now, a Platform **MUST** supply the current instant. No
-timezone field is needed in the standard `context` object because `open_at`
+extension-defined fields. `open_at` identifies the instant relevant to the
+request, such as an expected arrival or pickup time. Before sending a
+Buyer-local date and time, a Platform **MUST** resolve it to an exact instant.
+The Business evaluates the supplied instant against each Location's schedule.
+No timezone field is needed in the standard `context` object because `open_at`
 already identifies the instant.
 
 The `Z` or numeric offset identifies only that instant. Platforms and

--- a/docs/specification/location/search.md
+++ b/docs/specification/location/search.md
@@ -70,24 +70,26 @@ custom filters via `additionalProperties`.
 
 ### Hours-Based Filter
 
-The standard `filters.hours` object requires `open_at`, an exact RFC 3339
-instant expressed with `Z` or a numeric offset, and can include
-extension-defined fields. `open_at` identifies the instant relevant to the
-request, such as an expected arrival or pickup time. Before sending a
-Buyer-local date and time, a Platform **MUST** resolve it to an exact instant.
-The Business evaluates the supplied instant against each Location's schedule.
-No timezone field is needed in the standard `context` object because `open_at`
-already identifies the instant.
+The standard `filters.hours` object requires `open_at`, an RFC 3339 instant
+expressed with `Z` or a numeric offset.
 
-The `Z` or numeric offset identifies only that instant. Platforms and
-Businesses **MUST NOT** treat the offset as the Internet Assigned Numbers
-Authority (IANA) Time Zone Database identifier of a Platform, Business, Buyer,
-or Location. For each candidate Location, a Business **MUST** use that
-Location's authoritative `timezone` to convert `open_at` to the local date,
-day of week, and time, then evaluate the effective schedule under
-[Operating Hours](index.md#operating-hours). A Business **MUST** treat absent,
-invalid, or otherwise unusable schedule data as not matching the supplied
-instant.
+A Platform selects `open_at` to represent the time relevant to the Buyer's
+intent. It can use its current time or choose another time, such as an expected
+arrival, pickup, or order-acceptance time. A Platform **MAY** round or adjust
+its selected time to the granularity appropriate to the interaction, but the
+value it sends identifies one specific instant.
+
+For each candidate Location, a Business **MUST** evaluate `open_at` exactly as
+supplied. It converts the instant to the local date, day of week, and time using
+the Location's authoritative `timezone`, then evaluates the effective schedule
+under [Operating Hours](index.md#operating-hours). The `Z` or numeric offset in
+`open_at` identifies the instant; it does not identify the Location's timezone.
+
+A Business **MUST** return a Location only when it can establish that the
+Location is open at `open_at`. If its schedule data is absent, invalid, outside
+the range for which it can evaluate authoritatively, or otherwise unusable, the
+Location does not match the filter. A Business **MUST NOT** round, shift, or
+otherwise reinterpret the supplied instant.
 
 ### Offerings-Based Filter
 

--- a/source/schemas/common/types/daily_hour.json
+++ b/source/schemas/common/types/daily_hour.json
@@ -13,7 +13,7 @@
         "day": {
           "type": "string",
           "enum": ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"],
-          "description": "A stable UCP weekday identifier for the weekday on which this recurring local civil-time interval begins in the containing Location's `timezone`. It is not localized display text.",
+          "description": "A stable UCP day-of-week identifier for the day on which this recurring local civil-time interval begins in the containing Location's `timezone`. It is not localized display text.",
           "ucp_request": "omit"
         }
       }

--- a/source/schemas/common/types/daily_hour.json
+++ b/source/schemas/common/types/daily_hour.json
@@ -2,9 +2,9 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/common/types/daily_hour.json",
   "title": "Daily Hour",
-  "description": "Operating hours for a specific day of the week.",
+  "description": "A regular weekly operating interval. Its `day`, `opens`, and `closes` are recurring local civil values interpreted in the containing Location's `timezone`. Multiple entries for the same day support split shifts.",
   "type": "object",
-  "required": ["day"],
+  "required": ["day", "opens", "closes"],
   "allOf": [
     { "$ref": "time_interval.json" },
     {
@@ -12,7 +12,9 @@
       "properties": {
         "day": {
           "type": "string",
-          "enum": ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+          "enum": ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"],
+          "description": "A stable UCP weekday identifier for the weekday on which this recurring local civil-time interval begins in the containing Location's `timezone`. It is not localized display text.",
+          "ucp_request": "omit"
         }
       }
     }

--- a/source/schemas/common/types/exception_hour.json
+++ b/source/schemas/common/types/exception_hour.json
@@ -2,27 +2,30 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/common/types/exception_hour.json",
   "title": "Exception Hour",
-  "description": "Operating hours for a specific date range that differs from normal ones (e.g., holiday or temporary change).",
+  "description": "A date-specific operating interval or full closure. Its `valid_from`, `valid_through`, `opens`, and `closes` are local civil values interpreted in the containing Location's `timezone`. Date bounds are inclusive.",
   "type": "object",
-  "required": ["from", "through"],
+  "required": ["valid_from", "valid_through"],
   "allOf": [
     { "$ref": "time_interval.json" },
     {
       "type": "object",
       "properties": {
-        "from": {
+        "title": {
+          "type": "string",
+          "description": "A short human-readable heading naming the exception (for example, 'Thanksgiving'). Presentation metadata that does not affect schedule evaluation.",
+          "ucp_request": "omit"
+        },
+        "valid_from": {
           "type": "string",
           "format": "date",
-          "description": "An ISO 8601 date representing the start of the date range."
+          "description": "The first local civil date to which this exception applies, interpreted in the containing Location's `timezone`.",
+          "ucp_request": "omit"
         },
-        "through": {
+        "valid_through": {
           "type": "string",
           "format": "date",
-          "description": "An ISO 8601 date representing the date after the end of the date range."
-        },
-        "label": {
-          "type": "string",
-          "description": "Human readable explanation for the exception (e.g., 'Thanksgiving')."
+          "description": "The last local civil date to which this exception applies, interpreted in the containing Location's `timezone`.",
+          "ucp_request": "omit"
         }
       }
     }

--- a/source/schemas/common/types/location.json
+++ b/source/schemas/common/types/location.json
@@ -25,7 +25,7 @@
         },
         "hours": {
           "type": "array",
-          "description": "Regular weekly operating hours. Support split hours through multiple entries on the same day and overnight hours (open > close). Omission of days implies full day closures.",
+          "description": "Regular weekly operating hours whose day and time values use this Location's canonical local civil-time frame. Multiple entries for the same day support split shifts.",
           "items": {
             "$ref": "daily_hour.json"
           },
@@ -33,7 +33,7 @@
         },
         "exception_hours": {
           "type": "array",
-          "description": "Exception hours for specific dates (holidays, closures, etc.). Support split hours through multiple entries on the same day and overnight hours (open > close). For full day closures, MUST explicitly set open and close to 00:00.",
+          "description": "Date-specific operating-hour exceptions, including full closures, whose date and time values use this Location's canonical local civil-time frame.",
           "items": {
             "$ref": "exception_hour.json"
           },
@@ -41,11 +41,10 @@
         },
         "timezone": {
           "type": "string",
-          "description": "IANA timezone identifier (e.g., 'America/New_York'). MUST be set when hours or exception_hours are present. Required for correct interpretation.",
+          "description": "The Business-owned IANA Time Zone Database identifier (e.g., 'America/New_York') defining this Location's canonical local civil-time frame for all returned schedule day, time, and date fields. The Business does not vary this canonical framing by the requesting Platform's or Buyer's timezone. Required when hours or exception_hours is present.",
           "ucp_request": "omit"
         }
-      },
-      "additionalProperties": true
+      }
     }
   ],
   "if": {

--- a/source/schemas/common/types/location.json
+++ b/source/schemas/common/types/location.json
@@ -25,7 +25,7 @@
         },
         "hours": {
           "type": "array",
-          "description": "Regular weekly operating hours whose day and time values use this Location's canonical local civil-time frame. Multiple entries for the same day support split shifts.",
+          "description": "Regular weekly operating hours whose day and time values use this Location's canonical local civil-time frame. Multiple entries for the same day support split shifts. An omitted day has no regular interval beginning that day; an interval beginning on the preceding day can carry into it. Omission of the entire `hours` property means the regular schedule is unknown.",
           "items": {
             "$ref": "daily_hour.json"
           },

--- a/source/schemas/common/types/location_filter.json
+++ b/source/schemas/common/types/location_filter.json
@@ -57,7 +57,7 @@
           "type": "string",
           "format": "date-time",
           "pattern": "(?:[Zz]|[+-](?:[01][0-9]|2[0-3]):[0-5][0-9])$",
-          "description": "One exact RFC 3339 instant expressed with `Z` or a numeric offset. The `Z` or numeric offset identifies that instant, not the IANA Time Zone Database identifier of a Platform, Business, Buyer, or Location. The Business evaluates that instant in each Location's canonical local civil-time frame, identified by `Location.timezone`."
+          "description": "The RFC 3339 instant at which matching Locations must be open, expressed with `Z` or a numeric offset. The Platform selects the instant that represents the Buyer's intent. The Business evaluates it exactly as supplied using each Location's authoritative `timezone`; the supplied offset does not identify that timezone."
         }
       }
     },

--- a/source/schemas/common/types/location_filter.json
+++ b/source/schemas/common/types/location_filter.json
@@ -50,19 +50,16 @@
     },
     "hours": {
       "type": "object",
-      "description": "Filter by operating hours. If both values are specified, behavior is implementation-defined (usually open_at takes precedence or OR logic is enforced).",
+      "description": "Filter by operating hours, evaluated at the one supplied instant.",
+      "required": ["open_at"],
       "properties": {
-        "open_now": {
-          "type": "boolean",
-          "description": "Only return locations that are currently open."
-        },
         "open_at": {
           "type": "string",
           "format": "date-time",
-          "description": "An RFC 3339 instant. The business converts it to the location's local timezone and evaluates against the known hours."
+          "pattern": "(?:[Zz]|[+-](?:[01][0-9]|2[0-3]):[0-5][0-9])$",
+          "description": "One exact RFC 3339 instant expressed with `Z` or a numeric offset. The `Z` or numeric offset identifies that instant, not the IANA Time Zone Database identifier of a Platform, Business, Buyer, or Location. The Business evaluates that instant in each Location's canonical local civil-time frame, identified by `Location.timezone`."
         }
-      },
-      "additionalProperties": false
+      }
     },
     "amenities": {
       "type": "array",

--- a/source/schemas/common/types/time_interval.json
+++ b/source/schemas/common/types/time_interval.json
@@ -2,19 +2,31 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/common/types/time_interval.json",
   "title": "Time Interval",
-  "description": "An open time interval with 24-hour HH:MM format.",
+  "description": "Reusable local civil-time fields for a containing schedule schema. Containing schemas determine whether the `opens` and `closes` pair is required; this fragment's standalone `{}` is not an interval.",
   "type": "object",
-  "required": ["open", "close"],
   "properties": {
-    "open": {
+    "opens": {
       "type": "string",
       "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9]$",
-      "description": "Start time (e.g., '09:00')."
+      "description": "Local civil opening time in 24-hour HH:MM format, interpreted in the containing Location's `timezone`.",
+      "ucp_request": "omit"
     },
-    "close": {
+    "closes": {
       "type": "string",
       "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9]$",
-      "description": "End time (e.g., '18:00')."
+      "description": "Local civil closing time in 24-hour HH:MM format, interpreted in the containing Location's `timezone`.",
+      "ucp_request": "omit"
     }
+  },
+  "dependentRequired": {
+    "opens": ["closes"],
+    "closes": ["opens"]
+  },
+  "not": {
+    "properties": {
+      "opens": { "const": "00:00" },
+      "closes": { "const": "00:00" }
+    },
+    "required": ["opens", "closes"]
   }
 }

--- a/source/schemas/common/types/time_interval.json
+++ b/source/schemas/common/types/time_interval.json
@@ -2,31 +2,24 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/common/types/time_interval.json",
   "title": "Time Interval",
-  "description": "Reusable local civil-time fields for a containing schedule schema. Containing schemas determine whether the `opens` and `closes` pair is required; this fragment's standalone `{}` is not an interval.",
+  "description": "Reusable opening and closing time fields for a containing schedule schema. Containing schemas determine whether the `opens` and `closes` pair is required; this fragment's standalone `{}` is not an interval.",
   "type": "object",
   "properties": {
     "opens": {
       "type": "string",
       "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9]$",
-      "description": "Local civil opening time in 24-hour HH:MM format, interpreted in the containing Location's `timezone`.",
+      "description": "Opening time in 24-hour HH:MM format.",
       "ucp_request": "omit"
     },
     "closes": {
       "type": "string",
       "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9]$",
-      "description": "Local civil closing time in 24-hour HH:MM format, interpreted in the containing Location's `timezone`.",
+      "description": "Closing time in 24-hour HH:MM format.",
       "ucp_request": "omit"
     }
   },
   "dependentRequired": {
     "opens": ["closes"],
     "closes": ["opens"]
-  },
-  "not": {
-    "properties": {
-      "opens": { "const": "00:00" },
-      "closes": { "const": "00:00" }
-    },
-    "required": ["opens", "closes"]
   }
 }


### PR DESCRIPTION
   The current Location PR (https://github.com/Universal-Commerce-Protocol/ucp/pull/687) introduces weekly and exceptional operating hours,
   but leaves several wire and evaluation semantics ambiguous. In particular,
   closures rely on an artificial midnight interval, `open_now` depends on an
   implicit server clock, exception date bounds are unclear, and the specification
   does not define timezone, overnight, DST, overlap, or precedence behavior.

   Close those gaps with a UCP-native schedule model informed by Schema.org's
   OpeningHoursSpecification:
   https://schema.org/OpeningHoursSpecification

   Schema.org is design input only. UCP owns the field names, values, and
   evaluation rules defined here.

   Make weekly intervals explicit and reusable:

       "hours": [
         {
           "day": "tuesday",
           "opens": "09:00",
           "closes": "12:00"
         },
         {
           "day": "tuesday",
           "opens": "13:00",
           "closes": "21:00"
         }
       ]

   Rename `open` and `close` to `opens` and `closes`, and define `day` as a
   stable UCP weekday identifier rather than localized display text. Multiple
   entries for one day represent split shifts, and an interval whose closing time
   is earlier than its opening time continues into the next local date.

   Refactor the shared time interval schema so `opens` and `closes` are an
   optional but inseparable pair. Weekly hours require both fields, while
   exception hours may omit both to represent a full closure. Reject the ambiguous
   `00:00` to `00:00` pair and reserve `00:00` to `23:59` as the full-local-day
   sentinel.

   Replace the previous exception shape:

       {
         "from": "2026-11-26",
         "through": "2026-11-27",
         "label": "Thanksgiving",
         "open": "00:00",
         "close": "00:00"
       }

   with inclusive local-date bounds and an actual closure representation:

       {
         "title": "Thanksgiving",
         "valid_from": "2026-11-26",
         "valid_through": "2026-11-26"
       }

   Rename `from`, `through`, and `label` to `valid_from`, `valid_through`, and
   `title`. Treat `title` as optional presentation metadata that does not affect
   schedule evaluation. Allow timed exceptions with paired `opens` and `closes`,
   including multiple entries with identical bounds for split shifts.

   Define every returned schedule in the Location's Business-owned IANA timezone.
   Require `timezone` whenever regular or exception hours are present, and keep
   the canonical schedule independent of the requesting Platform or Buyer's
   timezone.

   Specify deterministic evaluation:

   - convert an exact instant into each Location's local date, weekday, and time
   - use half-open timed intervals, except for the reserved full-day sentinel
   - let overnight intervals carry into the following local date
   - replace regular hours with exception hours at local midnight
   - treat omitted weekdays as having no interval starting that day
   - treat absent schedules as unknown rather than closed
   - evaluate DST gaps and folds pointwise without shifting nonexistent times
   - reject equal time pairs and intersecting non-identical exception ranges as Business conformance errors where JSON Schema cannot express the constraint

   Remove the redundant `open_now` filter. It makes results depend on an implicit
   processing clock and creates undefined precedence when combined with
   `open_at`. Require one caller-supplied RFC 3339 instant instead:

       "filters": {
         "hours": {
           "open_at": "2026-05-18T17:00:00Z"
         }
       }

   Require `open_at` to include `Z` or a numeric offset. The offset identifies the
   instant only; the Business still evaluates that instant using each candidate
   Location's authoritative IANA timezone. Keep the nested hours filter open so
   extensions can add qualifiers without changing the standard predicate.

   Move complete Search and Lookup examples into the transport-neutral capability
   documents. Cover hours with serviceability and amenities, inventory with
   distance, split shifts, full closures, and partial Lookup success there.

   Reduce REST and MCP examples to equivalent binding envelopes that link to the
   same canonical payload examples. This keeps both transports on equal footing,
   avoids duplicating domain semantics, and prevents one binding's examples from
   becoming more complete or authoritative than the other. Preserve MCP's
   required `meta["ucp-agent"].profile` contract while separating protocol
   metadata from the Location request.

   This is a breaking correction to the Location PR's draft wire shape:

   - `open` becomes `opens`
   - `close` becomes `closes`
   - `from` becomes `valid_from`
   - `through` becomes `valid_through`
   - `label` becomes `title`
   - `open_now` is removed
   - full closures omit both time fields instead of using `00:00` to `00:00`