### PR TITLE
fix!: bind signed REST responses to their request

### DIFF
--- a/docs/specification/checkout-mcp.md
+++ b/docs/specification/checkout-mcp.md
@@ -788,7 +788,7 @@ Response signatures are **OPTIONAL** for:
 HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Digest: sha-256=:Y5fK8nLmPqRsT3vWxYzAbCdEfGhIjKlMnO...:
-Signature-Input: sig1=("@status" "content-digest" "content-type");keyid="merchant-2026"
+Signature-Input: sig1=("@status" "@authority";req "@method";req "@path";req "content-digest";req "content-digest" "content-type");created=1738617601;keyid="merchant-2026"
 Signature: sig1=:6G4i8TS6oUkGrx8KnCFUpsSPwd74...:
 
 {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"..."}],"structuredContent":{"id":"checkout_abc123","status":"completed"}}}

--- a/docs/specification/checkout-rest.md
+++ b/docs/specification/checkout-rest.md
@@ -1459,7 +1459,7 @@ Response signatures are **OPTIONAL** for:
 HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Digest: sha-256=:Y5fK8nLmPqRsT3vWxYzAbCdEfGhIjKlMnO...:
-Signature-Input: sig1=("@status" "content-digest" "content-type");keyid="merchant-2026"
+Signature-Input: sig1=("@status" "@authority";req "@method";req "@path";req "content-digest";req "content-digest" "content-type");created=1738617601;keyid="merchant-2026"
 Signature: sig1=:6G4i8TS6oUkGrx8KnCFUpsSPwd74...:
 
 {"id":"chk_123","status":"completed","order":{"id":"ord_456"}}

--- a/docs/specification/signatures.md
+++ b/docs/specification/signatures.md
@@ -249,7 +249,9 @@ signing operation, one signature on the wire — that both a UCP verifier
 wanting interop with WBA-conformant verifiers; the requirements below
 apply to any signature carrying `tag="web-bot-auth"`. WBA interop is
 request-scoped: responses are signed with standard UCP signatures
