### PR TITLE
feat: add price_treatment to the price type

### DIFF
--- a/docs/specification/catalog/index.md
+++ b/docs/specification/catalog/index.md
@@ -189,7 +189,9 @@ Businesses determine market assignment—including currency—based on context
 signals. Price filter values are denominated in `context.currency`; when
 the presentment currency differs, businesses SHOULD convert before applying
 (see [Price Filter](search.md#price-filter)). Response prices include
-explicit currency codes confirming the resolution.
+explicit currency codes confirming the resolution. Where tax treatment
+varies by market, `tax_included` on a price states whether the amount is
+tax-inclusive, so agents do not have to infer it from the country.
 
 When `context.eligibility` claims are present, Businesses that accept them
 **MAY** adjust `price` / `list_price` directly for strikethrough display and

--- a/docs/specification/catalog/index.md
+++ b/docs/specification/catalog/index.md
@@ -190,8 +190,12 @@ signals. Price filter values are denominated in `context.currency`; when
 the presentment currency differs, businesses SHOULD convert before applying
 (see [Price Filter](search.md#price-filter)). Response prices include
 explicit currency codes confirming the resolution. Where tax treatment
-varies by market, `tax_included` on a price states whether the amount is
-tax-inclusive, so agents do not have to infer it from the country.
+varies by market, `price_treatment.tax.inclusion` states whether the
+amount includes tax as resolved for that market, so agents do not have
+to infer it from the country. An absent field is equivalent to
+`not_asserted`. Prices within a single product response **SHOULD**
+share the same tax treatment. During checkout, the itemized `totals`
+breakdown remains authoritative.
 
 When `context.eligibility` claims are present, Businesses that accept them
 **MAY** adjust `price` / `list_price` directly for strikethrough display and

--- a/source/schemas/common/types/price.json
+++ b/source/schemas/common/types/price.json
@@ -18,9 +18,9 @@
       "description": "ISO 4217 currency code (e.g., 'USD', 'EUR', 'GBP').",
       "pattern": "^[A-Z]{3}$"
     },
-    "tax_included": {
-      "type": "boolean",
-      "description": "Whether the amount includes tax (e.g. VAT, GST). When omitted, tax treatment is not asserted and follows the resolved market."
+    "price_treatment": {
+      "$ref": "price_treatment.json",
+      "description": "How the amount should be interpreted for display and downstream calculation. When omitted, treatment follows the resolved market."
     }
   }
 }

--- a/source/schemas/common/types/price.json
+++ b/source/schemas/common/types/price.json
@@ -17,6 +17,10 @@
       "type": "string",
       "description": "ISO 4217 currency code (e.g., 'USD', 'EUR', 'GBP').",
       "pattern": "^[A-Z]{3}$"
+    },
+    "tax_included": {
+      "type": "boolean",
+      "description": "Whether the amount includes tax (e.g. VAT, GST). When omitted, tax treatment is not asserted and follows the resolved market."
     }
   }
 }

--- a/source/schemas/common/types/price_treatment.json
+++ b/source/schemas/common/types/price_treatment.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/types/price_treatment.json",
+  "title": "Price Treatment",
+  "description": "How a price amount should be interpreted for display and downstream calculation.",
+  "type": "object",
+  "properties": {
+    "tax": {
+      "$ref": "tax_treatment.json",
+      "description": "Tax treatment of the amount."
+    }
+  }
+}

--- a/source/schemas/common/types/tax_treatment.json
+++ b/source/schemas/common/types/tax_treatment.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/types/tax_treatment.json",
+  "title": "Tax Treatment",
+  "description": "Tax treatment of a price amount.",
+  "type": "object",
+  "required": [
+    "inclusion"
+  ],
+  "properties": {
+    "inclusion": {
+      "type": "string",
+      "enum": [
+        "included",
+        "excluded",
+        "not_applicable",
+        "not_asserted"
+      ],
+      "description": "Whether the amount includes tax (e.g. VAT, GST) as resolved for the market. 'included': tax is part of the amount. 'excluded': tax is added downstream. 'not_applicable': no tax applies to this amount. 'not_asserted': equivalent to omitting the field."
+    }
+  }
+}


### PR DESCRIPTION
_Context: #256 (LATAM pricing) raised the same class of issue. This scopes it to the catalog price marker._

---

`price_treatment` is a new optional object on the `price` type, scoped to tax for now: `tax.inclusion` states whether the amount includes tax (VAT, GST, etc.), as one of `included`, `excluded`, `not_applicable`, `not_asserted`. A catalog price already carries `amount` and `currency`; today it never says whether tax is in it, so an agent has to infer that from the buyer's country. This makes the price self-describing, mirroring how `currency` is already explicit, and the container leaves room for tax detail later without adding sibling fields to `price`.

## What it looks like

A tax-inclusive EU catalog price:

```json
{ "amount": 12000, "currency": "EUR", "price_treatment": { "tax": { "inclusion": "included" } } }
```

A US catalog price omits it (or sets `excluded`); tax is added downstream. The itemized tax breakdown stays in checkout `totals`; this field only disambiguates the displayed price.

Optional and backward-compatible: an absent field is equivalent to `not_asserted`, behavior is unchanged; agents that ignore it fall back to today's inference, agents that read it drop the guesswork.

## Category (Required)

- [x] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [x] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)

## Checklist

- [x] I have followed the Contributing Guide (Conventional Commits title, no breaking changes).
- [x] I have updated the documentation.
- [x] cspell and markdownlint pass locally. _`ucp-schema` and super-linter not run locally (no cargo/docker); relying on CI._
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk. _Not applicable, no Python SDK in this repo yet._
