### PR TITLE
add path targeting to Request Constraints

### DIFF
--- a/docs/documentation/schema-authoring.md
+++ b/docs/documentation/schema-authoring.md
@@ -530,37 +530,35 @@ This section covers only the schema-authoring boundary.
 
 `request_constraints` is centrally registered in `ucp.json#/$defs/members` as a
 response-only protocol member with `ucp_request: "omit"`. Capability, extension,
-and shared type schemas do not redeclare it. A conforming UCP-aware resolver
-materializes the registered member into eligible response scopes so ordinary
-resolved-schema validation applies the shared schema.
+handler, and shared type schemas do not redeclare it. A conforming UCP-aware
+resolver materializes the registered member into eligible response scopes so
+ordinary resolved-schema validation applies the shared schema.
 
 `schemas/common/types/constraint_expression.json` defines the closed Constraint
 Expression grammar. `schemas/common/types/request_constraints.json` binds that
-grammar to data in a subsequent UCP request and is the schema referenced by the
-registered member. An emitted value begins at an Object Constraint; Value
-Constraints occur only beneath its `properties` maps.
+grammar to data in the next UCP request and is the schema referenced by the
+registered member.
 
 | Position | Admitted members | Shape |
 | :-- | :-- | :-- |
 | Object Constraint | `required`, `properties` | `required` contains unique field names; `properties` maps field names to Object or Value Constraints; an empty object is a no-op. |
 | Value Constraint | `enum`, `const` | `enum` is non-empty and unique; at least one member is present; both apply when present together. |
 
-Only the listed members are admitted in an emitted value. Keywords the grammar
-uses to define this closed language do not become admitted members.
+The listed members define the grammar. A `request_constraints` value may
+additionally contain `path` at the top level.
 
-Add or change grammar members in `constraint_expression.json`.
-`request_constraints.json` defines only the binding to subsequent request data.
+Grammar changes belong in `constraint_expression.json`, and changes to the root
+Object Constraint must also be reflected in `request_constraints.json`.
 
 ### Annotations and applicability
 
 `constraint_expression.json` carries no `ucp_request` annotations. Its
-`required`, `properties`, `enum`, and `const` properties are Constraint
-Expression grammar syntax, not independently placeable UCP fields, so the
-grammar has no direction of its own.
+properties are Constraint Expression syntax, not independently placeable UCP
+fields, so the grammar has no direction of its own.
 
 Applicability belongs to the containing UCP property. Each UCP property that
 exposes a Constraint Expression owns whichever direction-specific applicability
-annotations that carrier calls for, and those annotations alone determine when
+annotations that property requires, and those annotations alone determine when
 the grammar is reachable. For `request_constraints`, the containing property is
 the member registered in `ucp.json#/$defs/members`; it remains
 `ucp_request: "omit"` and is the only place that member's response-only
@@ -570,11 +568,11 @@ response-only one without change.
 
 ### Constraint Expression grammar
 
