### PR TITLE
fix!: discriminate destinations at the method level

### DIFF
--- a/docs/specification/checkout-mcp.md
+++ b/docs/specification/checkout-mcp.md
@@ -190,7 +190,6 @@ Maps to the [Create Checkout](checkout.md#create-checkout) operation.
                   "type": "shipping",
                   "destinations": [
                     {
-                      "type": "shipping_address",
                       "street_address": "123 Main St",
                       "address_locality": "Springfield",
                       "address_region": "IL",

--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -406,7 +406,6 @@ references.
             "type": "shipping",
             "destinations": [
               {
-                "type": "shipping_address",
                 "street_address": "123 Main St",
                 "address_locality": "Springfield",
                 "address_region": "IL",
@@ -613,7 +612,6 @@ Follow-up calls after initial `fulfillment` data to update selection.
             "selected_destination_id": "dest_home",
             "destinations": [
               {
-                "type": "shipping_address",
                 "id": "dest_home",
                 "street_address": "123 Main St",
                 "address_locality": "Springfield",

--- a/docs/specification/embedded-checkout.md
+++ b/docs/specification/embedded-checkout.md
@@ -1306,7 +1306,6 @@ method.
                         "selected_destination_id": "address_123",
                         "destinations": [
                             {
-                                "type": "shipping_address",
                                 "id": "address_123",
                                 "street_address": "456 Old Street"
                                 // ...
@@ -1354,7 +1353,6 @@ rather than attempting to merge the new data with existing state.
                         "selected_destination_id": "address_789",
                         "destinations": [
                             {
-                                "type": "shipping_address",
                                 "id": "address_789",
                                 "first_name": "John",
                                 "last_name": "Doe",

--- a/docs/specification/fulfillment.md
+++ b/docs/specification/fulfillment.md
@@ -179,8 +179,12 @@ method.
 ## Destinations
 
 A fulfillment method's `type` describes how items are fulfilled, while each
-destination's `type` describes where fulfillment occurs. These discriminators
-are independent; neither implies the other.
+destination's `type` describes where fulfillment occurs. The two
+discriminators play different roles by direction: in Business responses,
+every destination carries a required `type`, so responses are
+self-describing; in Platform requests, the method's contract determines who
+authors `destinations[]` and MAY define a default destination shape when
+`type` is omitted.
 
 Destination authorship — whether the Platform may write entries into a
 method's `destinations[]` — is keyed by the method's `type`:
@@ -189,20 +193,25 @@ method's `destinations[]` — is keyed by the method's `type`:
 | --- | --- |
 | `shipping` | Platform-writable. The Platform writes the Buyer's shipping-address facts. |
 | `pickup` | Not Platform-writable (schema-enforced). The Business enumerates locations in its response; the Platform selects one by ID (see [Selection and Location Identity](#selection-and-location-identity)). |
-| extension-defined | The defining extension specifies the destination shape and whether it is Platform-writable. |
+| other method type | The method's defining contract specifies the destination shape and whether it is Platform-writable. |
 
-Destination `type` is **required in responses and optional in requests**. When
-a request destination omits `type`, the method's `type` implies its shape: an
-untyped destination under a `shipping` method validates as a Shipping
-Destination, and destinations under an extension-defined method type are
-validated by the negotiated extension's schema. A Platform **MAY** include
-`type` to disambiguate a destination reference when more than one kind can
-appear under a method — for example, an `id`-only destination that references
-a Business-managed mailing address versus an entry in an identity provider's
-customer address book. In responses, every destination carries a required,
-open `type`, so destinations remain self-describing wherever they appear. A
-request that includes `destinations[]` MUST also include the method's `type`.
-The well-known values are:
+Destination `type` is **required in responses and optional in requests**. In
+responses, every destination carries a required, open `type`, so destinations
+remain self-describing wherever they appear. In requests, the method's
+contract defines the destination shape:
+
+* Under a well-known `shipping` method, every destination is a Shipping
+    Destination: a destination that omits `type` defaults to
+    `shipping_address`.
+* Under a well-known `pickup` method, destinations are response-only; the
+    Platform selects a location via `selected_destination_id` (see
+    [Selection and Location Identity](#selection-and-location-identity)).
+* Under any other method type, the method's defining contract — a future
+    revision of this specification or a negotiated extension — specifies the
+    request destination shape and whether it is Platform-writable.
+
+A request that includes `destinations[]` MUST also include the method's
+`type`. The well-known values are:
 
 | Value | Meaning |
 | --- | --- |
@@ -218,7 +227,9 @@ For a Shipping Destination, the Platform supplies shipping-address facts as
 flat Postal Address fields directly on the destination. The Platform **MAY**
 include `id` and **MAY** include `type: "shipping_address"` in its request.
 The Business **MUST** include `type: "shipping_address"` and assign `id` in
-its response.
+its response. An `id`-only destination that references a saved or
+provider-held address is still a Shipping Destination; conveying provider
+provenance or additional fields requires a negotiated extension contract.
 
 #### Platform Request
 

--- a/docs/specification/fulfillment.md
+++ b/docs/specification/fulfillment.md
@@ -182,7 +182,27 @@ A fulfillment method's `type` describes how items are fulfilled, while each
 destination's `type` describes where fulfillment occurs. These discriminators
 are independent; neither implies the other.
 
-Every destination has a required, open `type`. The well-known values are:
+Destination authorship — whether the Platform may write entries into a
+method's `destinations[]` — is keyed by the method's `type`:
+
+| Method `type` | Request `destinations[]` |
+| --- | --- |
+| `shipping` | Platform-writable. The Platform writes the Buyer's shipping-address facts. |
+| `pickup` | Not Platform-writable (schema-enforced). The Business enumerates locations in its response; the Platform selects one by ID (see [Selection and Location Identity](#selection-and-location-identity)). |
+| extension-defined | The defining extension specifies the destination shape and whether it is Platform-writable. |
+
+Destination `type` is **required in responses and optional in requests**. When
+a request destination omits `type`, the method's `type` implies its shape: an
+untyped destination under a `shipping` method validates as a Shipping
+Destination, and destinations under an extension-defined method type are
+validated by the negotiated extension's schema. A Platform **MAY** include
+`type` to disambiguate a destination reference when more than one kind can
+appear under a method — for example, an `id`-only destination that references
+a Business-managed mailing address versus an entry in an identity provider's
+customer address book. In responses, every destination carries a required,
+open `type`, so destinations remain self-describing wherever they appear. A
+request that includes `destinations[]` MUST also include the method's `type`.
+The well-known values are:
 
 | Value | Meaning |
 | --- | --- |
@@ -195,27 +215,57 @@ specific to such a value are validated by the negotiated extension's schema.
 ### Shipping Destination
 
 For a Shipping Destination, the Platform supplies shipping-address facts as
-flat Postal Address fields directly on the destination. The Platform **MUST**
-include `type: "shipping_address"` and **MAY** include `id` in its request. The
-Business **MUST** include `type: "shipping_address"` and assign `id` in its
-response.
+flat Postal Address fields directly on the destination. The Platform **MAY**
+include `id` and **MAY** include `type: "shipping_address"` in its request.
+The Business **MUST** include `type: "shipping_address"` and assign `id` in
+its response.
+
+#### Platform Request
+
+<!-- ucp:example schema=shopping/types/shipping_destination op=update direction=request -->
+```json
+{
+  "street_address": "123 Main St",
+  "address_locality": "Springfield",
+  "address_region": "IL",
+  "postal_code": "62701",
+  "address_country": "US"
+}
+```
+
+#### Business Response
+
+<!-- ucp:example schema=shopping/types/shipping_destination op=read direction=response -->
+```json
+{
+  "type": "shipping_address",
+  "id": "dest_1",
+  "street_address": "123 Main St",
+  "address_locality": "Springfield",
+  "address_region": "IL",
+  "postal_code": "62701",
+  "address_country": "US"
+}
+```
 
 ### Business Location Destination
 
-For a Business Location Destination, the Platform selects the location with a
-stable, opaque, Business-scoped `id`. The Platform **MUST** include
-`type: "business_location"` and `id` in its request and **MUST NOT** include the
-Business-owned `name` or `address`. The Business **MUST** return
+Business Location Destinations appear only in responses; `destinations[]` on a
+`pickup` method is not a request field. The Platform **MUST NOT** write
+Business Location Destinations into `destinations[]`; it selects a location by
+submitting its stable, opaque, Business-scoped ID as
+`selected_destination_id`. The Business **MUST** return
 `type: "business_location"`, `id`, and its Buyer-facing `name`, and **MAY**
 return its Postal Address in `address`.
 
 #### Platform Request
 
-<!-- ucp:example schema=shopping/types/location_destination op=update direction=request -->
+<!-- ucp:example schema=shopping/types/fulfillment_method op=update direction=request -->
 ```json
 {
-  "type": "business_location",
-  "id": "loc_downtown"
+  "type": "pickup",
+  "line_item_ids": ["shirt", "pants"],
+  "selected_destination_id": "loc_downtown"
 }
 ```
 
@@ -240,12 +290,17 @@ return its Postal Address in `address`.
 ### Selection and Location Identity
 
 `selected_destination_id` identifies the selected destination in a method by
-its `id`. When Catalog represents a location as applicable to a particular
-fulfillment method, the Business **MUST** recognize the same Business-scoped ID
-when the Platform submits it in Checkout for that method, including as
-`selected_destination_id`. The Business **MUST** revalidate current availability
-and terms during Checkout; recognition does not reserve inventory or guarantee
-eligibility.
+its `id`, and is the sole channel for selecting a Business Location. It accepts
+any stable, Business-scoped Location ID the Business recognizes for that
+method, including IDs the Business has not (yet) enumerated in that method's
+`destinations[]` — for example an ID discovered through Catalog or a separately
+negotiated Location capability. When Catalog represents a location as
+applicable to a particular fulfillment method, the Business **MUST** recognize
+the same Business-scoped ID when the Platform submits it in Checkout for that
+method, including as `selected_destination_id`, and **MUST** return the
+corresponding typed destination in `destinations[]` in its response. The
+Business **MUST** revalidate current availability and terms during Checkout;
+recognition does not reserve inventory or guarantee eligibility.
 
 ## Rendering
 

--- a/docs/specification/playground.md
+++ b/docs/specification/playground.md
@@ -971,7 +971,7 @@ class UcpApp {
             req.buyer.email = "test@example.com";
             req.buyer.name = "Test User";
         } else {
-            req.fulfillment.methods = [{ type: 'shipping', destinations: [{ type: "shipping_address", id: "addr_1", street_address: "123 Main St", address_locality: "Tech City", address_country: "US", postal_code: "94103" }] }];
+            req.fulfillment.methods = [{ type: 'shipping', destinations: [{ id: "addr_1", street_address: "123 Main St", address_locality: "Tech City", address_country: "US", postal_code: "94103" }] }];
         }
     }
 
@@ -998,7 +998,7 @@ class UcpApp {
       patch.fulfillment = {
         methods: [{
             type: "shipping",
-            destinations: [{ type: "shipping_address", id: "addr_1", street_address: "123 Main St", address_locality: "Tech City", address_country: "US", postal_code: "94103" }]
+            destinations: [{ id: "addr_1", street_address: "123 Main St", address_locality: "Tech City", address_country: "US", postal_code: "94103" }]
         }]
       };
     }

--- a/source/schemas/shopping/types/fulfillment_destination.json
+++ b/source/schemas/shopping/types/fulfillment_destination.json
@@ -9,7 +9,7 @@
   "properties": {
     "type": {
       "type": "string",
-      "description": "Fulfillment destination type. Required in responses; optional in requests. When a request destination omits `type`, the enclosing fulfillment method's `type` implies its shape. A Platform MAY include `type` to disambiguate a destination reference when more than one kind can appear under a method. Well-known values: `shipping_address`, `business_location`. Additional values are extension-defined and active only when their defining extension is negotiated.",
+      "description": "Destination contract discriminator. Required in Business responses and optional in Platform requests. Well-known values: `shipping_address`, `business_location`. The enclosing method contract defines request defaults and which fields the Platform may write; negotiated extensions define additional values.",
       "ucp_request": "optional"
     },
     "id": {

--- a/source/schemas/shopping/types/fulfillment_destination.json
+++ b/source/schemas/shopping/types/fulfillment_destination.json
@@ -9,8 +9,8 @@
   "properties": {
     "type": {
       "type": "string",
-      "description": "Fulfillment destination type. Well-known values: `shipping_address`, `business_location`. Additional values are extension-defined and active only when their defining extension is negotiated.",
-      "ucp_request": "required"
+      "description": "Fulfillment destination type. Required in responses; optional in requests. When a request destination omits `type`, the enclosing fulfillment method's `type` implies its shape. A Platform MAY include `type` to disambiguate a destination reference when more than one kind can appear under a method. Well-known values: `shipping_address`, `business_location`. Additional values are extension-defined and active only when their defining extension is negotiated.",
+      "ucp_request": "optional"
     },
     "id": {
       "type": "string",

--- a/source/schemas/shopping/types/fulfillment_method.json
+++ b/source/schemas/shopping/types/fulfillment_method.json
@@ -4,38 +4,106 @@
   "title": "Fulfillment Method",
   "description": "A fulfillment method with destinations and groups.",
   "type": "object",
-  "required": ["id", "type", "line_item_ids"],
-  "additionalProperties": true,
+  "required": [
+    "id",
+    "type",
+    "line_item_ids"
+  ],
   "properties": {
     "id": {
       "type": "string",
       "description": "Unique fulfillment method identifier.",
-      "ucp_request": {"create": "omit", "update": "optional"}
+      "ucp_request": {
+        "create": "omit",
+        "update": "optional"
+      }
     },
     "type": {
       "type": "string",
       "description": "Fulfillment method type. Well-known values: `shipping`, `pickup`. Businesses MAY use additional values.",
-      "ucp_request": {"create": "required", "update": "optional"}
+      "ucp_request": {
+        "create": "required",
+        "update": "optional"
+      }
     },
     "line_item_ids": {
       "type": "array",
       "description": "Line item IDs fulfilled via this method.",
-      "items": { "type": "string" },
-      "ucp_request": {"create": "optional", "update": "required"}
-    },
-    "destinations": {
-      "type": "array",
-      "description": "Available destinations. For shipping: shipping addresses. For pickup: business locations.",
-      "items": { "$ref": "fulfillment_destination.json" }
+      "items": {
+        "type": "string"
+      },
+      "ucp_request": {
+        "create": "optional",
+        "update": "required"
+      }
     },
     "selected_destination_id": {
-      "type": ["string", "null"],
-      "description": "ID of the selected destination."
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "ID of the selected destination. Accepts any stable, Business-scoped ID the Business recognizes for this method, including Location IDs not yet enumerated in `destinations`."
     },
     "groups": {
       "type": "array",
       "description": "Fulfillment groups for selecting options. Agent sets selected_option_id on groups to choose shipping method.",
-      "items": { "$ref": "fulfillment_group.json" }
+      "items": {
+        "$ref": "fulfillment_group.json"
+      }
     }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "shipping"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "destinations": {
+            "type": "array",
+            "description": "Platform-authored shipping addresses for this method.",
+            "items": {
+              "$ref": "shipping_destination.json"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "pickup"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "destinations": {
+            "type": "array",
+            "description": "Business-authored business locations able to fulfill this method. Response-only: the Platform selects one via `selected_destination_id`, never writes one.",
+            "ucp_request": "omit",
+            "items": {
+              "$ref": "location_destination.json"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "dependentRequired": {
+    "destinations": [
+      "type"
+    ]
   }
 }

--- a/source/schemas/shopping/types/location_destination.json
+++ b/source/schemas/shopping/types/location_destination.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/shopping/types/location_destination.json",
   "title": "Business Location Destination",
-  "description": "A business location fulfillment destination.",
+  "description": "A business location fulfillment destination. Business-authored and response-only: the Platform selects a location via `selected_destination_id` rather than writing destinations.",
   "type": "object",
   "ucp_shared_request": true,
   "allOf": [
@@ -16,8 +16,8 @@
         "type": {
           "type": "string",
           "const": "business_location",
-          "description": "Destination type discriminator.",
-          "ucp_request": "required"
+          "description": "Destination type discriminator. Response-only.",
+          "ucp_request": "omit"
         }
       }
     }

--- a/source/schemas/shopping/types/shipping_destination.json
+++ b/source/schemas/shopping/types/shipping_destination.json
@@ -20,8 +20,8 @@
         "type": {
           "type": "string",
           "const": "shipping_address",
-          "description": "Destination type discriminator.",
-          "ucp_request": "required"
+          "description": "Destination type discriminator. Required in responses; optional in requests.",
+          "ucp_request": "optional"
         }
       },
       "required": [


### PR DESCRIPTION
Counter-proposal for the request side of #688; response-side typing is unchanged. Context: [Slack thread](https://shopify.slack.com/archives/C0A2DPGJKM2/p1785942981484979).

### Problem

#688 discriminates destinations per-object in both directions. Requiring `type` on request destinations invalidates every deployed Platform integration — requests that validate today fail the moment the requirement lands. Response-side `type` is additive: producers add a field; consumers ignore unknown fields under the open-world model. The two directions carry incomparable migration costs.

The per-object tag also leaves the agreed authority boundary unenforced. `{ "type": "business_location", "id": ... }` remains a schema-valid Platform-written destination, so a written destination and `selected_destination_id` can select different locations with no precedence rule — the conflict #688 sets out to remove.

### Solution

Move the discriminator up one level: a fulfillment method's `type` selects the shape of its entire subtree, destinations included. A `shipping` method has Shipping Destinations; a `pickup` method has Business Location Destinations; extension-defined method types define their own. Polymorphism resolves at the parent, so request destinations need no per-object tag, and the request wire format Platforms send today remains valid unchanged.

```jsonc
// fulfillment_method.json — illustrative
"dependentRequired": { "destinations": ["type"] },
"allOf": [
  { "if":   { "properties": { "type": { "const": "shipping" } }, "required": ["type"] },
    "then": { "properties": { "destinations": { "items": { "$ref": "shipping_destination.json" } } } } },
  { "if":   { "properties": { "type": { "const": "pickup" } }, "required": ["type"] },
    "then": { "properties": { "destinations": {
      "ucp_request": "omit",
      "items": { "$ref": "location_destination.json" } } } } }
]
```

Plain draft-2020 `if`/`then` + `$ref` — no direction- or context-specific request schemas.

**Design decisions:**

- **Pickup destinations are response-only, schema-enforced.** `ucp_request: "omit"` inside the pickup branch removes `destinations` from the request projection; under strict resolution a Platform-written location is rejected as unevaluated. `selected_destination_id` is the sole selection channel and accepts any stable, Business-scoped Location ID the Business recognizes for the method, including IDs not yet enumerated in `destinations[]` — the #589 handoff. One channel, one authority.
- **`dependentRequired: {"destinations": ["type"]}`.** Method `type` is update-optional (target by `id`), so a request that writes `destinations[]` must carry the method `type` for branch dispatch. Updates touching only `selected_destination_id` or `selected_option_id` are unaffected.
- **Responses are unchanged from #688.** Every response destination carries a required, open `type` and remains self-describing. `type` stays optional in requests for reference disambiguation (e.g., an `id`-only destination naming one of several address sources).
- **Extension-defined method types** match no core branch; the negotiated extension's schema defines destination shape and writability.

### Before / After — strict request validation

| Case | #688 | this PR |
| --- | --- | --- |
| Untyped inline shipping address (today's clients) | rejected | valid |
| Unknown field on a shipping address | rejected | rejected |
| Platform writes a business location into `destinations[]` | valid (blessed shape) | rejected |
| `destinations[]` without `method.type` | n/a | rejected (`dependentRequired`) |
| Update touching only selection fields | valid | valid |

### Resolver change

`ucp-schema --strict` seals item schemas referenced from base properties but does not descend into `if`/`then`/`else`; branch item schemas are never sealed. One match arm in `close_additional_properties_inner` (`resolver.rs`):

```rust
"then" | "else" => {
    // Conditional branches apply in-place alongside siblings: don't seal
    // the branch itself, but descend so nested properties/items get sealed.
    close_additional_properties_inner(child, true);
}
```

Verified against a patched build: the full matrix above holds on unmodified resolver output; resolver unit tests pass (153/153). Diagnostic trade-off: a failed `then` contributes no annotations, so some rejections surface as a root-level unevaluated-`destinations` error rather than an item-level message — verdicts unchanged, messages less precise.

### Trade-offs

- Pickup write-ban enforcement applies under strict resolution; open validation remains permissive and the MUST NOT prose governs that regime. Strictly stronger than #688, where the written location is schema-blessed in both regimes.
- The `schema_fields` macro does not collect branch-scoped properties, so `destinations` no longer renders in the Fulfillment Method field table (covered in the Destinations section). Either the macro learns `then.properties`, or destinations are documented per method type.
- `fulfillment_destination.json` is no longer schema-referenced; retained as the response-side documentation entity, or foldable into docs.
