### PR TITLE
fix: isolate example schema cache by root

### DIFF
--- a/scripts/test_validate_examples.py
+++ b/scripts/test_validate_examples.py
@@ -594,6 +594,38 @@ def test_process_block_integration() -> None:
   )
 
 
+def test_resolve_schema_cache_key() -> None:
+  """Resolved schemas are cached per schema root as well as schema identity."""
+  original_run = v.subprocess.run
+  calls: list[Path] = []
+
+  def fake_run(*args: object, **kwargs: object) -> object:
+    cwd = Path(str(kwargs["cwd"]))
+    calls.append(cwd)
+    return v.subprocess.CompletedProcess(
+      args[0], 0, stdout=json.dumps({"schema_root": cwd.name}), stderr=""
+    )
+
+  v._schema_cache.clear()
+  v.subprocess.run = fake_run
+  try:
+    with tempfile.TemporaryDirectory() as tmp:
+      base_a = Path(tmp, "a", "schemas")
+      base_b = Path(tmp, "b", "schemas")
+      base_a.mkdir(parents=True)
+      base_b.mkdir(parents=True)
+
+      first = v.resolve_schema("shopping/checkout", "response", "read", base_a)
+      cached = v.resolve_schema("shopping/checkout", "response", "read", base_a)
+      second = v.resolve_schema("shopping/checkout", "response", "read", base_b)
+
+    _check("schema_cache_same_base_hits", first == cached and len(calls) == 2)
+    _check("schema_cache_separates_bases", first != second, f"got {second!r}")
+  finally:
+    v.subprocess.run = original_run
+    v._schema_cache.clear()
+
+
 # -----------------------------------------------------------
 # Main
 # -----------------------------------------------------------
@@ -610,6 +642,7 @@ def main() -> int:
   test_annotation_parsing()
   test_extract_blocks()
   test_scaffold_resolution()
+  test_resolve_schema_cache_key()
   test_process_block_integration()
   return _report()
 

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -641,7 +641,7 @@ def resolve_schema(
   schema_base: Path,
 ) -> dict:
   """Resolve a schema via ucp-schema, with caching."""
-  key = (schema_path, direction, op)
+  key = (schema_base.resolve(), schema_path, direction, op)
   if key in _schema_cache:
     return _schema_cache[key]
 


### PR DESCRIPTION
## Description

`scripts/validate_examples.py::resolve_schema()` reads schemas from the supplied
`schema_base`, but its process-local cache omitted that argument:

```python
full_path = schema_base / f"{schema_path}.json"
...
key = (schema_path, direction, op)
```

Calling the helper for the same schema, direction, and operation under two
schema roots therefore returned the first root's resolved schema for the second
call. The second `ucp-schema resolve` was never executed.

**Fix:** include the normalized schema root in the cache key. The contract test
covers both sides: repeated calls under one root still hit the cache, while two
roots resolve independently.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [x] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A — script-only cache fix. Validation: 52 contract tests, 302 documentation
examples, and all pre-commit hooks passed.