-An emitted value and its nested constraint objects are JSON Schema Draft 2020-12
-Constraint Expression syntax, not structured UCP domain objects. Do not add or
-materialize ambient `ucp` inside them. The `properties` value is a field-name
-dictionary whose keys name target request fields; those keys are not ambient
-members.
+Except for the outer `path` member, an emitted value and its nested constraint
+objects are JSON Schema Draft 2020-12 Constraint Expression syntax, not
+structured UCP domain objects. Do not add or materialize ambient `ucp` inside
+them. The keys in a `properties` map name fields on a selected request object
+and are data, not ambient members.
 
 The containing `ucp` object still follows
 [The Reserved `ucp` Member](#the-reserved-ucp-member). A closed structured object

--- a/docs/specification/overview.md
+++ b/docs/specification/overview.md
@@ -177,58 +177,51 @@ uses the shared representation.
 After capabilities and extensions are negotiated, the resolved UCP request
 schema defines the fields and structure allowed for an operation. In an
 authoritative response, a Business can use `ucp.request_constraints` to signal
-additional rules it will apply when evaluating request data in a subsequent
+additional rules it will apply when evaluating request data in the next
 Platform request. For example, it can constrain a Line Item quantity to exactly
 `100` sale-basis steps or require a submitted payment instrument to include
 `billing_address`. A Platform can evaluate these constraints before submission,
 avoiding a round trip for request data the Business has already indicated it
 will reject.
 
-`ucp.request_constraints` applies only to authoritative operation responses. A
-Business or Platform **MUST** ignore the member if it receives it in a discovery
-profile or operation request.
+`ucp.request_constraints` is used only in authoritative operation responses and
+has no effect in discovery profiles or operation requests.
 
 ### Validation model
 
-Request Constraints combine with the resolved request schema to form the
-effective rules for subsequently submitted request data:
+A submitted request is valid under Request Constraints only if it satisfies the
+resolved request schema and every object selected by Request Constraints
+satisfies the corresponding Constraint Expression. Request Constraints only
+narrow the resolved request schema; they cannot make a request valid when that
+schema rejects it. A Business evaluates the request as follows:
 
 ```text
-effective_request_schema = allOf(
-  resolved_request_schema,
-  request_constraints
-)
+valid = validate(resolved_request_schema, request)
 
-validate(effective_request_schema, submitted_request_data)
-  = validate(resolved_request_schema, submitted_request_data)
-    AND validate(request_constraints, submitted_request_data)
+for each constraint:
+  objects = select(request, effective_path(constraint))
+  valid = valid AND validate_all(
+    constraint_expression(constraint),
+    objects
+  )
+
+return valid
 ```
 
-An implementation can construct the effective schema with JSON Schema `allOf`
-and validate the submitted request data once, or run the two validations
-separately. Both validations must pass for authoritative Business evaluation.
-Request Constraints can narrow the inputs allowed by the resolved request
-schema, but cannot make an input valid when that schema rejects it.
-
-A Platform **MUST** validate the `ucp.request_constraints` value against the
-shared [Request Constraints](site:schemas/common/types/request_constraints.json)
-schema before using it for preflight. This is ordinary JSON Schema Draft 2020-12
-validation.
+A Platform **MAY** perform the same checks as preflight. For each chosen value,
+the Platform **MUST** use its effective path and complete Constraint Expression.
+The Platform **MAY** submit the request regardless of the preflight result;
+Business evaluation is authoritative.
 
 ### Constraint Expression
 
-The Request Constraints schema binds the shared
-[Constraint Expression](site:schemas/common/types/constraint_expression.json)
-grammar to data in a subsequent UCP request. The grammar defines the closed
-constraint language used by a `request_constraints` value.
-
 A `request_constraints` value and every nested constraint object use embedded
-JSON Schema Draft 2020-12 language; they are not UCP domain objects. The grammar
-does not admit `ucp` inside them. The value of `properties` is a field-name
-dictionary whose keys name target request fields.
+JSON Schema Draft 2020-12 language. The outer value may additionally contain an
+optional `path`; nested constraint objects may not. The grammar does not admit
+`ucp`. Keys in `properties` name fields on selected request objects.
 
-The grammar has two closed positions. A `request_constraints` value begins at an
-Object Constraint; Value Constraints occur only as values in an Object
+The constraint begins at an Object Constraint. Object Constraints may nest
+through `properties`; Value Constraints occur only as values in an Object
 Constraint's `properties` map.
 
 | Position | Admitted members | Shape and behavior |
@@ -236,23 +229,67 @@ Constraint's `properties` map.
 | Object Constraint | `required`, `properties` | `required` is an array of unique field names. `properties` maps field names to Object or Value Constraints. An empty Object Constraint is a valid no-op at any Object Constraint position. |
 | Value Constraint | `enum`, `const` | `enum` is a non-empty array of unique JSON values. `const` is any JSON value. At least one member is present; when both are present, both apply. |
 
-No other member is admitted at either position.
+No other member is admitted at either grammar position.
+
+### Path
+
+`path` is optional. When omitted, the effective path is the
+[RFC 9535](https://www.rfc-editor.org/rfc/rfc9535.html){ target="_blank" }
+Normalized Path from the authoritative response root to the structured response
+object whose `ucp` member contains `request_constraints`. When the Business
+provides `path`, the Business **MUST** use a complete RFC 9535 JSONPath query
+evaluated against the next logical UCP request to that resource.
+
+An omitted path establishes positional correspondence for the next request, not
+stable identity: an array index still identifies that position if items reorder
+before that request. A Business **MUST** provide an explicit `path` when the
+Normalized Path of that structured response object does not identify the
+intended request objects. When a constraint must follow a stable identity into
+the next request, the Business **MUST** use an explicit query that encodes that
+association.
+
+A Business that constructs a query from data **MUST** serialize and escape each
+dynamic value as a valid RFC 9535 literal and **MUST NOT** use unsafe string
+concatenation.
+
+Before emitting a value, a Business **MUST** validate the complete value against
+the shared
+[Request Constraints](site:schemas/common/types/request_constraints.json)
+schema, and a Platform **MUST** do the same before using that value for
+preflight; `path` selects the objects and the remaining members form the
+[Constraint Expression](site:schemas/common/types/constraint_expression.json).
+
+The effective path is evaluated against the next request to the resource. A
+constraint is not tied to an operation name; it applies to every object its path
+selects. A path that selects zero objects has no effect. When
+`request_constraints` is in the response root's `ucp` member and `path` is
+omitted, that structured response object is the response root, so the effective
+path is `$`; the constraint applies only to the next request.
+
+If multiple paths select the same object, every corresponding Constraint
+Expression applies. The shared Request Constraints schema validates each value
+independently and cannot guarantee that expressions across overlapping paths can
+all be satisfied. A Business **MUST** ensure expressions that can apply to the
+same object are jointly satisfiable. Contradictory requirements on the same
+property are a Business authoring error.
+
+A Platform that performs preflight on overlapping values evaluates every value
+it chose; if any chosen value fails for the concrete request, preflight fails.
+There is no precedence or override.
 
 ### Guidelines
 
 #### Business
 
 A Business **MAY** include `ucp.request_constraints` in an authoritative
-response to describe rules it will enforce against request data in a subsequent
+response to describe rules it will enforce against request data in the next
 Platform request. The Business **MUST** emit Request Constraints that conform to
-the shared Request Constraints schema and **MUST** enforce every constraint it
-emits. If the submitted request data violates either the resolved request schema
-or the emitted constraints, the Business **MUST** treat it as invalid input and
-**MUST** report the failure through the operation's existing outcome and message
-contract.
+the shared Request Constraints schema, **MUST** use valid effective paths that
+select only objects, and **MUST** enforce every constraint it emits against that
+next request.
 
 A Business **SHOULD NOT** emit Request Constraints for rules that may change
-before the subsequent request unless it can continue to enforce the advertised
+before the next request unless it can continue to enforce the advertised
 constraint. Execution-time conditions such as inventory availability, fraud
 decisions, and payment authorization remain governed by the operation's existing
 outcomes and `messages`.
@@ -260,84 +297,146 @@ outcomes and `messages`.
 #### Platform
 
 A Platform **MAY** use `ucp.request_constraints` for preflight before submitting
-request data. It **MAY** evaluate any supported subset of valid constraints; a
-successful preflight does not establish that the request data satisfies every
-constraint emitted by the Business. If the value does not conform to the shared
-Request Constraints schema, the Platform **MUST** ignore it. Business
-enforcement remains authoritative regardless of whether the Platform uses
-Request Constraints for preflight.
+request data. It **MAY** evaluate any supported subset of values. This preflight
+is optional and advisory.
+
+A malformed or unsupported value, a value whose path selects a non-object, or a
+value the Platform cannot evaluate within its resource limits is unavailable
+for preflight, not a pass or failure. A Platform performing preflight **MUST**
+skip the whole unavailable value and continue with any other chosen values. If
+complete evaluation finds a violation, that value fails preflight.
+
+A successful preflight result covers only the values the Platform evaluated.
+UCP defines no new wire status or issue-marker field for preflight results.
 
 ### Scope and lifecycle
 
-Each operation that uses Request Constraints defines which data in a subsequent
-Platform request the constraints apply to. A later authoritative response
-replaces earlier Request Constraints for the same request data. If the later
-response omits `ucp.request_constraints`, the earlier constraints no longer
-apply.
+Each authoritative resource response from the Business supplies Request
+Constraints for the next request to that resource. The authoritative response
+to that request supplies the constraints for the following request and replaces
+the prior set. Omission clears the set. Invalid values in the new set do not
+preserve stale values, and sets are not merged by `path`.
+
+Only `request_constraints` values attached to eligible structured response
+objects under the [Reserved `ucp` Member](#the-ucp-protocol-namespace) rules
+make up the set; dictionary keys are data.
+
+A response without an authoritative resource supplies no Request Constraints
+set for a following request. A response containing an authoritative resource
+supplies the set even when it reports an application error. A partial
+authoritative resource representation supplies a set only when the resource
+contract defines its scope.
 
 ### Operation outcomes
 
-Request Constraints provide proactive, machine-evaluable preflight for a
-subsequent request; `messages` report outcomes from a submitted request,
-including runtime outcomes. Passing validation against the effective request
-schema establishes only schema validity, and the request can still fail other
-business rules. The containing operation's existing semantics, outcomes, and
-error contract apply; Request Constraints adds no outcome or error code.
+Request Constraints provide proactive, machine-evaluable preflight for the next
+request; `messages` report outcomes from a submitted request, including runtime
+outcomes. Passing validation against both the resolved request schema and
+Request Constraints establishes only schema validity; the request can still
+fail other Business rules. The containing operation's existing semantics and
+outcome/error contract, including `messages`, continue to govern
+submitted-request and runtime outcomes. Request Constraints add no outcome or
+error code.
 
 ### Examples
 
-#### Fixed item quantity
+#### Basket-wide and targeted quantities
 
-This Cart response constrains a Line Item's quantity in a subsequent Cart
-update.
+The following Cart responses are alternatives that illustrate different scopes.
 
-<!-- ucp:example schema=shopping/cart op=read direction=response -->
-```json
-{
-  "ucp": {
-    "version": "{{ ucp_version }}"
-  },
-  "id": "cart_123",
-  "line_items": [
+=== "Basket-wide"
+
+    <!-- ucp:example schema=shopping/cart op=read direction=response -->
+    ```json
     {
-      "id": "line_123",
-      "item": {
-        "id": "sku_123",
-        "title": "Bulk screws",
-        "price": 1200
-      },
-      "quantity": 100,
-      "totals": [
-        {"type": "subtotal", "amount": 120000},
-        {"type": "total", "amount": 120000}
-      ],
       "ucp": {
+        "version": "{{ ucp_version }}",
         "request_constraints": {
+          "path": "$['line_items'][*]",
           "properties": {
-            "quantity": {
-              "const": 100
+            "quantity": {"const": 1}
+          }
+        }
+      },
+      "id": "cart_123",
+      "line_items": [
+        {
+          "id": "line_123",
+          "item": {
+            "id": "sku_123",
+            "title": "Bulk screws",
+            "price": 1200
+          },
+          "quantity": 1,
+          "totals": [
+            {"type": "subtotal", "amount": 1200},
+            {"type": "total", "amount": 1200}
+          ]
+        }
+      ],
+      "currency": "USD",
+      "totals": [
+        {"type": "subtotal", "amount": 1200},
+        {"type": "total", "amount": 1200}
+      ]
+    }
+    ```
+
+=== "Targeted"
+
+    <!-- ucp:example schema=shopping/cart op=read direction=response -->
+    ```json
+    {
+      "ucp": {
+        "version": "{{ ucp_version }}"
+      },
+      "id": "cart_123",
+      "line_items": [
+        {
+          "id": "line_123",
+          "item": {
+            "id": "sku_123",
+            "title": "Bulk screws",
+            "price": 1200
+          },
+          "quantity": 100,
+          "totals": [
+            {"type": "subtotal", "amount": 120000},
+            {"type": "total", "amount": 120000}
+          ],
+          "ucp": {
+            "request_constraints": {
+              "path": "$['line_items'][?@['id'] == 'line_123']",
+              "properties": {
+                "quantity": {"const": 100}
+              }
             }
           }
         }
-      }
+      ],
+      "currency": "USD",
+      "totals": [
+        {"type": "subtotal", "amount": 120000},
+        {"type": "total", "amount": 120000}
+      ]
     }
-  ],
-  "currency": "USD",
-  "totals": [
-    {"type": "subtotal", "amount": 120000},
-    {"type": "total", "amount": 120000}
-  ]
-}
-```
+    ```
 
-The subsequent Line Item satisfies the effective request schema only when it has
-quantity `100` and meets every other Cart update requirement.
+The basket-wide response emits a root constraint that applies quantity `1` to
+every Line Item in the next request. The targeted response uses ambient local
+authoring and a stable-ID path to apply quantity `100` only to the Line Item
+whose `id` is `line_123`; stable-ID rebinding survives reorder. If that path
+finds no match, it selects zero objects and has no effect. These are separate
+responses and alternatives. Combining them as written would create
+contradictory constraints for `line_123` and is a Business authoring error.
 
 #### Locked negotiated discount codes
 
-This Checkout response has the Discount extension active. Its Request
-Constraints lock the negotiated discount-code array in a subsequent Checkout
-update.
+This Checkout response has the Discount extension active and advertises Request
+Constraints for the next Checkout Update request. Because `request_constraints`
+is in the Checkout response root's `ucp`, omitting `path` derives that
+structured response object's Normalized Path. For this root placement, the
+derived path is `$`, which selects the next request root.
 
 <!-- ucp:example schema=shopping/discount def=dev.ucp.shopping.checkout op=update direction=response -->
 ```json
@@ -400,15 +499,15 @@ update.
 }
 ```
 
-The subsequent Checkout update satisfies the effective request schema only when
-it meets every other Checkout update requirement, contains `discounts.codes`,
-and supplies exactly `["ACME-X7Q9-L2M4"]`.
+The next Checkout Update request is valid only if it satisfies the resolved
+request schema, contains `discounts.codes`, and supplies exactly
+`["ACME-X7Q9-L2M4"]`.
 
 #### Billing address on a submitted card instrument
 
 In this example, a Business emits `ucp.request_constraints` on an available card
-instrument to require `billing_address` on the card instrument submitted in a
-subsequent request:
+instrument to require `billing_address` in the next request if it contains a
+matching submitted card instrument:
 
 <!-- ucp:example schema=shopping/types/available_payment_instrument op=read direction=response -->
 ```json
@@ -416,15 +515,21 @@ subsequent request:
   "type": "card",
   "ucp": {
     "request_constraints": {
+      "path": "$['payment']['instruments'][?@['handler_id'] == 'processor_1' && @['type'] == 'card']",
       "required": ["billing_address"]
     }
   }
 }
 ```
 
-The payment-handler contract defines which submitted card instrument these
-constraints apply to. This example does not define card brands, credentials,
-support, availability, or payment policy.
+This fragment assumes its containing authoritative response payment-handler
+declaration has `id: processor_1`. The explicit `path` crosses from the
+response's `available_instruments[]` shape to submitted `payment.instruments[]`
+and matches instruments by `handler_id` and `type`. If the next request contains
+a match, the constraint requires `billing_address` on every matching instrument.
+The payment-handler or instrument contract defines any stronger association.
+This example does not define card brands, credentials, support, availability, or
+payment policy.
 
 ## Actions
 

--- a/docs/specification/payment-handler-guide.md
+++ b/docs/specification/payment-handler-guide.md
@@ -194,6 +194,15 @@ brands to `["visa", "mastercard"]`). In a Business profile and authoritative
 response, array order communicates preferred instrument presentation, earliest
 first.
 
