### PR TITLE
docs(identity-linking): repair the garbled JWT grant single-use bullet

### DIFF
--- a/docs/specification/common/identity-linking/index.md
+++ b/docs/specification/common/identity-linking/index.md
@@ -1018,10 +1018,10 @@ field conveys the business's value prompt to the platform (e.g.,
 * **JWT grant lifetime.** JWT authorization grants **MUST** be short-lived;
   the `exp` claim **SHOULD** be no more than 60 seconds after `iat`. Short
   lifetimes limit the window for grant theft and replay.
-* **JWT grant single-use.** Businesses **MUST** enforce single-use JWT;
-  a short exp narrows the replay window, but only jti tracking closes it.
+* **JWT grant single-use.** Businesses **MUST** enforce single-use JWT
   authorization grants by tracking the `jti` claim within the grant's
-  validity window.
+  validity window. A short `exp` narrows the replay window, but only
+  `jti` tracking closes it.
 * **Grant relay.** Businesses **MUST NOT** store or forward JWT
   authorization grants received from platforms. Grants are bearer
   credentials scoped to a single audience (`aud`) and a single use.


### PR DESCRIPTION
The JWT grant single-use bullet in Security Considerations reads as a broken sentence: an explanatory clause was inserted mid-sentence, leaving the requirement itself split across a full stop.

Currently:

> Businesses **MUST** enforce single-use JWT;
> a short exp narrows the replay window, but only jti tracking closes it.
> authorization grants by tracking the `jti` claim within the grant's
> validity window.

This PR restores the requirement as one sentence and keeps the explanation after it, with `exp` and `jti` in code formatting to match their use in the neighbouring bullets. No normative change: the MUST, the mechanism, and the window are the same.
