### PR TITLE
fix(openapi): declare authentication via securitySchemes instead of ignored header parameters

### DIFF
--- a/source/services/common/rest.openapi.json
+++ b/source/services/common/rest.openapi.json
@@ -16,6 +16,15 @@
       }
     }
   ],
+  "security": [
+    {},
+    {
+      "oauth2_bearer": []
+    },
+    {
+      "api_key": []
+    }
+  ],
   "paths": {
     "/locations/search": {
       "post": {
@@ -23,16 +32,12 @@
         "summary": "Search Locations",
         "description": "Search for physical locations using query text, explicit spatial relations, and structured filters.",
         "parameters": [
-          { "$ref": "#/components/parameters/authorization" },
-          { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/signature" },
           { "$ref": "#/components/parameters/signature_input" },
           { "$ref": "#/components/parameters/content_digest" },
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
           { "$ref": "#/components/parameters/ucp_agent" },
-          { "$ref": "#/components/parameters/content_type" },
-          { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
           { "$ref": "#/components/parameters/accept_encoding" }
         ],
@@ -67,16 +72,12 @@
         "summary": "Batch Lookup Locations",
         "description": "Lookup one or more physical Locations by supported identifiers, optionally refined by explicit spatial relations and structured filters.",
         "parameters": [
-          { "$ref": "#/components/parameters/authorization" },
-          { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/signature" },
           { "$ref": "#/components/parameters/signature_input" },
           { "$ref": "#/components/parameters/content_digest" },
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
           { "$ref": "#/components/parameters/ucp_agent" },
-          { "$ref": "#/components/parameters/content_type" },
-          { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
           { "$ref": "#/components/parameters/accept_encoding" }
         ],
@@ -107,25 +108,20 @@
     }
   },
   "components": {
-    "parameters": {
-      "authorization": {
-        "name": "Authorization",
-        "in": "header",
-        "required": false,
-        "schema": {
-          "type": "string"
-        },
-        "description": "Contains an OAuth token representing Platform or Buyer credentials."
+    "securitySchemes": {
+      "oauth2_bearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "OAuth 2.0 access token issued by the business's authorization server, which platforms discover per RFC 8414. Covers both platform self-authentication (client_credentials) and platform authentication on behalf of an end user (authorization_code). See the Identity Linking specification."
       },
-      "x_api_key": {
+      "api_key": {
+        "type": "apiKey",
+        "in": "header",
         "name": "X-API-Key",
-        "in": "header",
-        "required": false,
-        "schema": {
-          "type": "string"
-        },
-        "description": "Reusable API key allocated to the Platform by the Business."
-      },
+        "description": "Reusable API key allocated to the platform by the business."
+      }
+    },
+    "parameters": {
       "signature": {
         "name": "Signature",
         "in": "header",
@@ -180,24 +176,6 @@
           "type": "string"
         },
         "description": "Identifies the UCP agent making the call, containing the signer's profile URI. Format: profile=\"https://example.com/.well-known/ucp\"."
-      },
-      "content_type": {
-        "name": "Content-Type",
-        "in": "header",
-        "required": false,
-        "schema": {
-          "type": "string"
-        },
-        "description": "Representation Metadata describing the body content."
-      },
-      "accept": {
-        "name": "Accept",
-        "in": "header",
-        "required": false,
-        "schema": {
-          "type": "string"
-        },
-        "description": "Content Negotiation, indicating accepted formats."
       },
       "accept_language": {
         "name": "Accept-Language",

--- a/source/services/shopping/rest.openapi.json
+++ b/source/services/shopping/rest.openapi.json
@@ -16,6 +16,15 @@
       }
     }
   ],
+  "security": [
+    {},
+    {
+      "oauth2_bearer": []
+    },
+    {
+      "api_key": []
+    }
+  ],
   "paths": {
     "/checkout-sessions": {
       "post": {
@@ -23,12 +32,6 @@
         "summary": "Create Checkout",
         "description": "Create a new checkout session.",
         "parameters": [
-          {
-            "$ref": "#/components/parameters/authorization"
-          },
-          {
-            "$ref": "#/components/parameters/x_api_key"
-          },
           {
             "$ref": "#/components/parameters/signature"
           },
@@ -49,12 +52,6 @@
           },
           {
             "$ref": "#/components/parameters/ucp_agent"
-          },
-          {
-            "$ref": "#/components/parameters/content_type"
-          },
-          {
-            "$ref": "#/components/parameters/accept"
           },
           {
             "$ref": "#/components/parameters/accept_language"
@@ -106,12 +103,6 @@
         "description": "Get the latest state of a checkout session.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/authorization"
-          },
-          {
-            "$ref": "#/components/parameters/x_api_key"
-          },
-          {
             "$ref": "#/components/parameters/signature"
           },
           {
@@ -125,12 +116,6 @@
           },
           {
             "$ref": "#/components/parameters/ucp_agent"
-          },
-          {
-            "$ref": "#/components/parameters/content_type"
-          },
-          {
-            "$ref": "#/components/parameters/accept"
           },
           {
             "$ref": "#/components/parameters/accept_language"
@@ -169,12 +154,6 @@
         "description": "Update Checkout is a full replacement operation. A new Update Checkout operation is not permitted while Checkout status is `complete_in_progress`. Duplicate requests remain subject to Replay Protection. If the Business receives a new Update Checkout request in that state, it leaves the Checkout unchanged and returns the current Checkout with a recoverable error Message.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/authorization"
-          },
-          {
-            "$ref": "#/components/parameters/x_api_key"
-          },
-          {
             "$ref": "#/components/parameters/signature"
           },
           {
@@ -194,12 +173,6 @@
           },
           {
             "$ref": "#/components/parameters/ucp_agent"
-          },
-          {
-            "$ref": "#/components/parameters/content_type"
-          },
-          {
-            "$ref": "#/components/parameters/accept"
           },
           {
             "$ref": "#/components/parameters/accept_language"
@@ -251,12 +224,6 @@
         "description": "Place the order",
         "parameters": [
           {
-            "$ref": "#/components/parameters/authorization"
-          },
-          {
-            "$ref": "#/components/parameters/x_api_key"
-          },
-          {
             "$ref": "#/components/parameters/signature"
           },
           {
@@ -276,12 +243,6 @@
           },
           {
             "$ref": "#/components/parameters/ucp_agent"
-          },
-          {
-            "$ref": "#/components/parameters/content_type"
-          },
-          {
-            "$ref": "#/components/parameters/accept"
           },
           {
             "$ref": "#/components/parameters/accept_language"
@@ -331,12 +292,6 @@
         "description": "Cancel a checkout session",
         "parameters": [
           {
-            "$ref": "#/components/parameters/authorization"
-          },
-          {
-            "$ref": "#/components/parameters/x_api_key"
-          },
-          {
             "$ref": "#/components/parameters/signature"
           },
           {
@@ -356,12 +311,6 @@
           },
           {
             "$ref": "#/components/parameters/ucp_agent"
-          },
-          {
-            "$ref": "#/components/parameters/content_type"
-          },
-          {
-            "$ref": "#/components/parameters/accept"
           },
           {
             "$ref": "#/components/parameters/accept_language"
@@ -401,8 +350,6 @@
         "summary": "Create Cart",
         "description": "Create a new cart session.",
         "parameters": [
-          { "$ref": "#/components/parameters/authorization" },
-          { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/signature" },
           { "$ref": "#/components/parameters/signature_input" },
           { "$ref": "#/components/parameters/content_digest" },
@@ -410,8 +357,6 @@
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
           { "$ref": "#/components/parameters/ucp_agent" },
-          { "$ref": "#/components/parameters/content_type" },
-          { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
           { "$ref": "#/components/parameters/accept_encoding" }
         ],
@@ -449,15 +394,11 @@
         "summary": "Get Cart",
         "description": "Get the latest state of a cart session.",
         "parameters": [
-          { "$ref": "#/components/parameters/authorization" },
-          { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/signature" },
           { "$ref": "#/components/parameters/signature_input" },
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
           { "$ref": "#/components/parameters/ucp_agent" },
-          { "$ref": "#/components/parameters/content_type" },
-          { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
           { "$ref": "#/components/parameters/accept_encoding" }
         ],
@@ -482,8 +423,6 @@
         "summary": "Update Cart",
         "description": "Update a cart session.",
         "parameters": [
-          { "$ref": "#/components/parameters/authorization" },
-          { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/signature" },
           { "$ref": "#/components/parameters/signature_input" },
           { "$ref": "#/components/parameters/content_digest" },
@@ -491,8 +430,6 @@
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
           { "$ref": "#/components/parameters/ucp_agent" },
-          { "$ref": "#/components/parameters/content_type" },
-          { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
           { "$ref": "#/components/parameters/accept_encoding" }
         ],
@@ -530,8 +467,6 @@
         "summary": "Cancel Cart",
         "description": "Cancel a cart session. Returns the cart state at time of cancellation.",
         "parameters": [
-          { "$ref": "#/components/parameters/authorization" },
-          { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/signature" },
           { "$ref": "#/components/parameters/signature_input" },
           { "$ref": "#/components/parameters/content_digest" },
@@ -539,8 +474,6 @@
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
           { "$ref": "#/components/parameters/ucp_agent" },
-          { "$ref": "#/components/parameters/content_type" },
-          { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
           { "$ref": "#/components/parameters/accept_encoding" }
         ],
@@ -567,16 +500,12 @@
         "summary": "Search Catalog",
         "description": "Search for products in the business's catalog.",
         "parameters": [
-          { "$ref": "#/components/parameters/authorization" },
-          { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/signature" },
           { "$ref": "#/components/parameters/signature_input" },
           { "$ref": "#/components/parameters/content_digest" },
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
           { "$ref": "#/components/parameters/ucp_agent" },
-          { "$ref": "#/components/parameters/content_type" },
-          { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
           { "$ref": "#/components/parameters/accept_encoding" }
         ],
@@ -611,16 +540,12 @@
         "summary": "Batch Lookup Catalog Items",
         "description": "Lookup one or more products by ID with explicit market context. Supports batch lookups of multiple items in a single request.",
         "parameters": [
-          { "$ref": "#/components/parameters/authorization" },
-          { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/signature" },
           { "$ref": "#/components/parameters/signature_input" },
           { "$ref": "#/components/parameters/content_digest" },
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
           { "$ref": "#/components/parameters/ucp_agent" },
-          { "$ref": "#/components/parameters/content_type" },
-          { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
           { "$ref": "#/components/parameters/accept_encoding" }
         ],
@@ -658,15 +583,11 @@
         "summary": "Get Order",
         "description": "Get the current state of an order. Returns the full order entity as a current-state snapshot. The business verifies the requesting platform created the checkout that produced this order.",
         "parameters": [
-          { "$ref": "#/components/parameters/authorization" },
-          { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/signature" },
           { "$ref": "#/components/parameters/signature_input" },
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
           { "$ref": "#/components/parameters/ucp_agent" },
-          { "$ref": "#/components/parameters/content_type" },
-          { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
           { "$ref": "#/components/parameters/accept_encoding" }
         ],
@@ -693,16 +614,12 @@
         "summary": "Get Product Details",
         "description": "Retrieve complete product detail by identifier. Returns a singular product with a relevant set of variants, exact pricing, and real-time availability. Supports interactive option selection via `selected` and `preferences` parameters for variant narrowing and availability signals.",
         "parameters": [
-          { "$ref": "#/components/parameters/authorization" },
-          { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/signature" },
           { "$ref": "#/components/parameters/signature_input" },
           { "$ref": "#/components/parameters/content_digest" },
           { "$ref": "#/components/parameters/request_id" },
           { "$ref": "#/components/parameters/user_agent" },
           { "$ref": "#/components/parameters/ucp_agent" },
-          { "$ref": "#/components/parameters/content_type" },
-          { "$ref": "#/components/parameters/accept" },
           { "$ref": "#/components/parameters/accept_language" },
           { "$ref": "#/components/parameters/accept_encoding" }
         ],
@@ -743,7 +660,6 @@
           { "$ref": "#/components/parameters/signature_input" },
           { "$ref": "#/components/parameters/content_digest" },
           { "$ref": "#/components/parameters/ucp_agent" },
-          { "$ref": "#/components/parameters/x_api_key" },
           { "$ref": "#/components/parameters/webhook_timestamp" },
           { "$ref": "#/components/parameters/webhook_id" }
         ],
@@ -777,6 +693,19 @@
     }
   },
   "components": {
+    "securitySchemes": {
+      "oauth2_bearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "OAuth 2.0 access token issued by the business's authorization server, which platforms discover per RFC 8414. Covers both platform self-authentication (client_credentials) and platform authentication on behalf of an end user (authorization_code). See the Identity Linking specification."
+      },
+      "api_key": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+        "description": "Reusable API key allocated to the platform by the business."
+      }
+    },
     "parameters": {
       "checkout_session_id_path": {
         "name": "id",
@@ -804,24 +733,6 @@
         "schema": {
           "type": "string"
         }
-      },
-      "authorization": {
-        "name": "Authorization",
-        "in": "header",
-        "required": false,
-        "schema": {
-          "type": "string"
-        },
-        "description": "Should contain oauth token representing the following 2 schemes: 1. Platform self authenticating (client_credentials). 2. Platform authenticating on behalf of end user (authorization_code)."
-      },
-      "x_api_key": {
-        "name": "X-API-Key",
-        "in": "header",
-        "required": false,
-        "schema": {
-          "type": "string"
-        },
-        "description": "Authenticates the platform with a reusable api key allocated to the platform by the business."
       },
       "signature": {
         "name": "Signature",
@@ -887,24 +798,6 @@
           "type": "string"
         },
         "description": "Identifies the UCP agent making the call. All requests MUST include the UCP-Agent header containing the signer's profile URI using RFC 8941 Dictionary syntax. The URL MUST point to /.well-known/ucp. Format: profile=\"https://example.com/.well-known/ucp\"."
-      },
-      "content_type": {
-        "name": "Content-Type",
-        "in": "header",
-        "required": false,
-        "schema": {
-          "type": "string"
-        },
-        "description": "Representation Metadata. Tells the receiver what the data in the message body actually is."
-      },
-      "accept": {
-        "name": "Accept",
-        "in": "header",
-        "required": false,
-        "schema": {
-          "type": "string"
-        },
-        "description": "Content Negotiation. The client tells the server what data formats it is capable of understanding."
       },
       "accept_language": {
         "name": "Accept-Language",


### PR DESCRIPTION
Closes #668

## Summary

- Add `components.securitySchemes` with `oauth2_bearer` (HTTP bearer) and
  `api_key` (`X-API-Key`), plus a document-level `security` requirement, to
  **both** REST service specifications.
- Remove the `authorization`, `x_api_key`, `content_type` and `accept` header
  parameter definitions and all 61 `$ref`s to them.

## Motivation

#668 reports that `Authorization` is declared as a header parameter, which
OpenAPI 3.1 requires implementations to ignore. The same clause covers two more
parameters in the same file that the issue does not mention:

> If `in` is `"header"` and the `name` field is `"Accept"`, `"Content-Type"` or
> `"Authorization"`, the parameter definition **SHALL** be ignored.
> — OpenAPI 3.1.0, Parameter Object

### `source/services/shopping/rest.openapi.json`

| Parameter | `name` | `$ref`s | Ignored by OpenAPI 3.1 |
| --- | --- | --- | --- |
| `authorization` | `Authorization` | 13 | **yes** — reported in #668 |
| `content_type` | `Content-Type` | 13 | **yes** — not previously reported |
| `accept` | `Accept` | 13 | **yes** — not previously reported |
| `x_api_key` | `X-API-Key` | 14 | no, but it is authentication |

### `source/services/common/rest.openapi.json`

This file did not exist when the PR was opened. Location Search + Lookup (#589)
introduced it in v2026-08-25, reproducing the defect exactly — the same four
parameters with the same descriptions, and no `components.securitySchemes` at
all:

| Parameter | `name` | `$ref`s | Ignored by OpenAPI 3.1 |
| --- | --- | --- | --- |
| `authorization` | `Authorization` | 2 | **yes** |
| `content_type` | `Content-Type` | 2 | **yes** |
| `accept` | `Accept` | 2 | **yes** |
| `x_api_key` | `X-API-Key` | 2 | no, but it is authentication |

Across the two documents that is **45 parameter references the specification
requires tooling to discard**, and neither document declared
`components.securitySchemes` before this change. Anything generated from these
files — clients, validators, docs — silently drops the authentication contract.

Fixing only Shopping would ship two REST specs that state authentication
differently: Shopping via `securitySchemes`, Common via parameters OpenAPI 3.1
tells tooling to ignore. The Common service is independently discoverable —
`docs/specification/common/location/rest.md` advertises it as
`services["dev.ucp.common"][transport=rest].schema` — so the gap is not
theoretical.

`Content-Type` and `Accept` need no replacement: the information is already
carried correctly and non-ignorably by the `requestBody.content` and
`responses.*.content` media-type maps, which every operation in both files
already declares.

`X-API-Key` is not in the ignore list, but #668 asks for "securitySchemes that
specify all supported types (i.e. JWT/OAuth, API key, basic auth, etc.)", so
leaving it as a parameter would be half a fix.

## Design decisions

**`type: http, scheme: bearer` rather than `type: oauth2` with flows.** The
replaced description named `client_credentials` and `authorization_code`, which
argues for `type: oauth2`. But an OAuth Flow Object requires concrete
`tokenUrl` / `authorizationUrl` values, and UCP has none to give: per
`identity-linking.md`, platforms discover the business's authorization server at
runtime via RFC 8414 metadata (OIDC fallback), and the issuer may sit on a
different origin than the business. `http`/`bearer` states exactly what is true
on the wire — `Authorization: Bearer <access_token>` — without fabricating fixed
endpoints. The description points readers at Identity Linking for discovery.
Happy to switch to `oauth2` if the council would rather assert templated URLs.

**`security` includes the empty requirement `{}`.** Every parameter this PR
replaces was `required: false`, and `signatures.md` states that platforms
**SHOULD** sign requests and **MAY** use alternative mechanisms (API keys, OAuth,
mTLS) instead. So no single scheme is universally mandatory, and omitting `{}`
would tighten the contract beyond what the spec says.

**RFC 9421 signature headers stay as parameters.** `Signature`,
`Signature-Input` and `Content-Digest` are not in the OpenAPI ignore list, and
OpenAPI 3.1 has no security-scheme type that expresses HTTP Message Signatures.
Modelling them is a separate question and is deliberately out of scope here.
`Request-Id`, `UCP-Agent`, `Accept-Language` and `Accept-Encoding` stay as
parameters in both files for the same reason.

**The two documents get an identical block.** The Common spec receives the same
`securitySchemes` definitions and the same `security` requirement, word for
word, so the two specifications state one contract rather than two dialects of
it.

## Scope

| File | Diff |
| --- | --- |
| `source/services/shopping/rest.openapi.json` | +22 / −129 |
| `source/services/common/rest.openapi.json` | +21 / −43 |

A scan of every document under `source/services/` confirms no other spec is
affected: `shopping/permalink.openapi.json` declares only query parameters, and
the four OpenRPC documents (`common/mcp`, `shopping/mcp`, `shopping/embedded`,
`payment-actions/embedded`) declare no `components.parameters` at all. After
this change no document in the repository declares `Authorization`, `Accept` or
`Content-Type` as a parameter.

Note that `x_api_key` was also referenced by the `orderEvent` webhook; the
document-level `security` requirement applies to webhook operations too, so the
webhook's authentication contract is preserved rather than dropped.

## Validation

Re-run on the rebased head, on top of `main` at `1d399483` (v2026-08-25):

- `ucp-schema lint source/` — 124 files checked, all passed; byte-identical
  output on `origin/main`, so no new lint surface.
- `uv run python scripts/validate_examples.py --schema-base source/schemas/` —
  343 passed, 0 failed, 0 errors, 50 skipped.
- `openapi-spec-validator` against the built artifact shape, with `info.version`
  injected the way `hooks.py::_set_schema_version` does at build time:
  **valid OpenAPI 3.1** for both documents after the change, and for the Common
  document before it — document validity is preserved, not merely unbroken.
- Structural checks on both files: no dangling parameter `$ref`s, no orphaned
  parameter definitions left behind, and every key in `security` resolves to a
  declared scheme.
- `mkdocs build --strict` — no content warnings. (The strict-mode warnings on my
  machine are all the same missing native `cairo` library used for social-card
  rendering, unrelated to this change.)
- The Common edit was applied as line-level surgery rather than a JSON
  round-trip, so the file keeps its existing compact `{ "$ref": ... }` style and
  the diff contains no reformatting noise.
- No rendered-docs regression: `main.py::method_fields` explicitly skips
  `in: header` parameters ("Filter out headers (transport-specific)"), so
  removing them changes no generated table. The prose references to `X-API-Key`
  in `shopping/cart/rest.md` and `shopping/checkout/rest.md` remain accurate —
  these headers are still sent on the wire; only their OpenAPI *declaration*
  moves.

## Rebase note

Force-pushed to rebase onto current `main` and to add the Common service fix.
No review comments were outstanding, so nothing was lost.