+When an authoritative response includes `ucp.request_constraints` on an
+available instrument, the Business **MUST** include an explicit `path` because
+the available instrument's response Normalized Path does not identify submitted
+instruments. The path matches the containing handler's `id`
+to submitted `handler_id` and the available instrument's `type` to submitted
+`type`, and applies when the next request contains matching instruments.
+Payment-handler and instrument specifications define any stronger association
+the query needs. See [Request Constraints](overview.md#request-constraints).
+
 ---
 
 #### Handler Declaration Variants

--- a/source/schemas/common/types/request_constraints.json
+++ b/source/schemas/common/types/request_constraints.json
@@ -2,6 +2,26 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/common/types/request_constraints.json",
   "title": "Request Constraints",
-  "description": "Binds the shared Constraint Expression grammar to data in a subsequent UCP request.",
-  "$ref": "constraint_expression.json"
+  "description": "Binds the shared Constraint Expression grammar to data in the next UCP request to the same resource.",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "A complete RFC 9535 JSONPath query evaluated against the next logical UCP request to the same resource."
+    },
+    "required": {
+      "$ref": "constraint_expression.json#/properties/required"
+    },
+    "properties": {
+      "type": "object",
+      "description": "Constraints keyed by property name.",
+      "additionalProperties": {
+        "oneOf": [
+          {"$ref": "constraint_expression.json"},
+          {"$ref": "constraint_expression.json#/$defs/value_constraint"}
+        ]
+      }
+    }
+  },
+  "additionalProperties": false
 }

