### PR TITLE
chore: support inline comment versions for super_linter_local.py

### DIFF
--- a/scripts/super_linter_local.py
+++ b/scripts/super_linter_local.py
@@ -16,11 +16,16 @@ def map_action_to_image(action_str):
   """Map GitHub Action string to ghcr.io image."""
   # super-linter/super-linter/slim@v8 ->
   # ghcr.io/super-linter/super-linter:slim-v8
-  match = re.match(r"super-linter/super-linter/(.*)@(.*)", action_str)
+  # super-linter/super-linter/slim@<hash> # v8.7.0 ->
+  # ghcr.io/super-linter/super-linter:slim-v8.7.0
+  match = re.match(
+    r"super-linter/super-linter/([^@\s]+)@(?:[0-9a-f]{40}\s*#\s*(\S+)|(\S+))",
+    action_str,
+  )
 
   if match:
     variant = match.group(1)
-    version = match.group(2)
+    version = match.group(2) or match.group(3)
     return f"ghcr.io/super-linter/super-linter:{variant}-{version}"
 
   return action_str
@@ -77,6 +82,12 @@ def main():
 
   lint_env = lint_step.get("env", {})
   action_uses = lint_step.get("uses", "")
+
+  for line in workflow_path.read_text().splitlines():
+    if "super-linter/super-linter" in line and "uses:" in line:
+      action_uses = line.split("uses:", 1)[1].strip()
+      break
+
   image = map_action_to_image(action_uses)
 
   cmd = [


### PR DESCRIPTION
# Description

When upgrading super linter to v8.7.0, we moved to hash-based versions to satisfy a pre-commit check. This PR fixes our super_linter_local.py script to be able to handle either hash versions with an inline comment specifying the tag or an explicit tag version.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [x] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.