-(covering `@status`) and do not carry `tag="web-bot-auth"`.
+(covering `@status` and the request binding described in
+[REST Response Signing](#rest-response-signing)) and do not carry
+`tag="web-bot-auth"`.
 
 **On the wire.** A dual-audience signature is a normal UCP signature with
 a few additions: it carries a `Signature-Agent` header **alongside**
@@ -536,17 +538,55 @@ Signature: sig1=:6G4i8TS6oUkGrx8KnCFUpsSPwd74...:
 
 ### REST Response Signing
 
-Response signatures use `@status` instead of `@method`:
+Response signatures use `@status` instead of `@method`, and **MUST** bind
+the response to the request that produced it.
 
 **Signed Components:**
 
-| Component        | Required   | Description                       |
-| :--------------- | :--------- | :-------------------------------- |
-| `@status`        | Yes        | HTTP status code (200, 201, etc.) |
-| `content-digest` | Cond. `*`  | Body digest (if body present)     |
-| `content-type`   | Cond. `*`  | Content-Type (if body present)    |
+| Component              | Required  | Description                                     |
+| :--------------------- | :-------- | :---------------------------------------------- |
+| `@status`              | Yes       | HTTP status code (200, 201, etc.)               |
+| `@authority`;`req`     | Yes       | Request target host (binds the serving origin)  |
+| `@method`;`req`        | Yes       | Request method (binds the operation)            |
+| `@path`;`req`          | Yes       | Request path (binds the addressed resource)     |
+| `@query`;`req`         | Cond. `*` | Request query string (if the request had one)   |
+| `content-digest`;`req` | Cond. `**`| Request body digest (if the request had a body) |
+| `content-digest`       | Cond. `†` | Response body digest (if response has a body)   |
+| `content-type`         | Cond. `†` | Content-Type (if response has a body)           |
 
-* `*` Required if response has a body
+* `*` Required if the request had query parameters
+
+* `**` Required if the request had a body
+
+* `†` Required if the response has a body
+
+**Request Binding:** The `;req` parameter is
+[RFC 9421 §2.4](https://www.rfc-editor.org/rfc/rfc9421#section-2.4)
+request-response signature binding: it directs the signer and verifier to
+draw the named component from the **associated request** rather than from
+the response. Without it, a response signature covers only the response's
+own status and body, so a correctly signed response remains valid when
+detached from its request. That admits two attacks that TLS does not
+prevent when an intermediary terminates it (see the Intermediary Warning
+in [Headers](#headers)):
+
+* **Rollback / stale replay.** A signed response captured earlier is
+  replayed verbatim in answer to a later request for the same resource.
+  Every covered component still matches, so the verifier accepts a stale
+  view (an outdated `totals`, an expired `status`) as current. Inspecting
+  the body does not help: the body is a genuine, correctly signed earlier
+  state of the correct object.
+
+* **Cross-request substitution.** A signed response to one request is
+  served in answer to a different request to the same origin, since
+  neither the method, the path, nor the query was covered.
+
+**Freshness:** For signed responses the RFC 9421 `created` parameter is
+**REQUIRED**, and verifiers **MUST** reject a response whose `created` is
+outside an acceptable window. Verifiers **SHOULD** use a window of 300
+seconds and **MUST NOT** accept a `created` in the future beyond their
+tolerated clock skew. Request binding alone does not bound how long a
+captured response can be replayed against a repeated identical request.
 
 **Complete Response Example:**
 
@@ -556,11 +596,15 @@ required fields (`ucp`, `currency`, `line_items`, `totals`, `links`); see
 [Create Checkout response](checkout-rest.md#create-checkout) for the
 complete shape.
 
+The signature below answers the `POST /checkout-sessions` request shown in
+[REST Request Signing](#rest-request-signing); the `;req` components are
+drawn from that request.
+
 ```http
 HTTP/1.1 201 Created
 Content-Type: application/json
 Content-Digest: sha-256=:Y5fK8nLmPqRsT3vWxYzAbCdEfGhIjKlMnO...:
-Signature-Input: sig1=("@status" "content-digest" "content-type");created=1738617601;keyid="merchant-2026"
+Signature-Input: sig1=("@status" "@authority";req "@method";req "@path";req "content-digest";req "content-digest" "content-type");created=1738617601;keyid="merchant-2026"
 Signature: sig1=:6G4i8TS6oUkGrx8KnCFUpsSPwd74...:
 
 {
@@ -572,31 +616,40 @@ Signature: sig1=:6G4i8TS6oUkGrx8KnCFUpsSPwd74...:
 
 **Response Signature Generation:**
 
-Response signing mirrors request signing with `@status` replacing `@method`:
+Response signing mirrors request signing with `@status` replacing `@method`,
+plus the `;req` components drawn from the associated request:
 
 ```text
-sign_rest_response(status, body_bytes, private_key, kid):
+sign_rest_response(status, body_bytes, request, private_key, kid):
     // 1. Compute body digest (if body present)
     if body_bytes:
         digest = sha256(body_bytes)  // Hash raw bytes, no canonicalization
         digest_header = "sha-256=:" + base64(digest) + ":"
 
-    // 2. Build signature base (RFC 9421)
+    // 2. Build component list. ";req" components come from the request
+    // this response answers (RFC 9421 section 2.4).
+    components = ["@status", "@authority;req", "@method;req", "@path;req"]
+    if request.query:  components.append("@query;req")
+    if request.body:   components.append("content-digest;req")
+    if body_bytes:     components.extend(["content-digest", "content-type"])
+
+    // 3. Build signature base (RFC 9421). created is REQUIRED on responses.
     signature_base = build_signature_base(
-        components=["@status", "content-digest", "content-type"],
+        components=components,
         status=status,
+        request=request,  // source for the ";req" components
         headers={"content-digest": digest_header, "content-type": "application/json"},
         created=current_timestamp(),
         keyid=kid
     )
 
-    // 3. Sign
+    // 4. Sign
     signature = sign(signature_base, private_key)  // ecdsa for EC, eddsa for OKP
 
-    // 4. Return headers
+    // 5. Return headers
     return {
         "Content-Digest": digest_header,
-        "Signature-Input": 'sig1=("@status" "content-digest" "content-type");created=...;keyid="..."',
+        "Signature-Input": format_signature_input(components, created, kid),
         "Signature": "sig1=:" + base64(signature) + ":"
     }
 ```
@@ -748,7 +801,7 @@ Response verification mirrors request verification with `@status` replacing
 `@method`:
 
 ```text
-verify_rest_response(response, signer_profile_url):
+verify_rest_response(response, request, signer_profile_url):
     // 1. Parse Signature-Input
     sig_input = parse_signature_input(response.headers["Signature-Input"])
     keyid = sig_input.keyid
@@ -768,12 +821,24 @@ verify_rest_response(response, signer_profile_url):
         return skip_signature("algorithm_unsupported")
 
     // 2b. Enforce covered-component requirements for responses (all regimes).
-    // No method/idempotency to bind, but the body still MUST be covered.
-    required = ["@status"]
+    // The response body MUST be covered, and the response MUST be bound to
+    // the request it answers, so it cannot be detached and replayed against
+    // a later or different request (RFC 9421 section 2.4).
+    required = ["@status", "@authority;req", "@method;req", "@path;req"]
+    if request.query:     required += ["@query;req"]
+    if request.has_body:  required += ["content-digest;req"]
     if response.has_body: required += ["content-digest", "content-type"]
     for component in required:
         if component not in components:
-            return skip_signature("signature_invalid")
+            return skip_signature("coverage_insufficient")
+
+    // 2c. Enforce freshness. created is REQUIRED on responses; a bound
+    // response can still be replayed against a repeated identical request
+    // until it ages out.
+    if sig_input.created is absent:
+        return skip_signature("signature_invalid")
+    if abs(current_timestamp() - sig_input.created) > freshness_window:
+        return skip_signature("signature_expired")  // window: 300s RECOMMENDED
 
     // 3. Verify body digest (if body present)
     if "content-digest" in components:
@@ -781,10 +846,13 @@ verify_rest_response(response, signer_profile_url):
         if response.headers["Content-Digest"] != expected:
             return skip_signature("digest_mismatch")
 
-    // 4. Reconstruct signature base
+    // 4. Reconstruct signature base. The ";req" components are taken from
+    // the request this verifier actually sent, NOT from anything the
+    // response asserts. Rebuilding from the response would be
+    // self-certifying and would not bind anything.
     signature_base = build_signature_base(
         components, response.status,
-        response.headers, keyid
+        response.headers, request, keyid
     )
 
     // 5. Verify signature
@@ -797,13 +865,19 @@ verify_rest_response(response, signer_profile_url):
 
 ### Replay Protection
 
-UCP handles replay protection at the **business layer** through idempotency keys,
-not at the signature layer. This provides separation of concerns:
+UCP handles **request** replay protection at the **business layer** through
+idempotency keys, not at the signature layer. This provides separation of
+concerns:
 
 | Layer | Responsibility |
 | :---- | :------------- |
 | **Signature** | Authentication (who), Integrity (what) |
 | **Idempotency** | Safe retries, Replay protection |
+
+Idempotency keys are a request-direction mechanism and do not protect
+responses. **Response** replay is handled at the signature layer instead,
+by the request binding and `created` freshness window specified in
+[REST Response Signing](#rest-response-signing).
 
 **How it works:**
 
@@ -847,9 +921,11 @@ modify the request payload — including retries with modified payment
 instruments, updated shipping addresses, swapped line items, or any
 other change to the request body.
 
-**Note:** For **default UCP** signatures, the RFC 9421 `created`
+**Note:** For **default UCP** *request* signatures, the RFC 9421 `created`
 parameter is **OPTIONAL** and replay protection is handled at the
-business layer through idempotency keys, not signature timestamps.
+business layer through idempotency keys, not signature timestamps. On
+*response* signatures `created` is **REQUIRED** and enforced; see
+[REST Response Signing](#rest-response-signing).
 **WBA-shape** signatures additionally carry `created`/`expires` (and
 SHOULD carry a `nonce`) for WBA verifiers; enforcing that freshness
 window is application-defined (RFC 9421 §3.2.1). See


### PR DESCRIPTION
# Description

Signed REST responses are not bound to the request that produced them.

Proposal: #698. This PR is the reference spec change for it, opened for review alongside the proposal rather than as a request to merge ahead of TC approval.

### Problem

[REST Response Signing](https://ucp.dev/specification/signatures/#rest-response-signing) covers three components: `@status`, `content-digest`, `content-type`. The verifier enforces only those. Nothing ties a response to the request's method, path, query or body, nothing ties it to the serving origin, and `created` is **OPTIONAL** and never read by the verifier, so there is no freshness bound either.

A correctly signed response therefore stays valid once detached from its request. The adversary that matters here is not a network attacker, since TLS covers that. It is something that terminates TLS and can relay bytes but cannot mint signatures, because the signing key lives at the origin and not at the edge: a CDN, WAF, API gateway or reverse proxy in front of the Business. That is the same adversary the spec's own **Intermediary Warning** already assumes.

**Rollback / stale replay.** A signed `200` captured earlier is replayed verbatim against a later request for the same resource:

1. Platform polls `GET /checkout-sessions/chk_123` and gets a signed `200` with `totals` of $40.00.
2. Business reprices the session to $60.00.
3. Platform re-polls. The intermediary replays the earlier byte-identical response.
4. `@status` still matches, `content-digest` matches the stale body's own bytes, `content-type` matches, and the Business's key is live. Verification passes.

Checking the body does not catch this. The body is a real, correctly signed earlier state of the correct object, and since it was internally consistent when issued it also passes the Platform side totals check in [checkout.md](https://ucp.dev/specification/checkout/#verification).

Scope of the damage: the Business stays authoritative and settles against its own state ([checkout.md](https://ucp.dev/specification/checkout/#verification)), so it charges $60.00 and this is not a route to theft. What breaks is that the Platform and buyer act on stale terms. That matters where a Platform completes autonomously, and it matters for AP2 mandates, whose whole point is non-repudiable authorization over data that turns out to be attacker-selected. The same trick applies to replaying a superseded `"status": "completed"` or an old payment authorization response.

**Cross-request substitution.** A signed response to one request served against a different request to the same origin, since neither method, path nor query is covered. Mostly mitigated in practice by self-describing bodies carrying `id`. It is the weaker of the two, and it gets closed for free by the same fix.

### Solution

Use [RFC 9421 §2.4](https://www.rfc-editor.org/rfc/rfc9421#section-2.4) request-response binding. It is a parameter in an RFC the spec already depends on, so there is no new UCP construct here. Response signatures cover `@authority`, `@method` and `@path` from the associated request via `;req`, plus `@query` and `content-digest` when the request carried them.

```text
- sig1=("@status" "content-digest" "content-type")
+ sig1=("@status" "@authority";req "@method";req "@path";req
+       "content-digest";req "content-digest" "content-type");created=...
```

**Design decisions:**

- **Verifiers rebuild the `;req` components from the request they actually sent**, never from anything the response claims. Rebuilding from the response would be self-certifying and would bind nothing. This is stated normatively at the reconstruction step.
- **`created` becomes REQUIRED on responses**, with an enforced window (300s RECOMMENDED, not MUST, so deployments with worse clock skew can widen it). Binding alone does not bound how long a captured response can be replayed against a repeated identical request, which is the polling case above. It stays OPTIONAL on requests, where idempotency keys already handle replay.
- **Request signing is untouched.** Response direction only, so deployed Platform request signers keep working.
- **Replay Protection reworded.** It read as though idempotency keys covered both directions. They are request only. That section now says so and points at the response side mechanism.

### Before / After

| Case | Before | After |
| --- | --- | --- |
| Stale response replayed against a later identical request | accepted | rejected (`created` window) |
| Response to `/checkout-sessions/A` served for `/checkout-sessions/B` | accepted | rejected (`@path;req`) |
| Response relayed from a different origin | accepted | rejected (`@authority;req`) |
| Response signature with no `created` | accepted | rejected |
| Tampered response body | rejected | rejected |

### Trade-offs

- **Breaking for verifiers.** A verifier on the new rule rejects any signer still on the old shape, so the two move together. Doing it now costs prose, because nothing depends on the current shape yet. Once signers ship it turns into a coordinated cutover across every independent signer and verifier. Transition is publisher controlled by UCP version in the same way as #566.
- **`;req` support is uneven** across RFC 9421 libraries. Signers on a library without it have to build the signature base by hand. That is the main adoption cost and the most likely thing to get pushback.
- **A 300s window still allows replay inside the window.** Closing that needs response side nonce tracking, which is not worth it here. The window takes exposure from unbounded to minutes.
- **Verifiers now need the request at verification time.** In practice a client already has the request it sent, so this is a call signature change rather than new state.
- **CI cannot catch regressions here.** Nothing in this repo asserts on covered components, so this rides on review until the conformance suite covers it.

### Scope

Docs only in this repo. Nothing under `source/` encodes covered components (`profile.json` and `ap2_mandate.json` mention signatures only in key and JWK descriptions), and no Python in `main.py`, `hooks.py` or `scripts/` parses `Signature-Input`. The spec text is the product, so the prose change is the protocol change.

Per [CONTRIBUTING § Significant Changes](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md#significant-changes) this counts twice over, as a Protocol Change and as Backwards Incompatibility, so it needs the proposal in #698 and TC approval before merge.

## Category (Required)

_Please select one or more categories that apply to this change._

- [x] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

Proposal: #698

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

No schema or model changes: no JSON Schema encodes signature covered components, so there is nothing to update or regenerate. No tests added because nothing in this repo can assert on covered components. `validate_examples.py` validates fenced JSON bodies against schemas and never parses `Signature-Input`, so this belongs in the conformance suite. The Test Plan in #698 covers it: a signer emitting the `;req` set, plus negative cases for a response replayed against a different request, one outside the `created` window, and a verifier that rebuilds `;req` from the response instead of its own request. Verification: doc example corpus 292 passed / 0 failed / 48 skipped, `markdownlint` clean across `docs/specification/*.md`, `cspell` clean on the three changed files.

## Screenshots / Logs (if applicable)

No rendering change. Table rows, fenced `text` and `http` blocks, and prose.

```
validate_examples.py --schema-base source/schemas/
292 passed, 0 failed, 0 errors, 48 skipped
```
