### PR TITLE
fix: add --frozen to uv run in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,21 +25,21 @@ repos:
       #    invalidate examples across many docs (cross-file regression).
       - id: validate-examples-changed
         name: Validate JSON examples (changed docs)
-        entry: uv run python scripts/validate_examples.py --schema-base source/schemas/ --file
+        entry: uv run --frozen python scripts/validate_examples.py --schema-base source/schemas/ --file
         language: system
         pass_filenames: true
         files: ^docs/.*\.md$
         stages: [pre-commit, pre-push]
       - id: validate-examples-full
         name: Validate JSON examples (full corpus)
-        entry: uv run python scripts/validate_examples.py --schema-base source/schemas/
+        entry: uv run --frozen python scripts/validate_examples.py --schema-base source/schemas/
         language: system
         pass_filenames: false
         files: ^(source/schemas/|scripts/validate_examples\.py$)
         stages: [pre-commit, pre-push]
       - id: validate-examples-tests
         name: Validator unit tests
-        entry: uv run python scripts/test_validate_examples.py
+        entry: uv run --frozen python scripts/test_validate_examples.py
         language: system
         pass_filenames: false
         files: ^scripts/(validate_examples|test_validate_examples)\.py$


### PR DESCRIPTION
# Description

Addresses feedback from Ilya in #704. Added `--frozen` to `uv run` commands in pre-commit hooks to prevent them from re-resolving dependencies and modifying `uv.lock` based on developer-local configurations.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

- Related to #704 (post-merge feedback)

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.