--- a/source/schemas/common/types/request_constraints.json
+++ b/source/schemas/common/types/request_constraints.json
@@ -13,13 +13,7 @@
       "$ref": "constraint_expression.json#/properties/required"
     },
     "properties": {
-      "type": "object",
-      "description": "Constraints keyed by property name.",
-      "additionalProperties": {
-        "oneOf": [
-          {"$ref": "constraint_expression.json"},
-          {"$ref": "constraint_expression.json#/$defs/value_constraint"}
-        ]
+      "$ref": "constraint_expression.json#/properties/properties"
       }
     }
   },


### PR DESCRIPTION
#655 defines a reusable closed Constraint Expression grammar, but the response location alone does not always identify the request data to validate. For example, a constraint attached to a response Line Item could mean the item at the same array position, the item with the same identity, or some other request object. The ambiguity becomes unavoidable when arrays reorder or when response and request shapes differ, such as an available payment instrument constraining a submitted instrument.

---

This PR adds an optional, outer-only `path` to Request Constraints. An explicit `path` is a complete RFC 9535 JSONPath query evaluated against the next logical UCP request to the same resource. When omitted, the effective path is derived from the RFC 9535 Normalized Path of the structured response object whose `ucp` member contains the constraint.

The omission behavior preserves concise ambient authoring. A constraint on the response root derives `$`; a constraint on a nested object derives that object's positional path. That positional correspondence is deterministic but does not imply stable identity. Authors use an explicit query when a rule must survive reordering, select multiple objects, or bridge different response and request shapes.

