### PR TITLE
docs: fix stale references found in fact-accuracy audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,6 @@ Validate your changes locally using these commands before considering a task com
 Then validate your changes with:
 
 * **Lint Schemas:** `ucp-schema lint source/` (after schema changes)
-* **Regenerate SDK Models:** `bash sdk/python/generate_models.sh` (after schema changes)
 * **Run Pre-commit Checks:** `pre-commit run --all-files` (after all changes)
 * **Execute Local Super-Linter:** `./scripts/super_linter_local.py` (requires docker or podman)
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ including spec versions:
 ./scripts/build_local.sh
 ```
 
-This will build the site and start a local server. You can use the
+This will build the full site into `local_preview/` and print the command to
+serve it (see below) — it does not start a server itself. You can use the
 `--draft-only` flag to skip release branches and only build the current draft:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ucp"
-version = "2026.04.08"
+version = "2026.01.23"
 description = "Universal Commerce Protocol"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ucp"
-version = "2026.01.23"
+version = "2026.04.08"
 description = "Universal Commerce Protocol"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- `AGENTS.md`: drops the "Regenerate SDK Models" step referencing `sdk/python/generate_models.sh` — that path has never existed in this repo (confirmed via full git history search); SDKs are published from separate org repos per README.md's own "Use our SDKs" section.
- `README.md`: corrects the `build_local.sh` description — it builds the site only and does not start a local server (confirmed by reading the script, which ends by printing the serve command rather than running one). `AGENTS.md` already documented this correctly as two separate steps.
- `pyproject.toml`: version pin left unchanged — an earlier commit on this branch bumped it to match the current release, then reverted that change since package versioning is the maintainers' release-process concern, not a doc correction.

## Test plan
- [ ] Confirm `sdk/python/generate_models.sh` genuinely doesn't exist anywhere in this repo's history
- [ ] Confirm `build_local.sh`'s actual behavior matches the corrected description