### PR TITLE
fix(scripts): correctly resolve internal absolute root site URLs to root index.html in check_links.py

### DIFF
--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -160,11 +160,17 @@ def check_links():
         continue
 
       parsed = urlparse(link)
+      is_absolute_internal = False
       if parsed.scheme and parsed.scheme in ("http", "https"):
-        if not link.startswith(SITE_URL):
+        site_url_no_slash = SITE_URL.rstrip("/")
+        if not link.startswith(SITE_URL) and not link.startswith(site_url_no_slash):
           continue  # External link
-        # Internal absolute URL (e.g. https://ucp.dev/foo) -> /foo
-        link = link[len(SITE_URL) - 1 :]  # Keep the leading slash
+        is_absolute_internal = True
+        if link.startswith(SITE_URL):
+          link = link[len(SITE_URL) - 1 :]
+        else:
+          link = "/" + link[len(site_url_no_slash) :]
+        parsed = urlparse(link)
 
       path_part = parsed.path
       anchor_part = parsed.fragment
@@ -179,7 +185,7 @@ def check_links():
 
       # Resolve Target File
       if not path_part:
-        target_file = file_path
+        target_file = ROOT_DIR / "index.html" if is_absolute_internal else file_path
       elif path_part.startswith("/"):
         # Absolute path from root
         rel_path = path_part[1:]

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -190,6 +190,7 @@ def check_links():
         path_part = "/" + path_part[len(SITE_BASE_PATH) :]
 
       target_file = None
+      is_unbuilt_version = False
 
       # Resolve Target File
       if not path_part:
@@ -211,7 +212,14 @@ def check_links():
           )
           and not (ROOT_DIR / parts[0]).exists()
         ):
-          rel_path = parts[1]
+          is_unbuilt_version = True
+          stripped_path = parts[1]
+          if (
+            (ROOT_DIR / stripped_path).exists()
+            or (ROOT_DIR / (stripped_path + ".html")).exists()
+            or (ROOT_DIR / stripped_path / "index.html").exists()
+          ):
+            rel_path = stripped_path
 
         target_file = ROOT_DIR / rel_path
       else:
@@ -232,11 +240,15 @@ def check_links():
           if candidate.exists():
             target_file = candidate
           else:
+            if is_unbuilt_version:
+              continue
             errors_by_version[version][str(file_path)].append(
               f"  Link: {original_link}\n  Target: {target_file} (Not Found)"
             )
             continue
         else:
+          if is_unbuilt_version:
+            continue
           errors_by_version[version][str(file_path)].append(
             f"  Link: {original_link}\n  Target: {target_file} (Not Found)"
           )

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -160,17 +160,25 @@ def check_links():
         continue
 
       parsed = urlparse(link)
-      is_absolute_internal = False
       if parsed.scheme and parsed.scheme in ("http", "https"):
-        site_url_no_slash = SITE_URL.rstrip("/")
-        if not link.startswith(SITE_URL) and not link.startswith(site_url_no_slash):
-          continue  # External link
-        is_absolute_internal = True
-        if link.startswith(SITE_URL):
-          link = link[len(SITE_URL) - 1 :]
+        parsed_site = urlparse(SITE_URL)
+        if parsed.hostname == parsed_site.hostname:
+          path = parsed.path if parsed.path else "/"
+          site_path = parsed_site.path
+          site_path_no_slash = site_path.rstrip("/")
+          if (path == site_path_no_slash) or path.startswith(site_path):
+            if path.startswith(site_path):
+              rel_link_path = "/" + path[len(site_path) :]
+            else:
+              rel_link_path = "/"
+            query_part = f"?{parsed.query}" if parsed.query else ""
+            fragment_part = f"#{parsed.fragment}" if parsed.fragment else ""
+            link = rel_link_path + query_part + fragment_part
+            parsed = urlparse(link)
+          else:
+            continue  # External link
         else:
-          link = "/" + link[len(site_url_no_slash) :]
-        parsed = urlparse(link)
+          continue  # External link
 
       path_part = parsed.path
       anchor_part = parsed.fragment
@@ -185,7 +193,7 @@ def check_links():
 
       # Resolve Target File
       if not path_part:
-        target_file = ROOT_DIR / "index.html" if is_absolute_internal else file_path
+        target_file = file_path
       elif path_part.startswith("/"):
         # Absolute path from root
         rel_path = path_part[1:]


### PR DESCRIPTION
Resend because google cla  ,Updated check_links.py to correctly recognize internal absolute root site URLs (e.g. https://ucp.dev or https://ucp.dev/#anchor) and resolve them to ROOT_DIR/index.html instead of falling back to file_path. Also handles unslashed site URL matches.