A path may select zero, one, or many objects. Zero matches have no effect, while every selected object must satisfy the complete Constraint Expression. Overlapping constraints compose conjunctively without precedence or override, and the Business must ensure potentially overlapping expressions are jointly satisfiable. These checks narrow the resolved request schema; they cannot make an otherwise invalid request valid.

## Binding shape

The chosen wire shape keeps `path` beside the root members of the expression:

```json
{
  "path": "$['line_items'][?@['id'] == 'line_123']",
  "properties": {
    "quantity": {"const": 100}
  }
}
```

One considered alternative was separating path from constraint expression: 

```json
{
  "path": "$['line_items'][?@['id'] == 'line_123']",
  "expression": {
    "properties": {
      "quantity": {"const": 100}
    }
  }
}
```

The benefit of the latter is that keeps expression strict subset of JSONSchema. The cost is permanent wire noise in the common case. Most constraints use ambient placement and omit `path`, so even a simple local requirement would need an otherwise meaningless wrapper:

```json
{
  "expression": {
    "required": ["billing_address"]
  }
}
```

The selected shape optimizes for the authoring and wire surface rather than schema-factoring purity. `constraint_expression.json` remains direction-neutral and contains no `path`; `request_constraints.json` is the closed binding that admits `path` only at its root and re-exposes the root Object Constraint members. Recursive constraints continue through the pure expression schema, so nested `path` members remain invalid. The trade-off is that future changes to the root Object Constraint must also be reflected in `request_constraints.json`.

This preserves the core invariant that one binding carries one schema. It avoids introducing a list of independently targeted rules, repeated navigation, target precedence, or another orchestration model alongside JSON Schema.