### PR TITLE
ci: serialize gh-pages deploys and add job timeouts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Don't run this workflow if this is a release branch creation event
     # (event.before SHA is all zeros)
     if: >-
@@ -80,6 +81,7 @@ jobs:
   build_and_verify_main:
     needs: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main'
     permissions:
       contents: read
@@ -107,6 +109,7 @@ jobs:
   build_and_verify_release:
     needs: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: >-
       startsWith(github.ref, 'refs/heads/release/') ||
       startsWith(github.event.pull_request.base.ref, 'release/')
@@ -137,6 +140,14 @@ jobs:
   deploy_main:
     needs: build_and_verify_main
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Both deploy jobs write the gh-pages branch. Without a shared group two
+    # merges landing inside one deploy's runtime race and the loser's push is
+    # rejected, so that commit's docs never publish. Queue them instead of
+    # cancelling: a cancelled deploy is a deploy that did not happen.
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     if: contains(fromJson('["push", "workflow_dispatch"]'), github.event_name) && github.ref == 'refs/heads/main'
     permissions:
       contents: write
@@ -190,6 +201,10 @@ jobs:
   deploy_release:
     needs: build_and_verify_release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     if: contains(fromJson('["push", "workflow_dispatch"]'), github.event_name) && startsWith(github.ref, 'refs/heads/release/')
     permissions:
       contents: write
@@ -226,6 +241,7 @@ jobs:
   create_release:
     needs: deploy_release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: contains(fromJson('["push", "workflow_dispatch"]'), github.event_name) && startsWith(github.ref, 'refs/heads/release/')
     permissions:
       contents: write

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -21,7 +21,6 @@ on:
       - 'release/**'
     paths:
       - ".github/workflows/linter.yaml"
-      - ".github/workflows/schema-validation.yml"
       - ".github/linters/**"
       - ".pre-commit-config.yaml"
       - "pyproject.toml"


### PR DESCRIPTION
# Description

`deploy_main` and `deploy_release` both push to `gh-pages`, and neither has a concurrency group. Two merges landing close together means two runs racing on the push, and one gets rejected.

It's hit twice in the last 100 main pushes (2026-04-20 to 2026-08-07), from two different push sites, the raw `git push` in the root deploy and mike's own:

```
run 26217319631  2026-05-21
  ! [remote rejected] gh-pages -> gh-pages (cannot lock ref
    'refs/heads/gh-pages': is at 37c3742 but expected dcf2a70)

run 27422226472  2026-06-12
  error: failed to push branch gh-pages to origin:
  ! [rejected]  gh-pages -> gh-pages (fetch first)
```

Whether it matters depends on which run loses. In May the loser was the older commit, and since the winner was a descendant on main its build already had that content, so all we got was a red X on someone's merge for something they didn't break. June was the bad case: the loser was `feat!: buyer consent with per-segment extensibility`, and those docs didn't publish until the next merge to main.

Call it one stale publish and one false failure a quarter at the current rate. Not an outage. But the window is "two merges inside one deploy" and the median gap between deploys is already 6 minutes, so it won't get better on its own.

### Fix

Both deploy jobs go in one group:

```yaml
concurrency:
  group: gh-pages-deploy
  cancel-in-progress: false
```

`cancel-in-progress: false` matters here. A cancelled deploy is just one that didn't happen, and for `deploy_release` that means a version never publishing.

One gap this doesn't close: if two runs queue behind a third, GitHub keeps only the newest pending one. That's fine for `deploy_main` since a newer build supersedes an older one, but two release versions queueing at once could still drop one. I had retry-and-rebase loops around mike and the raw push to cover it, then took them back out. The root deploy builds a single commit that replaces the whole root tree, and rebasing that onto a moved tip can conflict. I'd rather not ship a retry path I can't exercise in CI, wrapped around a deploy. At least a cancelled run shows up in the Actions tab. Happy to put them back if you'd rather have them.

### Also in here

Two things I noticed while reading the workflows:

* No job anywhere sets `timeout-minutes`, so the default is 6 hours. Nothing here takes more than a few minutes. Set 30 on all six jobs in `docs.yml`.
* The `linter.yaml` paths filter lists `.github/workflows/schema-validation.yml`. That file doesn't exist.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

Workflow-only, so nothing to update for docs, schemas or models. No tests because there's no way to assert on Actions concurrency from this repo; the evidence is the two failed runs above.

`yamllint -c .github/linters/.yamllint.yml .github/workflows/` shows nothing new. The two line-length warnings left in `docs.yml` are on existing `if: contains(fromJson(...))` lines that just shifted down, 127 chars before and after.

## Screenshots / Logs (if applicable)

Job logs quoted above. No rendering change.
