### PR TITLE
feat: add com.mercadopago.shopping.digital_delivery extension

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -179,3 +179,6 @@ zapatillas
 recoverably
 Honeycrisp
 unrepresentable
+mercadopago
+chargeback
+sunsetting

--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -180,3 +180,6 @@ zapatillas
 recoverably
 Honeycrisp
 unrepresentable
+mercadopago
+chargeback
+sunsetting

--- a/docs/specification/digital-delivery.md
+++ b/docs/specification/digital-delivery.md
@@ -1,0 +1,147 @@
+<!--
+   Copyright 2026 UCP Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# Digital Delivery Extension
+
+* **Capability Name:** `com.mercadopago.shopping.digital_delivery`
+* **Schema:** `https://ucp.dev/schemas/shopping/digital_delivery.json`
+
+## Overview
+
+The Digital Delivery extension lets a Business record **delivered digital /
+intangible goods** on the **Order** — gift-card codes, vouchers, top-up PINs,
+license keys, and access entitlements (a course, platform/SaaS access, a
+download). Unlike an in-session payment artifact, a delivered artifact **outlives
+the checkout session**: a code can be redeemed weeks later, and "has it been
+redeemed yet?" is a question an agent must be able to ask long after the order
+closed. So the record lives on the durable [Order](order.md), not on the
+checkout.
+
+The extension deliberately stores **only a durable reference and a way to ask
+the issuer** — never the balance, validity, or redemption status. The issuer is
+the single source of truth; current state is always obtained by querying it, so
+there is no cached copy on the Order for an integrator to trust once it is
+stale.
+
+This is a vendor-namespaced capability. The **capability** is
+`com.mercadopago.shopping.digital_delivery`; it adds a `digital_delivery` record
+to the Order and the shape of its artifacts.
+
+**Key features:**
+
+* Two delivery shapes via `kind`: a bearer **`redeemable_artifact`** (drawn down
+  at an issuer) and an **`entitlement`** (a granted, revocable right)
+* Durable **issuer reference** plus a defined **lookup** — the Order stores the
+  pointer, never the balance
+* Redemption — including **partial** redemption — resolved against the issuer,
+  which models it as an append-only ledger; the Order never keeps a copy or
+  collapses it into a status flag
+* Inert display data (code / QR image / hosted instructions) under the same
+  render/trust rules as other display artifacts
+
+**Dependencies:**
+
+* Order Capability
+
+**Scope (prototype-first).** This extension is the vendor-namespaced,
+no-core-change piece: recording the delivered artifact and its redemption
+lifecycle on the Order. Reconciling the `digital` `method_type` in
+`expectation.json`/`fulfillment.md` and adding a non-postal
+`expectation.destination` (phone, email, account) are **core** changes and are
+tracked separately as Enhancement Proposals. Discussion:
+[#648](https://github.com/Universal-Commerce-Protocol/ucp/discussions/648).
+
+## Discovery
+
+Businesses advertise this extension in their profile, extending the Order
+capability:
+
+<!-- ucp:example schema=profile def=business_schema extract=$.ucp.capabilities target=$.ucp.capabilities -->
+```json
+{
+  "ucp": {
+    "version": "{{ ucp_version }}",
+    "capabilities": {
+      "com.mercadopago.shopping.digital_delivery": [
+        {
+          "version": "{{ ucp_version }}",
+          "extends": ["dev.ucp.shopping.order"],
+          "spec": "https://ucp.dev/{{ ucp_version }}/specification/digital-delivery",
+          "schema": "https://ucp.dev/{{ ucp_version }}/schemas/shopping/digital_delivery.json"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Schema
+
+When this extension is active, the Order carries a `digital_delivery` array —
+one entry per delivered artifact. Each artifact is described below.
+
+### Delivered Artifact
+
+{{ extension_schema_fields('digital_delivery.json#/$defs/artifact', 'digital_delivery') }}
+
+## State and Trust Contract
+
+The Order carries **a pointer, never the authoritative state.** Redemption state
+(a balance that decrements, a validity window that can be revoked) is owned by
+the issuer and changes without the order ever being touched — a chargeback, a
+ToS termination, the issuer sunsetting a product. Storing it on the order would
+turn every integrator into a reader of a stale copy. Implementations MUST honor:
+
+* **`reference` is the durable pointer.** It identifies the artifact at the
+  issuer for lookup. It is not the balance and not a credential to spend.
+* **`lookup` is how you ask.** Current state is obtained *only* by querying the
+  issuer via `lookup.url` (an `https:` origin allowlist), keyed by `reference`.
+* **No cached state on the Order.** The Order carries no balance, validity, or
+  redemption status — not even as an advisory copy — so there is nothing stale
+  to trust. A Platform MUST NOT release funds, grant access, or deny a
+  redemption without a fresh issuer answer.
+* **Display data is inert.** `code` is display text, `image` is a static image
+  only (`data:`/`https:`), and `instructions_url` is the only loadable field
+  (`https:` origin allowlist, opened as a plain document).
+
+## Lifecycle
+
+**Delivery is not terminal, and it is not settlement.**
+
+* `delivered` means the buyer received the artifact (the code/entitlement is
+  usable). It does **not** mean the artifact was redeemed, and it does **not**
+  mean funds settled. A settlement rail MUST NOT wire "delivered" to "release
+  funds": a delivered code may never be redeemed, or may be revoked later.
+* **`redeemable_artifact`** is drawn down at the issuer. The issuer models
+  redemption — including **partial** redemption — as an append-only ledger,
+  never a single terminal flag, so the history a dispute needs is preserved.
+  "How much is left" is answered by querying the issuer via `lookup`.
+* **`entitlement`** is a granted right with a validity window. It can be revoked
+  by the issuer for reasons the order never sees; "is this still valid, until
+  when" is answered by querying the issuer via `lookup`.
+
+## Out of Scope
+
+* **Delivery destination and vocabulary.** Capturing a non-postal delivery target
+  at checkout (phone for a top-up, email for a voucher, account/device for
+  e-SIM), and reconciling the `digital` `method_type` contradiction between
+  `expectation.json` and `fulfillment.md`, are **core** changes tracked as
+  separate Enhancement Proposals.
+* **Recurring/renewable entitlements.** Time-boxed access that renews on a
+  schedule (subscriptions) is payment-terms/recurring-billing territory
+  (see [#587](https://github.com/Universal-Commerce-Protocol/ucp/issues/587),
+  [#629](https://github.com/Universal-Commerce-Protocol/ucp/issues/629)); this
+  extension records the entitlement and its validity, not its billing schedule.

--- a/docs/specification/digital-delivery.md
+++ b/docs/specification/digital-delivery.md
@@ -46,9 +46,9 @@ to the Order and the shape of its artifacts.
   at an issuer) and an **`entitlement`** (a granted, revocable right)
 * Durable **issuer reference** plus a defined **lookup** — the Order stores the
   pointer, never the balance
-* Redemption — including **partial** redemption — resolved against the issuer,
-  which models it as an append-only ledger; the Order never keeps a copy or
-  collapses it into a status flag
+* Redemption — including **partial** redemption — reported through a typed
+  issuer lookup response (never stored on the Order), so partial state stays
+  expressible and is not collapsed into a boolean
 * Inert display data (code / QR image / hosted instructions) under the same
   render/trust rules as other display artifacts
 
@@ -97,6 +97,13 @@ one entry per delivered artifact. Each artifact is described below.
 
 {{ extension_schema_fields('digital_delivery.json#/$defs/artifact', 'digital_delivery') }}
 
+### Issuer Lookup Response
+
+The shape the issuer returns from `lookup.url`. This is the authoritative,
+live-queried state — it is never stored on the Order.
+
+{{ extension_schema_fields('digital_delivery.json#/$defs/lookup_response', 'digital_delivery') }}
+
 ## State and Trust Contract
 
 The Order carries **a pointer, never the authoritative state.** Redemption state
@@ -105,14 +112,23 @@ the issuer and changes without the order ever being touched — a chargeback, a
 ToS termination, the issuer sunsetting a product. Storing it on the order would
 turn every integrator into a reader of a stale copy. Implementations MUST honor:
 
-* **`reference` is the durable pointer.** It identifies the artifact at the
-  issuer for lookup. It is not the balance and not a credential to spend.
-* **`lookup` is how you ask.** Current state is obtained *only* by querying the
-  issuer via `lookup.url` (an `https:` origin allowlist), keyed by `reference`.
+* **`reference` is the durable pointer, not a credential.** It identifies the
+  artifact at the issuer for lookup; it is not the balance and not a credential
+  to spend. Because it is opaque but not necessarily unguessable, the issuer
+  MUST authenticate the caller of `lookup.url`; disclosing state to any holder of
+  `reference` is not acceptable unless the extension explicitly says so.
+* **`lookup` is required, and it is how you ask.** Every artifact carries a
+  `lookup`; current state is obtained *only* by querying the issuer via
+  `lookup.url` (an `https:` origin allowlist), keyed by `reference`. The answer
+  conforms to the [Issuer Lookup Response](#issuer-lookup-response) shape and MUST
+  carry `as_of`, so a Platform can tell a live answer from a stale or cached one.
 * **No cached state on the Order.** The Order carries no balance, validity, or
   redemption status — not even as an advisory copy — so there is nothing stale
   to trust. A Platform MUST NOT release funds, grant access, or deny a
   redemption without a fresh issuer answer.
+* **Fail closed when the issuer is unreachable.** If a fresh answer cannot be
+  obtained, the Platform MUST NOT act (no release, grant, or denial) and MUST NOT
+  fall back to a cached copy — the absence of an answer is not a state.
 * **Display data is inert.** `code` is display text, `image` is a static image
   only (`data:`/`https:`), and `instructions_url` is the only loadable field
   (`https:` origin allowlist, opened as a plain document).
@@ -121,17 +137,24 @@ turn every integrator into a reader of a stale copy. Implementations MUST honor:
 
 **Delivery is not terminal, and it is not settlement.**
 
-* `delivered` means the buyer received the artifact (the code/entitlement is
-  usable). It does **not** mean the artifact was redeemed, and it does **not**
-  mean funds settled. A settlement rail MUST NOT wire "delivered" to "release
-  funds": a delivered code may never be redeemed, or may be revoked later.
-* **`redeemable_artifact`** is drawn down at the issuer. The issuer models
-  redemption — including **partial** redemption — as an append-only ledger,
-  never a single terminal flag, so the history a dispute needs is preserved.
-  "How much is left" is answered by querying the issuer via `lookup`.
+* The presence of `delivered_at` means the buyer received the artifact (the
+  code/entitlement is usable). It does **not** mean the artifact was redeemed,
+  and it does **not** mean funds settled. This extension records the delivery
+  timestamp; it does not define a core Order state named `delivered`.
+* **Delivery does not release funds.** A settlement rail MUST NOT wire delivery
+  to "release funds": a delivered code may never be redeemed, or may be revoked
+  later. The release trigger is agreed by the rail out of band — a redemption
+  event, a dispute window expiring, an issuer attestation — and this extension's
+  contribution is the `lookup` that makes such a trigger checkable.
+* **`redeemable_artifact`** is drawn down at the issuer. Redemption — including
+  **partial** redemption — is expressed through the [lookup
+  response](#issuer-lookup-response), which MUST be able to report partial state
+  (`status: partially_redeemed` with a `remaining` balance), not merely redeemed
+  or not, so the history a dispute needs is not collapsed. "How much is left" is
+  answered by querying the issuer.
 * **`entitlement`** is a granted right with a validity window. It can be revoked
   by the issuer for reasons the order never sees; "is this still valid, until
-  when" is answered by querying the issuer via `lookup`.
+  when" is answered by the lookup response's `valid_until`.
 
 ## Out of Scope
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
               - Transports:
                   - REST: specification/shopping/order/rest.md
                   - MCP: specification/shopping/order/mcp.md
+              - Digital Delivery Extension: specification/digital-delivery.md
           - Playground: specification/shopping/playground.md
       - Payment:
           - Payment Authentication:
@@ -479,6 +480,12 @@ plugins:
               Model Context Protocol (MCP) transport binding for the Order
               Capability, detailing the JSON-RPC tool interface and parameters
               for fetching order states.
+          - specification/digital-delivery.md: >-
+              Digital Delivery Extension on the Order Capability, recording
+              delivered digital / intangible goods (gift-card codes, vouchers,
+              top-up PINs, license keys, and access entitlements) as durable
+              artifacts with an issuer reference and lookup, a delivered vs
+              redeemed lifecycle, and append-only partial-redemption draws.
         Payment:
           - specification/payment/authentication.md: >-
               Payment Authentication Extension, defining negotiation,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
           - Transports:
               - REST: specification/order-rest.md
               - MCP: specification/order-mcp.md
+          - Digital Delivery Extension: specification/digital-delivery.md
       - Identity Linking Capability: specification/identity-linking.md
       - Payment Handlers:
           - Guide: specification/payment-handler-guide.md
@@ -417,6 +418,12 @@ plugins:
               Model Context Protocol (MCP) transport binding for the Order
               Capability, detailing the JSON-RPC tool interface and parameters
               for fetching order states.
+          - specification/digital-delivery.md: >-
+              Digital Delivery Extension on the Order Capability, recording
+              delivered digital / intangible goods (gift-card codes, vouchers,
+              top-up PINs, license keys, and access entitlements) as durable
+              artifacts with an issuer reference and lookup, a delivered vs
+              redeemed lifecycle, and append-only partial-redemption draws.
           - specification/identity-linking.md: >-
               User authentication via the Identity Linking Capability,
               specifying direct B2C/B2B OAuth 2.0 flows (with PKCE and

--- a/source/schemas/shopping/digital_delivery.json
+++ b/source/schemas/shopping/digital_delivery.json
@@ -9,7 +9,7 @@
       "type": "object",
       "title": "Delivered Artifact",
       "description": "One digital artifact delivered by the order. Carries the inert data the buyer acts on plus a durable issuer reference; it does not carry authoritative mutable state.",
-      "required": ["id", "kind", "reference", "delivered_at"],
+      "required": ["id", "kind", "reference", "lookup", "delivered_at"],
       "properties": {
         "id": {
           "type": "string",
@@ -40,14 +40,49 @@
     "lookup": {
       "type": "object",
       "title": "Issuer Status Lookup",
-      "description": "How a Platform asks the issuer for the artifact's current state. The issuer is the single source of truth; the Platform MUST NOT treat a stored snapshot as authoritative.",
+      "description": "How a Platform asks the issuer for the artifact's current state. The issuer is the single source of truth; the Platform obtains state only by querying here and MUST NOT store or trust a snapshot. The issuer MUST authenticate the caller — 'reference' identifies the artifact but is not an authorization credential, so an unauthenticated GET keyed by 'reference' MUST NOT be used to disclose state. The issuer's answer conforms to '#/$defs/lookup_response'.",
       "required": ["url"],
       "properties": {
         "url": {
           "type": "string",
           "format": "uri",
-          "description": "HTTPS endpoint the Platform queries (GET) for current artifact state, keyed by 'reference'. MUST be constrained to an 'https:' origin allowlist advertised for the handler."
+          "description": "HTTPS endpoint the Platform queries for current artifact state, keyed by 'reference'. MUST be constrained to an 'https:' origin allowlist advertised for the handler, and MUST require caller authentication."
         }
+      }
+    },
+    "lookup_response": {
+      "type": "object",
+      "title": "Issuer Lookup Response",
+      "description": "The normative shape the issuer returns from 'lookup.url'. This is the authoritative state; it is queried live and never stored on the Order. It MUST carry 'as_of' so a Platform can distinguish a live issuer answer from a stale/cached one.",
+      "required": ["status", "as_of"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["active", "partially_redeemed", "redeemed", "expired", "revoked"],
+          "description": "Current artifact status at the issuer. 'partially_redeemed' MUST be expressible so redemption history is not collapsed into a redeemed/not-redeemed boolean."
+        },
+        "as_of": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 timestamp at which the issuer computed this answer. A Platform MUST use it to reject stale responses; without it a live answer is indistinguishable from a cached one."
+        },
+        "remaining": {
+          "$ref": "../common/types/amount.json",
+          "description": "For 'redeemable_artifact': remaining balance in ISO 4217 minor units. Together with 'currency', expresses partial redemption. Omitted for 'entitlement'."
+        },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$",
+          "description": "For 'redeemable_artifact': ISO 4217 currency code of 'remaining'."
+        },
+        "valid_until": {
+          "type": "string",
+          "format": "date-time",
+          "description": "For 'entitlement': end of the current validity window. The issuer MAY shorten it (revocation) at any time. Omitted for 'redeemable_artifact'."
+        }
+      },
+      "dependentRequired": {
+        "remaining": ["currency"]
       }
     },
     "display": {

--- a/source/schemas/shopping/digital_delivery.json
+++ b/source/schemas/shopping/digital_delivery.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/digital_delivery.json",
+  "name": "com.mercadopago.shopping.digital_delivery",
+  "title": "Digital Delivery Extension",
+  "description": "Extends Order with delivered artifacts for digital / intangible goods (gift-card codes, vouchers, top-up PINs, license keys, and access entitlements). The Order carries a durable reference to each artifact plus a defined way to query the issuer for its current state; mutable redemption state (balance, validity) is never stored as authoritative on the Order. The record lives on the durable Order so it outlives the checkout session.",
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "title": "Delivered Artifact",
+      "description": "One digital artifact delivered by the order. Carries the inert data the buyer acts on plus a durable issuer reference; it does not carry authoritative mutable state.",
+      "required": ["id", "kind", "reference", "delivered_at"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable identifier for this delivered artifact within the order."
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["redeemable_artifact", "entitlement"],
+          "description": "Delivery shape. 'redeemable_artifact' is a bearer value drawn down/redeemed at an issuer (gift card, voucher, top-up PIN, license key) — the standing question is 'how much is left?'. 'entitlement' is a granted right whose standing question is 'is this still valid, and until when?' (course, platform/SaaS access, download)."
+        },
+        "reference": {
+          "type": "string",
+          "description": "Durable, opaque issuer reference for this artifact — the pointer the Platform uses to query the issuer. Not buyer-facing; it is neither the balance nor a credential to spend."
+        },
+        "lookup": {
+          "$ref": "#/$defs/lookup"
+        },
+        "display": {
+          "$ref": "#/$defs/display"
+        },
+        "delivered_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 timestamp when the artifact was delivered to the buyer. Delivery is neither settlement nor redemption (see the specification)."
+        }
+      }
+    },
+    "lookup": {
+      "type": "object",
+      "title": "Issuer Status Lookup",
+      "description": "How a Platform asks the issuer for the artifact's current state. The issuer is the single source of truth; the Platform MUST NOT treat a stored snapshot as authoritative.",
+      "required": ["url"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "HTTPS endpoint the Platform queries (GET) for current artifact state, keyed by 'reference'. MUST be constrained to an 'https:' origin allowlist advertised for the handler."
+        }
+      }
+    },
+    "display": {
+      "type": "object",
+      "title": "Delivered Artifact Display",
+      "description": "Public, inert data the buyer acts on to use the artifact (the code to enter, a QR image, or hosted instructions). Display data only. Render fields are non-executable — 'image' is shown as a static image (never HTML or script), 'code' is display text, and 'instructions_url' is the only loadable field.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The redeemable code / PIN / license key as display text. The Platform SHOULD offer a copy affordance. MUST NOT be interpreted as a URL or executed."
+        },
+        "image": {
+          "type": "string",
+          "format": "uri",
+          "description": "Optional QR (or equivalent) image encoding the artifact, as a 'data:' or 'https:' URI. The Platform MUST render it as a static image only and MUST NOT execute, parse, or fetch it as anything other than image bytes."
+        },
+        "instructions_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Optional hosted, human-readable redemption instructions. The ONLY loadable field; the Platform MUST constrain it to an 'https:' origin allowlist advertised for the handler and MUST NOT auto-submit or pass buyer data to it."
+        }
+      }
+    },
+    "digital_delivery": {
+      "type": "array",
+      "title": "Digital Delivery",
+      "description": "Delivered digital artifacts for this order. Typically one; more when a single order fulfils multiple digital line items.",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/artifact"
+      }
+    },
+    "dev.ucp.shopping.order": {
+      "title": "Order with Digital Delivery",
+      "description": "Order whose delivered digital artifacts (codes, vouchers, entitlements) persist on the durable order and are resolved against the issuer, not by holding the checkout session open.",
+      "allOf": [
+        {
+          "$ref": "order.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "digital_delivery": {
+              "$ref": "#/$defs/digital_delivery"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `com.mercadopago.shopping.digital_delivery`, a vendor-namespaced **Order
extension** for **digital / intangible goods delivery** — gift-card codes,
vouchers, top-up PINs, license keys, and access entitlements. Prototypes the
shape discussed in #648.

## Why this shape

- **Attaches to the durable Order.** A delivered artifact outlives the checkout
  session (a code can be redeemed weeks later), so the record lives on the Order,
  not the checkout.
- **`kind` discriminator** — `redeemable_artifact` (bearer value drawn down at an
  issuer; "how much is left?") vs `entitlement` (a granted, revocable right;
  "still valid, until when?").
- **Pointer, not balance.** The Order stores only a durable `reference` + a
  `lookup` to query the issuer. No mutable state (balance, validity, redemption
  status) is cached on the Order — there is no stale copy to trust. Partial
  redemption lives at the issuer as an append-only ledger, obtained via `lookup`.
- **Delivery ≠ settlement ≠ redemption.** `delivered` is not terminal; a
  settlement rail must not release funds on delivery.
- Inert display data (code / QR image / hosted instructions) under the same
  render/trust rules as #635.

## Scope

Vendor extension, no core change. Reconciling the `digital` `method_type`
contradiction (`expectation.json` / `fulfillment.md`) and adding a non-postal
`expectation.destination` are **core** and tracked as separate Enhancement
Proposals.

## Changes

- `source/schemas/shopping/digital_delivery.json` — extension schema
- `docs/specification/digital-delivery.md` — spec (discovery, schema, state/trust
  contract, lifecycle, scope)
- `mkdocs.yml` — nav under Order Capability + llmstxt entry
- `.cspell/custom-words.txt` — domain terms

## Related

- Discussion #648 (digital goods delivery) — the prototype-first, vendor piece.
- Sibling of #635 (in-session render artifact) — reuses the inert display/trust
  contract.
