### PR TITLE
docs: index Split Payments and the Glossary in llms.txt

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -341,6 +341,12 @@ plugins:
               memberships, tiers, benefits, and reward earning forecasts while
               managing provisional eligibility claims and enforcing
               data-minimization privacy rules.
+          - specification/split-payments.md: >-
+              Split Payments Extension, enabling a single checkout to be paid
+              with multiple instruments by defining business-declared allowed
+              combinations, specified- and open-amount contributions,
+              per-instrument charge reporting, and all-or-nothing failure
+              handling.
         Cart Capability:
           - specification/cart.md: >-
               Pre-purchase Cart Capability, detailing item collection, state

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -277,6 +277,11 @@ plugins:
           - specification/overview.md: >-
               Master technical specification of UCP, discovery mechanisms,
               secure transports, and error taxonomies.
+          - specification/glossary.md: >-
+              Definitions of the protocol, commerce, payment, regulatory, and
+              standards terms and acronyms used throughout the specification,
+              including Capability, Extension, Action, Platform, Business, and
+              Merchant of Record.
         Message Signatures:
           - specification/signatures.md: >-
               Implementation details for RFC 9421 HTTP Message Signatures and


### PR DESCRIPTION
## Summary

Add `specification/split-payments.md` and `specification/glossary.md` to the
`llmstxt` `sections` allowlist so both reach the published `llms.txt`.

## Motivation

`plugins.llmstxt.sections` is a strict allowlist. Comparing it against `nav`:

- `specification/split-payments.md` is the **only** one of the 45 nav pages
  missing from it. `git log -S` traces this to #409, which added the nav entry
  without the llmstxt entry; later feature PRs (#458, #523) added both, so this
  is a lone omission rather than a policy.
- `specification/glossary.md` is in neither, and has been since #241 — while
  being extended by #582, #657 and #653. It is reachable only through a prose
  link at `overview.md`.

`AGENTS.md` §2 asks for exactly this: *"Sync any MkDocs navigation additions
(`mkdocs.yml`) with the `llmstxt` plugin section to ensure that content is
discoverable and legible by agents."*

Confirmed against the built artifact before the change:
`dev.ucp.shopping.split_payments` appears twice in `llms-full.txt` and **zero**
times in `llms.txt`; same for the Glossary.

## Scope

One file, two commits — the split-payments entry is a drift fix under the
AGENTS.md rule, while indexing the Glossary is a new editorial decision, so
they are separable if you want only one.

Two things checked and deliberately left alone:

- **`specification/embedded-protocol.md` appears in both the Checkout and Cart
  sections, and in neither nav entry.** Left as-is: it is a shared transport page
  referenced by both capabilities, so the duplication reads as intentional and
  keeps each capability index self-contained. It does cost ~30KB of duplicated
  content in `llms-full.txt`; happy to dedupe in a follow-up if you prefer.
- **The Glossary is not added to `nav`.** Whether an orphan page belongs in site
  navigation is an IA decision rather than an index-drift fix (there is precedent
  for llms.txt-only pages: `embedded-protocol.md`). Happy to add the nav entry
  too if you want it.

## Validation

`mkdocs build --strict` exit 0 under both `DOCS_MODE=spec` and `DOCS_MODE=root`.

`llms.txt` diff against `main` is **exactly the two new lines** (86 → 88); the
`llms-full.txt` diff is purely additive with no other page affected; and the
`DOCS_MODE=root` output is byte-identical to `main`.

`ucp-schema lint source/` 100 files passed; `validate_examples.py` 302 passed,
0 failed. yamllint reports no new diagnostic on the added lines.

Note for release branches: `split-payments.md` does not exist on any release
branch, and `sections` entries pointing at a missing page fail `--strict`, so
these two lines should not be cherry-picked.
