### PR TITLE
fix!: Location spatial relations and Lookup correlation

### DIFF
--- a/docs/specification/catalog/mcp.md
+++ b/docs/specification/catalog/mcp.md
@@ -710,5 +710,6 @@ A conforming MCP transport implementation **MUST**:
 4. Return successful result for lookup requests; unknown identifiers result in fewer products returned (MAY include informational `not_found` messages).
 5. Validate tool inputs against UCP schemas.
 6. Return products with valid `Price` objects (amount + currency).
-7. Support cursor-based pagination with default limit of 10.
+7. Support cursor-based pagination for Search according to the shared
+    pagination contract (see [Pagination](search.md#pagination)).
 8. Return `-32602` (Invalid params) for requests exceeding batch size limits.

--- a/docs/specification/catalog/rest.md
+++ b/docs/specification/catalog/rest.md
@@ -602,6 +602,7 @@ A conforming REST transport implementation **MUST**:
 
 1. Implement endpoints for each catalog capability advertised in the business's UCP profile, per their respective capability requirements ([Search](search.md), [Lookup](lookup.md)). Each capability may be adopted independently. When the Lookup capability is advertised, both `/catalog/lookup` and `/catalog/product` MUST be available.
 2. Return products with valid `Price` objects (amount + currency).
-3. Support cursor-based pagination with default limit of 10.
+3. Support cursor-based pagination for Search according to the shared
+    pagination contract (see [Pagination](search.md#pagination)).
 4. Return HTTP 200 for lookup requests; unknown identifiers result in fewer products returned (MAY include informational `not_found` messages).
 5. Return HTTP 400 with `request_too_large` error for requests exceeding batch size limits.

--- a/docs/specification/catalog/search.md
+++ b/docs/specification/catalog/search.md
@@ -63,16 +63,19 @@ merchants MAY support additional custom filters via `additionalProperties`.
 
 ## Pagination
 
-Cursor-based pagination for list operations. Cursors are opaque strings
-that implementations MAY encode as stateless keyset tokens.
+Cursor-based pagination for list operations. Cursors are opaque strings. A
+Business **MAY** encode them as stateless keyset tokens.
 
 ### Page Size
 
-The `limit` parameter is a requested page size, not a guaranteed count.
-Implementations SHOULD accept a page size of at least 10. When the
-requested limit exceeds the implementation's maximum, implementations
-MAY clamp to their maximum silently — returning fewer results without
-error. Clients MUST NOT assume the response size equals the requested limit.
+The `limit` parameter is a requested page size, not a guaranteed result
+count. When `limit` is omitted, the Business **MUST** apply a default page
+size. A default of 10 is **RECOMMENDED**, but the Business **MAY** choose
+another value.
+
+The Business **MAY** return fewer results than the requested or default page
+size, including when enforcing its maximum page size. A Platform **MUST NOT**
+assume that the response count equals either value.
 
 ### Pagination Request
 

--- a/docs/specification/location/index.md
+++ b/docs/specification/location/index.md
@@ -22,16 +22,16 @@ The Location capability allows platforms to discover, search, and retrieve physi
 This is vertical-agnostic and enables key commerce flows such as:
 
 * **Local Pickup Discovery**: Finding locations like retail stores or restaurant branches
-    nearby that support customer pickup and checking their operating hours & inventory availability
+    nearby that support Buyer pickup and checking their operating hours & inventory availability
     before selection.
 * **Fulfillment Area Verification**: Checking if a specific location (e.g., utility depot, restaurant,
-    or local service provider) has delivery coverage for a buyer's address.
+    or local service provider) can serve a Buyer's address (the `serves` relation).
 
 ## Capabilities
 
 | Capability | Description |
 | :--- | :--- |
-| [`dev.ucp.common.location.search`](search.md) | Search for locations using natural language queries and filters (hours, offerings, geofencing). |
+| [`dev.ucp.common.location.search`](search.md) | Search for locations using free-text queries, explicit spatial relations (`distance`, `serves`), and filters (hours, offerings). |
 | [`dev.ucp.common.location.lookup`](lookup.md) | Retrieve full details for one or more locations by identifier. |
 
 ## Key Concepts
@@ -43,10 +43,13 @@ This is vertical-agnostic and enables key commerce flows such as:
     * **Amenities**: Static features, services, or capabilities of the location. Modeled as a flat reverse-DNS array to avoid
       semantic ambiguity across diverse industries (e.g., food drive-through vs. pharmacy drive-through).
     * **Inventory**: Dynamic availability of goods (e.g., retail products or restaurant dishes).
-* **Geofencing & Service Area**: Locations implicitly carry a geofence boundary around their coordinates.
-    This is used to determine if a location can serve a specific user (e.g., delivery area check).
-    Clients can perform proximity searches (`distance` filter) or coverage checks (`geofence_point` filter)
-    using the filter.
+* **Proximity & Serviceability**: Two distinct, explicit spatial relations. `distance`
+    compares a Location's coordinates against a Platform-supplied center point and inclusive
+    radius. `serves` asks whether the Location can provisionally serve one explicit
+    Platform-supplied target; the Business is authoritative for that answer, and UCP does not
+    model or expose the underlying coverage geometry — a Location does not implicitly carry a
+    geometric boundary around its coordinates. See
+    [Spatial Relations](search.md#spatial-relations).
 * **Operating Hours**: Regular weekly schedules (`hours`) and date-specific
     exceptions (`exception_hours`), interpreted in the Location's `timezone`.
     See [Operating Hours](#operating-hours).
@@ -60,9 +63,9 @@ other capabilities (like Catalog, Cart, and Checkout in Shopping):
     business-scoped `location.id` values. These IDs are referenced further in other requests & responses
     (e.g., associating product variants to specific locations in Catalog filters, passed directly
     in `selected_destination_id` to indicate pickup fulfillment mode).
-2. **Inventory-Based Store Finder**: Platforms can use Location Search with the `offerings.inventory` filter
-    to locate nearby stores that have a specific item available, bridging the gap between online catalog
-    browsing and physical store visits.
+2. **Inventory-Based Store Finder**: Platforms can use Location Search with the `filters.inventory`
+    predicate to locate nearby stores that have a specific item available, bridging the gap between
+    online catalog browsing and physical store visits.
 3. **Provisional vs. Authoritative Boundaries**:
     * *Discovery Phase (Provisional)*: Location responses based on operating hours, real-time inventory
         availability, and amenities offerings represent the business's *current terms* at the
@@ -189,14 +192,17 @@ Platform **MAY** present `title` according to its presentation policy and
 
 ### Context
 
-User location and market context for the operations. All fields are optional
+Buyer location and market context for the operations. All fields are optional
 hints for relevance and localization. Platforms **MAY** geo-detect context from
 request headers.
 
-Context signals are provisional—not authoritative data. Businesses **SHOULD** use
-these values when verified inputs (e.g., coordinates as part of the request filter)
-are absent, and **MAY** ignore or down-rank them if inconsistent with
-higher-confidence signals (authenticated account, risk detection).
+Context signals are provisional—not authoritative data. A Business **MAY** use
+them to influence ranking, localization, or selection of a bounded default
+browse page, and **MAY** ignore or down-rank them if inconsistent with
+higher-confidence signals (authenticated account, risk detection). They never
+substitute for the explicit `distance` and `serves` operands and prove neither
+proximity nor serviceability (see
+[Request Grammar](search.md#request-grammar)).
 
 {{ schema_fields('types/context', 'location') }}
 
@@ -219,7 +225,7 @@ Messages communicate business outcomes and provide context:
 
 | Type | When to Use | Example Codes |
 | :--- | :--- | :--- |
-| `error` | Business-level errors | `no_service_coverage` (geographic coordinates based filter) |
+| `error` | Business-level errors | Business-defined codes (freeform codes permitted) |
 | `warning` | Important conditions affecting purchase | `permanently_closed`, `temporary_closure` |
 | `info` | Additional context without issues | `not_found`, `holiday_hours_active` |
 
@@ -261,13 +267,13 @@ The capabilities above are bound to specific transport protocols:
 ## Security & Privacy Considerations
 
 1. **Coarse-by-default**: Platforms **SHOULD** default to sending coarse location hints (e.g., postal code or rounded coordinates) during the discovery phase.
-  Precise locations/coordinates **SHOULD** only be shared when the user explicitly consents or selects a specific location.
+  Precise locations/coordinates **SHOULD** only be shared when the Buyer explicitly consents or selects a specific Location.
 2. **Inventory Probing Mitigation**: Businesses **SHOULD** implement rate-limiting on search requests, especially if containing inventory availability filters,
   to prevent scraping & aggressive numeration of the entire directory.
-3. **Private/Dark Locations**: Businesses **MUST** filter out internal-only or non-user-accessible locations (e.g., dark kitchens, fulfillment-only hubs)
+3. **Private/Dark Locations**: Businesses **MUST** filter out internal-only or non-Buyer-accessible locations (e.g., dark kitchens, fulfillment-only hubs)
   from search results.
 4. **Physical Address Spoofing (Integrity)**: While location discovery is read-only, tampering with physical addresses in responses (e.g., through MITM attacks)
-  poses a physical safety/fraud risk. Platforms **SHOULD** verify signatures on location payloads before rendering them to users.
-5. **Data Retention & Logging Sanitization**: Businesses **MUST NOT** persist precise location inputs beyond the lifecycle of the request, unless explicit user
+  poses a physical safety/fraud risk. Platforms **SHOULD** verify signatures on location payloads before rendering them to Buyers.
+5. **Data Retention & Logging Sanitization**: Businesses **MUST NOT** persist precise location inputs beyond the lifecycle of the request, unless explicit Buyer
   consent is collected. Server logs should sanitize coordinate inputs by truncating decimal places (e.g., to 2 decimal places, ~1km accuracy) to prevent
-  accidental storage of precise user history.
+  accidental storage of precise Buyer history.

--- a/docs/specification/location/index.md
+++ b/docs/specification/location/index.md
@@ -31,7 +31,7 @@ This is vertical-agnostic and enables key commerce flows such as:
 
 | Capability | Description |
 | :--- | :--- |
-| [`dev.ucp.common.location.search`](search.md) | Search for locations using free-text queries, explicit spatial relations (`distance`, `serves`), and filters (hours, offerings). |
+| [`dev.ucp.common.location.search`](search.md) | Search for locations using free-text queries, explicit spatial relations (`distance`, `serves`), and filters (hours, offerings like `amenities` or `inventory`, etc.). |
 | [`dev.ucp.common.location.lookup`](lookup.md) | Retrieve full details for one or more locations by identifier. |
 
 ## Key Concepts
@@ -43,13 +43,12 @@ This is vertical-agnostic and enables key commerce flows such as:
     * **Amenities**: Static features, services, or capabilities of the location. Modeled as a flat reverse-DNS array to avoid
       semantic ambiguity across diverse industries (e.g., food drive-through vs. pharmacy drive-through).
     * **Inventory**: Dynamic availability of goods (e.g., retail products or restaurant dishes).
-* **Proximity & Serviceability**: Two distinct, explicit spatial relations. `distance`
-    compares a Location's coordinates against a Platform-supplied center point and inclusive
-    radius. `serves` asks whether the Location can provisionally serve one explicit
-    Platform-supplied target; the Business is authoritative for that answer, and UCP does not
-    model or expose the underlying coverage geometry — a Location does not implicitly carry a
-    geometric boundary around its coordinates. See
-    [Spatial Relations](search.md#spatial-relations).
+* **Proximity & Serviceability**: Two distinct, explicit spatial relations:
+    * **`distance`**: Compares a Location's coordinates against a Platform-supplied center point and inclusive radius.
+    * **`serves`**: Asks whether the Location can provisionally serve one explicit
+      Platform-supplied target; the Business is authoritative for that answer, and UCP does not
+      model or expose the underlying coverage geometry — a Location does not implicitly carry a
+      geometric boundary around its coordinates. See [Spatial Relations](search.md#spatial-relations).
 * **Operating Hours**: Regular weekly schedules (`hours`) and date-specific
     exceptions (`exception_hours`), interpreted in the Location's `timezone`.
     See [Operating Hours](#operating-hours).
@@ -199,7 +198,7 @@ request headers.
 Context signals are provisional—not authoritative data. A Business **MAY** use
 them to influence ranking, localization, or selection of a bounded default
 browse page, and **MAY** ignore or down-rank them if inconsistent with
-higher-confidence signals (authenticated account, risk detection). They never
+higher-confidence signals (authenticated account, risk detection). They **MUST NOT**
 substitute for the explicit `distance` and `serves` operands and prove neither
 proximity nor serviceability (see
 [Request Grammar](search.md#request-grammar)).

--- a/docs/specification/location/index.md
+++ b/docs/specification/location/index.md
@@ -198,9 +198,9 @@ request headers.
 Context signals are provisional—not authoritative data. A Business **MAY** use
 them to influence ranking, localization, or selection of a bounded default
 browse page, and **MAY** ignore or down-rank them if inconsistent with
-higher-confidence signals (authenticated account, risk detection). They **MUST NOT**
-substitute for the explicit `distance` and `serves` operands and prove neither
-proximity nor serviceability (see
+higher-confidence signals (authenticated account, risk detection). A Business
+**MUST NOT** substitute them for the explicit `distance` and `serves` operands;
+they prove neither proximity nor serviceability (see
 [Request Grammar](search.md#request-grammar)).
 
 {{ schema_fields('types/context', 'location') }}

--- a/docs/specification/location/lookup.md
+++ b/docs/specification/location/lookup.md
@@ -18,47 +18,62 @@
 
 * **Capability Name:** `dev.ucp.common.location.lookup`
 
-Retrieves physical locations by their unique identifiers.
-Supports full-detail batch retrieval of multiple locations to provide optionalities
-or retrieval of a single location (useful for a dedicated location detail page).
+Resolves identifiers to physical Locations.
+Supports full-detail batch retrieval of multiple Locations to provide optionalities
+or retrieval of a single Location (useful for a dedicated Location detail page).
 
 ## Operation
 
-| Operation              | Description                                   |
-| :--------------------- | :-------------------------------------------- |
-| **Lookup Location(s)** | Retrieve single or multiple locations by ID.  |
+| Operation              | Description                                          |
+| :--------------------- | :--------------------------------------------------- |
+| **Lookup Location(s)** | Retrieve single or multiple Locations by identifier. |
 
 ## Supported Identifiers
 
-The `ids` parameter accepts an array of identifiers. Implementations **MUST**
-support lookup by the Business's stable location ID.
+The `ids` parameter accepts an array of identifiers. A Business **MUST**
+support lookup by a Location's stable canonical `Location.id` and **MAY**
+additionally support secondary or alias identifiers.
 
-A Business **MUST** deduplicate duplicate identifiers in the request. When
-multiple identifiers resolve to the same physical Location, the Business
-**MUST** return it only once in the response.
+A Business **MUST** deduplicate duplicate identifiers in the request. When an
+identifier matches multiple Locations, the Business returns the matching
+Locations and **MAY** limit the result set. When multiple identifiers resolve
+to the same Location, the Business **MUST** return it only once.
 
 ### Platform Correlation
 
-The response does not guarantee order. A Platform correlates returned
-Locations simply by matching the returned `id` field against its requested
-`ids`.
+The response does not guarantee order. Each Location carries an `inputs`
+array identifying which requested identifiers resolved to it. Every entry
+contains a required `id`, copied exactly from the Lookup request.
+
+Multiple request identifiers may resolve to the same Location. When this
+occurs, the Location's `inputs` array contains one entry per resolved
+identifier. A Business **MUST NOT** include a Location without an `inputs`
+entry in a Lookup response.
 
 ### Batch Size
 
-Implementations **SHOULD** accept at least 10 identifiers per request.
-Implementations **MAY** enforce a maximum batch size and **MUST** reject
-requests exceeding their limit with an appropriate error (HTTP 400
-`request_too_large` for REST, JSON-RPC `-32602` for MCP).
+A Business **SHOULD** accept at least 10 identifiers per request and **MAY**
+enforce a maximum batch size. The maximum applies after duplicate identifiers
+are deduplicated.
+
+When a request exceeds that maximum, the Business **MUST** process the first
+maximum number of distinct identifiers in request order and return a successful
+response for that prefix. It **MUST** include an informational message with
+`code: "batch_limit_applied"`; the message content **MUST** state the applied
+maximum and how many identifiers were not processed. The Business **MUST NOT**
+evaluate the omitted suffix or report its identifiers as unresolved. A Platform
+**MUST NOT** interpret the omitted suffix as unresolved and **MAY** submit it in
+a subsequent request.
 
 ### Refinement
 
-The Business first resolves the canonical `ids` and deduplicates repeated
-IDs. Optional root `distance` and `serves` relations and `filters` predicates
-then refine the resolved set. All supplied criteria combine with AND: a
-resolved Location is returned only when it satisfies `distance` (when
-present), `serves` (when present), and every supplied `filters` predicate.
-The relations and predicates use the same schemas and semantics as Search —
-see [Spatial Relations](search.md#spatial-relations) and
+The Business first resolves the identifiers and deduplicates repeated values.
+Optional root `distance` and `serves` relations and `filters` predicates then
+refine the resolved set. All supplied criteria combine with AND: a resolved
+Location is returned only when it satisfies `distance` (when present),
+`serves` (when present), and every supplied `filters` predicate. The relations
+and predicates use the same schemas and semantics as Search — see
+[Spatial Relations](search.md#spatial-relations) and
 [Search Filters](search.md#search-filters).
 
 For example, if a Platform requests `["loc_downtown", "loc_uptown"]` with an
@@ -69,10 +84,12 @@ hours filter of `{"open_at": "2026-05-18T17:00:00Z"}`:
 3. If `loc_uptown` is closed at that instant, the Business excludes it and
     returns only `loc_downtown`.
 
-A requested ID is absent from the response when it does not resolve or when
-the resolved Location fails any supplied criterion. The request still
-succeeds. The Business **MAY** attach an informational message (for example,
-`not_found`), but no per-ID explanation is guaranteed.
+An identifier that does not resolve has no corresponding returned Location or
+`inputs` entry. If an identifier resolves to a Location that fails any
+supplied criterion, that Location and its corresponding `inputs` entry are
+omitted. The request still succeeds. The Business **MAY** attach an
+informational message (for example, `not_found`), but no per-identifier
+explanation is guaranteed.
 
 ### Request
 
@@ -93,7 +110,7 @@ The following request and response are transport-neutral UCP payloads.
     <!-- ucp:example schema=common/location_lookup op=lookup direction=request -->
     ```json
     {
-      "ids": ["loc_downtown"]
+      "ids": ["loc_downtown", "downtown-store"]
     }
     ```
 
@@ -113,6 +130,10 @@ The following request and response are transport-neutral UCP payloads.
       "locations": [
         {
           "id": "loc_downtown",
+          "inputs": [
+            {"id": "loc_downtown"},
+            {"id": "downtown-store"}
+          ],
           "name": "Downtown Store",
           "address": {
             "street_address": "100 Broadway",
@@ -152,9 +173,10 @@ The following request and response are transport-neutral UCP payloads.
     }
     ```
 
-Tuesday's two `hours` entries form a split shift. Sunday has no `hours` entry,
-meaning no regular interval begins that day. The `exception_hours` entry omits
-`opens` and `closes`, making it a full closure.
+The response correlates the canonical identifier and the Business-supported
+alias to one Location. Tuesday's two `hours` entries form a split shift.
+Sunday has no `hours` entry, meaning no regular interval begins that day. The
+`exception_hours` entry omits `opens` and `closes`, making it a full closure.
 See [Operating Hours](index.md#operating-hours) for schedule representation and
 evaluation rules.
 
@@ -185,6 +207,9 @@ evaluation rules.
       "locations": [
         {
           "id": "loc_downtown",
+          "inputs": [
+            {"id": "loc_downtown"}
+          ],
           "name": "Downtown Store"
         }
       ],
@@ -199,7 +224,60 @@ evaluation rules.
     ```
 
 The request succeeds with the Locations that resolve. A Business can use an
-informational `not_found` message to identify an unresolved ID.
+informational `not_found` message to identify an unresolved identifier.
+
+### Batch limit applied
+
+The following Business accepts at most two distinct identifiers per Lookup
+request.
+
+=== "Request"
+
+    <!-- ucp:example schema=common/location_lookup op=lookup direction=request -->
+    ```json
+    {
+      "ids": ["loc_downtown", "loc_uptown", "loc_airport"]
+    }
+    ```
+
+=== "Response"
+
+    <!-- ucp:example schema=common/location_lookup op=lookup direction=response -->
+    ```json
+    {
+      "ucp": {
+        "version": "{{ ucp_version }}",
+        "capabilities": {
+          "dev.ucp.common.location.lookup": [
+            {"version": "{{ ucp_version }}"}
+          ]
+        }
+      },
+      "locations": [
+        {
+          "id": "loc_downtown",
+          "inputs": [{"id": "loc_downtown"}],
+          "name": "Downtown Store"
+        },
+        {
+          "id": "loc_uptown",
+          "inputs": [{"id": "loc_uptown"}],
+          "name": "Uptown Store"
+        }
+      ],
+      "messages": [
+        {
+          "type": "info",
+          "code": "batch_limit_applied",
+          "content": "Processed the first 2 of 3 distinct identifiers; 1 identifier was not processed."
+        }
+      ]
+    }
+    ```
+
+The Business evaluates `loc_downtown` and `loc_uptown` in request order.
+`loc_airport` was not evaluated and is not unresolved; the Platform can submit
+it in a subsequent request.
 
 ## Transport Bindings
 

--- a/docs/specification/location/lookup.md
+++ b/docs/specification/location/lookup.md
@@ -31,16 +31,17 @@ or retrieval of a single location (useful for a dedicated location detail page).
 ## Supported Identifiers
 
 The `ids` parameter accepts an array of identifiers. Implementations **MUST**
-support lookup by the business's stable location ID.
+support lookup by the Business's stable location ID.
 
-Duplicate identifiers in the request **MUST** be deduplicated by the server.
-When multiple identifiers resolve to the same physical location,
-it **MUST** be returned only once in the response.
+A Business **MUST** deduplicate duplicate identifiers in the request. When
+multiple identifiers resolve to the same physical Location, the Business
+**MUST** return it only once in the response.
 
-### Client Correlation
+### Platform Correlation
 
-The response does not guarantee order. Clients correlate returned locations
-simply by matching the returned `id` field against their requested `ids`.
+The response does not guarantee order. A Platform correlates returned
+Locations simply by matching the returned `id` field against its requested
+`ids`.
 
 ### Batch Size
 
@@ -49,20 +50,29 @@ Implementations **MAY** enforce a maximum batch size and **MUST** reject
 requests exceeding their limit with an appropriate error (HTTP 400
 `request_too_large` for REST, JSON-RPC `-32602` for MCP).
 
-### Filters
+### Refinement
 
-Optional `filters` (hours, offerings/inventory, geo) are accepted
-to narrow down the returned locations.
-Filters use the same schema and AND semantics as [Search Filters](search.md#search-filters).
+The Business first resolves the canonical `ids` and deduplicates repeated
+IDs. Optional root `distance` and `serves` relations and `filters` predicates
+then refine the resolved set. All supplied criteria combine with AND: a
+resolved Location is returned only when it satisfies `distance` (when
+present), `serves` (when present), and every supplied `filters` predicate.
+The relations and predicates use the same schemas and semantics as Search —
+see [Spatial Relations](search.md#spatial-relations) and
+[Search Filters](search.md#search-filters).
 
-Filters apply **after** identifier resolution. For example, if a Platform
-requests `["loc_downtown", "loc_uptown"]` with an hours filter of
-`{"open_at": "2026-05-18T17:00:00Z"}`:
+For example, if a Platform requests `["loc_downtown", "loc_uptown"]` with an
+hours filter of `{"open_at": "2026-05-18T17:00:00Z"}`:
 
 1. The Business first resolves both identifiers to their respective Locations.
 2. The Business evaluates the supplied instant against each resolved Location.
 3. If `loc_uptown` is closed at that instant, the Business excludes it and
     returns only `loc_downtown`.
+
+A requested ID is absent from the response when it does not resolve or when
+the resolved Location fails any supplied criterion. The request still
+succeeds. The Business **MAY** attach an informational message (for example,
+`not_found`), but no per-ID explanation is guaranteed.
 
 ### Request
 

--- a/docs/specification/location/mcp.md
+++ b/docs/specification/location/mcp.md
@@ -262,9 +262,8 @@ A conforming MCP transport implementation **MUST**:
     check when `serves` is absent.
 4. Apply `distance`, `serves`, and every supplied `filters` predicate
     conjunctively (AND).
-5. Support cursor-based pagination for search results; an omitted `pagination.limit` means an arbitrary
-    Business supplied threshold, never all records (see
-    [Pagination](search.md#pagination)).
+5. Support cursor-based pagination for Search according to the shared
+    pagination contract (see [Pagination](search.md#pagination)).
 6. Return a successful JSON-RPC result for lookup requests; unknown identifiers result in fewer or no locations
     returned (**MAY** include informational `not_found` messages in the `messages` array).
 7. Return a successful JSON-RPC result when a lookup request exceeds the

--- a/docs/specification/location/mcp.md
+++ b/docs/specification/location/mcp.md
@@ -69,7 +69,7 @@ request in `location`.
 
 | Tool | Capability | Description |
 | :--- | :--- | :--- |
-| `search_locations` | [Search](search.md) | Search for locations using text, coordinates, and filters. |
+| `search_locations` | [Search](search.md) | Search for locations using text, spatial relations, and filters. |
 | `lookup_locations` | [Lookup](lookup.md) | Batch lookup one or multiple location(s) by ID. |
 
 ### `search_locations`
@@ -232,6 +232,14 @@ All application-level outcomes return a successful JSON-RPC result with the UCP 
 
 {{ schema_fields('types/location_filter', 'location/mcp') }}
 
+### Location Distance {: #location-distance-schema }
+
+{{ schema_fields('types/location_distance', 'location/mcp') }}
+
+### Location Serves {: #location-serves-schema }
+
+{{ schema_fields('types/location_serves', 'location/mcp') }}
+
 ### Error Response {: #error-response }
 
 {{ schema_fields('types/error_response', 'location/mcp') }}
@@ -244,9 +252,17 @@ A conforming MCP transport implementation **MUST**:
 2. Implement tools for each location capability advertised in the business's UCP profile, per their respective
     capability requirements ([Search](search.md), [Lookup](lookup.md)).
     Each capability may be adopted independently.
-3. Default to business-derived coordinates based on user location hint provided in `context.json`
-    for proximity (`distance`) filters when explicit coordinates are omitted by the platform in the request.
-4. Return a successful JSON-RPC result for lookup requests; unknown identifiers result in fewer or no locations
+3. Evaluate the `distance` relation only against the explicit Platform-supplied
+    `distance.center`, and the `serves` relation only against the explicit
+    Platform-supplied target; never derive either operand from `context`,
+    `signals`, or an IP address, and never apply an implicit serviceability
+    check when `serves` is absent.
+4. Apply `distance`, `serves`, and every supplied `filters` predicate
+    conjunctively (AND).
+5. Support cursor-based pagination for search results with a default limit
+    of 10; an omitted `pagination.limit` means 10, never all records (see
+    [Pagination](search.md#pagination)).
+6. Return a successful JSON-RPC result for lookup requests; unknown identifiers result in fewer or no locations
     returned (**MAY** include informational `not_found` messages in the `messages` array).
-5. Validate tool inputs against UCP schemas.
-6. Return `-32602` (Invalid params) for requests exceeding batch size limits.
+7. Validate tool inputs against UCP schemas.
+8. Return `-32602` (Invalid params) for requests exceeding batch size limits.

--- a/docs/specification/location/mcp.md
+++ b/docs/specification/location/mcp.md
@@ -70,7 +70,7 @@ request in `location`.
 | Tool | Capability | Description |
 | :--- | :--- | :--- |
 | `search_locations` | [Search](search.md) | Search for locations using text, spatial relations, and filters. |
-| `lookup_locations` | [Lookup](lookup.md) | Batch lookup one or multiple location(s) by ID. |
+| `lookup_locations` | [Lookup](lookup.md) | Batch lookup one or more Locations by identifier. |
 
 ### `search_locations`
 
@@ -198,6 +198,9 @@ Maps to the [Location Lookup](lookup.md) capability. See the
           "locations": [
             {
               "id": "loc_downtown",
+              "inputs": [
+                {"id": "loc_downtown"}
+              ],
               "name": "Downtown Store"
             }
           ]
@@ -264,5 +267,8 @@ A conforming MCP transport implementation **MUST**:
     [Pagination](search.md#pagination)).
 6. Return a successful JSON-RPC result for lookup requests; unknown identifiers result in fewer or no locations
     returned (**MAY** include informational `not_found` messages in the `messages` array).
-7. Validate tool inputs against UCP schemas.
-8. Return `-32602` (Invalid params) for requests exceeding batch size limits.
+7. Return a successful JSON-RPC result when a lookup request exceeds the
+    Business's batch maximum, process the first maximum number of distinct
+    identifiers in request order, and include an informational
+    `batch_limit_applied` message.
+8. Validate tool inputs against UCP schemas.

--- a/docs/specification/location/mcp.md
+++ b/docs/specification/location/mcp.md
@@ -262,8 +262,8 @@ A conforming MCP transport implementation **MUST**:
     check when `serves` is absent.
 4. Apply `distance`, `serves`, and every supplied `filters` predicate
     conjunctively (AND).
-5. Support cursor-based pagination for search results with a default limit
-    of 10; an omitted `pagination.limit` means 10, never all records (see
+5. Support cursor-based pagination for search results; an omitted `pagination.limit` means an arbitrary
+    Business supplied threshold, never all records (see
     [Pagination](search.md#pagination)).
 6. Return a successful JSON-RPC result for lookup requests; unknown identifiers result in fewer or no locations
     returned (**MAY** include informational `not_found` messages in the `messages` array).

--- a/docs/specification/location/rest.md
+++ b/docs/specification/location/rest.md
@@ -63,7 +63,7 @@ Location capabilities through their UCP profile at `/.well-known/ucp`.
 | Endpoint | Method | Capability | Description |
 | :--- | :--- | :--- | :--- |
 | `/locations/search` | POST | [Search](search.md) | Search for physical locations. |
-| `/locations/lookup` | POST | [Lookup](lookup.md) | Lookup single or multiple location(s) by known ID. |
+| `/locations/lookup` | POST | [Lookup](lookup.md) | Lookup one or more Locations by identifier. |
 
 ### `POST /locations/search`
 
@@ -158,6 +158,9 @@ Maps to the [Location Lookup](lookup.md) capability. See the
       "locations": [
         {
           "id": "loc_downtown",
+          "inputs": [
+            {"id": "loc_downtown"}
+          ],
           "name": "Downtown Store"
         }
       ]
@@ -232,4 +235,6 @@ A conforming REST transport implementation **MUST**:
     [Pagination](search.md#pagination)).
 5. Return HTTP 200 for lookup requests; unknown identifiers result in fewer or no locations
     returned (**MAY** include informational `not_found` messages).
-6. Return HTTP 400 with `request_too_large` error for requests exceeding batch size limits.
+6. Return HTTP 200 when a lookup request exceeds the Business's batch maximum,
+    process the first maximum number of distinct identifiers in request order,
+    and include an informational `batch_limit_applied` message.

--- a/docs/specification/location/rest.md
+++ b/docs/specification/location/rest.md
@@ -230,8 +230,8 @@ A conforming REST transport implementation **MUST**:
     check when `serves` is absent.
 3. Apply `distance`, `serves`, and every supplied `filters` predicate
     conjunctively (AND).
-4. Support cursor-based pagination for search results with a default limit
-    of 10; an omitted `pagination.limit` means 10, never all records (see
+4. Support cursor-based pagination for search results; an omitted `pagination.limit` means an arbitrary
+    Business supplied threshold, never all records (see
     [Pagination](search.md#pagination)).
 5. Return HTTP 200 for lookup requests; unknown identifiers result in fewer or no locations
     returned (**MAY** include informational `not_found` messages).

--- a/docs/specification/location/rest.md
+++ b/docs/specification/location/rest.md
@@ -230,9 +230,8 @@ A conforming REST transport implementation **MUST**:
     check when `serves` is absent.
 3. Apply `distance`, `serves`, and every supplied `filters` predicate
     conjunctively (AND).
-4. Support cursor-based pagination for search results; an omitted `pagination.limit` means an arbitrary
-    Business supplied threshold, never all records (see
-    [Pagination](search.md#pagination)).
+4. Support cursor-based pagination for Search according to the shared
+    pagination contract (see [Pagination](search.md#pagination)).
 5. Return HTTP 200 for lookup requests; unknown identifiers result in fewer or no locations
     returned (**MAY** include informational `not_found` messages).
 6. Return HTTP 200 when a lookup request exceeds the Business's batch maximum,

--- a/docs/specification/location/rest.md
+++ b/docs/specification/location/rest.md
@@ -201,6 +201,14 @@ All application-level outcomes return HTTP 200 with the UCP envelope and optiona
 
 {{ schema_fields('types/location_filter', 'location/rest') }}
 
+### Location Distance {: #location-distance-schema }
+
+{{ schema_fields('types/location_distance', 'location/rest') }}
+
+### Location Serves {: #location-serves-schema }
+
+{{ schema_fields('types/location_serves', 'location/rest') }}
+
 ### Error Response {: #error-response }
 
 {{ schema_fields('types/error_response', 'location/rest') }}
@@ -212,9 +220,16 @@ A conforming REST transport implementation **MUST**:
 1. Implement endpoints for each location capability advertised in the business's UCP profile,
     per their respective capability requirements ([Search](search.md), [Lookup](lookup.md)).
     Each capability **MAY** be adopted independently.
-2. Default to business-derived coordinates based on user location hint provided in `context.json`
-    for proximity (`distance`) filters when explicit coordinates are omitted by the platform in the request.
-3. Support cursor-based pagination with a default limit of 10 for search results.
-4. Return HTTP 200 for lookup requests; unknown identifiers result in fewer or no locations
+2. Evaluate the `distance` relation only against the explicit Platform-supplied
+    `distance.center`, and the `serves` relation only against the explicit
+    Platform-supplied target; never derive either operand from `context`,
+    `signals`, or an IP address, and never apply an implicit serviceability
+    check when `serves` is absent.
+3. Apply `distance`, `serves`, and every supplied `filters` predicate
+    conjunctively (AND).
+4. Support cursor-based pagination for search results with a default limit
+    of 10; an omitted `pagination.limit` means 10, never all records (see
+    [Pagination](search.md#pagination)).
+5. Return HTTP 200 for lookup requests; unknown identifiers result in fewer or no locations
     returned (**MAY** include informational `not_found` messages).
-5. Return HTTP 400 with `request_too_large` error for requests exceeding batch size limits.
+6. Return HTTP 400 with `request_too_large` error for requests exceeding batch size limits.

--- a/docs/specification/location/search.md
+++ b/docs/specification/location/search.md
@@ -19,15 +19,15 @@
 * **Capability Name:** `dev.ucp.common.location.search`
 
 Performs a search for physical locations (e.g., retail stores, restaurants,
-warehouses). Supports natural language queries, geographic proximity (distance)
-searches, and structured filtering by operating hours and offerings such as
-amenities and inventory availability.
+warehouses). Supports free-text queries, explicit spatial relations
+(`distance` and `serves`), and structured filtering by operating hours and
+offerings such as amenities and inventory availability.
 
 ## Operation
 
 | Operation | Description |
 | :--- | :--- |
-| **Search Locations** | Search for locations using query text, context, and filters. |
+| **Search Locations** | Search for locations using query text, spatial relations, context, and filters. |
 
 ### Request
 
@@ -37,34 +37,164 @@ amenities and inventory availability.
 
 {{ extension_schema_fields('location_search.json#/$defs/search_response', 'location') }}
 
-## Search Inputs
+## Request Grammar
 
-A valid search request **MUST** include at least one of: a `query` string, one or more
-`filters`, platform-provided user `context` hints, or an extension-defined input.
-When `query` is omitted, the request represents a browse operation — the business
-returns locations matching the provided filters without text-relevance ranking.
+Each request input has a distinct role:
 
-Implementations **MUST** validate that incoming requests contain at least one
-recognized input and **SHOULD** reject empty or invalid requests with an
-appropriate error. Implementations define and enforce their own rules for
-input presence and content — for example, requiring `query`, rejecting
-empty `query` strings, or accepting filter-only requests.
+| Input | Meaning |
+| :--- | :--- |
+| `query` | Free-text retrieval (e.g., "restaurants near me that deliver"). |
+| `distance` | A relation between a candidate Location and an explicit Platform-supplied center point and inclusive radius. |
+| `serves` | A relation between a candidate Location and one explicit Platform-supplied service target. |
+| `filters` | Predicates over inherent or current Location facts: `hours`, `amenities`, and `inventory`. |
+| `context` / `signals` | Provisional hints for relevance, localization, and bounded default selection; never spatial proof. |
+| `pagination` | A request for the shape of a bounded result page. |
 
-> **Implementation guidance:** For processing search requests containing only `context`,
-> the following rules **MAY** be followed by businesses:
->
-> If the provided `context` is insufficient to determine a location boundary
-> (e.g., only country is provided, or context is empty), business **MAY** return a default
-> set of locations (e.g., featured locations, or all locations up to a default server-side
-> limit) or an empty list.
->
-> If the server cannot resolve the location, it **SHOULD** return an error message.
+`distance` and `serves` sit at the request root because they compare a
+candidate Location against external facts the Platform supplies, while
+`filters` predicates ask whether the Location itself has or currently
+satisfies a fact. The two relations are independent: either can anchor a
+request by itself, they can use different points, and neither inherits an
+operand from the other.
+
+For any candidate Location, every explicit structured constraint is
+conjunctive:
+
+```text
+matches = distance (when present)
+      AND serves (when present)
+      AND every supplied filters.* predicate
+```
+
+This rule defines observable results, not backend evaluation order.
+
+A Business **MAY** use the `query` text to narrow and rank results as
+ordinary free-text retrieval, including letting spatial phrases in it (for
+example, "near me") influence text relevance and ranking. The `query` never
+carries structured authority in either direction. A Business **MUST NOT**
+treat `query` text as creating a `distance` or `serves` relation or as
+proof of spatial matching — only the explicit operands in
+[Spatial Relations](#spatial-relations) establish those — and **MUST NOT**
+relax an explicit structured constraint because of the `query` text: a
+Location that fails `distance`, `serves`, or a `filters` predicate is
+excluded no matter how well it matches the query.
+
+### Bounded Browse
+
+A request with no structured spatial constraint is valid. An empty body
+`{}`, a request carrying only `context` or `signals`, a request carrying
+only `pagination`, and a filters-only request are each a bounded browse over
+the Business's default, policy-controlled selection — never a spatial
+assertion and never an export. An omitted `pagination.limit` defaults to 10,
+not all records.
+
+A Business **MAY** use `context`, `signals`, and IP-derived locality to
+influence ranking, localization, or selection of a bounded default browse
+page. A Business using those hints **MUST NOT** treat that choice as proof
+that a Location serves a target or falls within an unstated radius; only
+explicit `distance` and `serves` operands establish spatial matching.
+
+### Rejection and Empty Results
+
+Requests that fail the Search request schema use the binding's
+invalid-request mechanism. The same mechanism carries the defined semantic
+errors for `distance` and `serves`; see
+[Spatial Relations](#spatial-relations). A supported predicate that simply
+matches no Locations remains a successful empty business outcome (see
+[Empty Search](index.md#common-scenarios)).
+
+## Spatial Relations
+
+### Distance
+
+The `distance` relation matches Locations within an inclusive radius of an
+explicit center point. Both members are required: `distance.center` is a
+`geo.json` point in World Geodetic System 1984 (WGS 84) decimal degrees, and
+`distance.max` is the inclusive maximum distance in meters.
+
+{{ schema_fields('types/location_distance', 'location') }}
+
+The Platform **MUST** supply `distance.center` whenever it supplies
+`distance`. The Business **MUST NOT** derive a missing center from `context`,
+`signals`, an Internet Protocol (IP) address, or `serves`; a request missing
+a required operand is invalid rather than broader than intended.
+
+Matching semantics are closed:
+
+* The computed distance is the shortest geodesic distance over the WGS 84
+    ellipsoid between `distance.center` and the Location's authoritative
+    `geo`, in meters. When the two points lie on opposite sides of the
+    180-degree meridian the same rule applies — the shortest geodesic — with
+    no special casing.
+* The Business **MUST** compare the unrounded computed value to
+    `distance.max`; a Location matches when that value is less than or equal
+    to `distance.max`, and exact equality matches.
+* The Business **MUST NOT** apply a tolerance band, substitute an operand,
+    clamp the radius, or evaluate route, travel, or planar distance in place
+    of the geodesic comparison.
+* The Business **MAY** compute the value with any algorithm that produces
+    the WGS 84 inverse-geodesic result at sufficient precision that the
+    match outcome agrees with the unrounded comparison defined above.
+* A Business that cannot honor a supplied `distance.max` (for example, a
+    radius cap below the requested value) **MUST** reject the request with an
+    actionable error; it **MUST NOT** silently clamp the radius or substitute
+    its own. Requested-limit clamping in [Pagination](#pagination) never
+    applies to `distance.max`.
+* A Location without a usable authoritative `geo` does not match; exclusion
+    is a non-match, not an error.
+* A Business **MUST** return each matching Location with the `geo` value
+    used in the evaluation.
+
+The relation is a hard restriction; it neither requests nor implies distance
+ordering. Ranking remains separate Business behavior unless another
+negotiated input specifies it.
+
+### Serves
+
+The `serves` relation matches Locations that can provisionally serve one
+explicit target. It is a one-entry map: the Platform **MUST** supply exactly
+one target representation — `point`, `address`, or a negotiated
+reverse-domain extension target.
+
+{{ schema_fields('types/location_serves', 'location') }}
+
+* `point` is a WGS 84 latitude and longitude coordinate pair and uses the
+    same coordinate representation as `distance.center`.
+* `address` is a coarse locality. When supplying it, the Platform **MUST**
+    include at least one non-empty `address_country`, `address_region`, or
+    `postal_code`. An `address` is invalid if it is empty, contains only
+    unrecognized fields, or all of its recognized fields are empty. A `serves`
+    map is invalid if it is empty or contains more than one target.
+
+The explicit target is authoritative. Omitting `serves` never creates an
+implicit serviceability check, and the Business **MUST NOT** derive a target
+from `context`, `signals`, or an IP address.
+
+A Location matches when at least one currently available service or
+fulfillment method at that Location can provisionally serve the target. The
+match does not disclose the Business's coverage geometry, identify the
+qualifying method, reserve capacity, or guarantee that checkout or
+fulfillment will succeed; the Business revalidates serviceability against
+binding transaction data later in the commerce flow.
+
+A Business unable to evaluate an otherwise well-formed target — for example,
+a postal code system it does not model — **MUST** return an actionable
+request error; it **MUST NOT** fall back to a coarser interpretation or
+return broadened results. If a namespaced target's extension was not
+negotiated, the Business **MUST** return an actionable request error rather
+than silently omit the target.
+
+The relation also has a deliberate correlation limit: a Location matching
+both `filters.inventory` and `serves` establishes that the inventory
+predicate holds there and that at least one method can serve the target —
+not that the same method can fulfill that item to that target.
 
 ## Search Filters
 
-Location filters allow narrowing results based on specific criteria.
-Standard filters are defined as below; businesses **MAY** support additional
-custom filters via `additionalProperties`.
+Location filters are predicates over inherent or current Location facts.
+Standard Location filters are `hours`, `amenities`, and `inventory`. A
+Business **MAY** support additional custom filters through
+`additionalProperties`. All supplied filters combine with AND.
 
 {{ schema_fields('types/location_filter', 'location') }}
 
@@ -126,42 +256,22 @@ interoperability. Implementations **SHOULD** map their internal features to the 
   availability predicate is always evaluated as `false`. Business **MUST** return an empty result set and **MAY** append
   an info message with `code: "item_not_found"`.
 
-### Geographic & Geofencing Filter
-
-Supports two distinct, industry-agnostic spatial search models:
-
-* **`distance` (Proximity Search)**: Filters for locations within a `max_distance`
-    (in RFC 7035 distance units = meters) of a `center` point.
-
-> **Privacy Integration**: If `center` is omitted, business **MUST** use the
-> user's address hint provided in the request `context` (which may be coarse/sanitized)
-> to derive the center. If `context` is omitted or business is unable to resolve the
-> provided address hint, then business **MUST** return an error message with
-> `code: "location_geo_filter_resolution_failed"`.
-
-* **`serves` (Service Area Coverage)**: Filters for locations that can serve
-    a target destination. The business evaluates coverage using their internal service area rules
-    (e.g., internal geometry, ZIP code lists) and returns qualifying locations only.
-
-> **Contextual Fallback**: If the `serves` filter is not explicitly specified in
-> the request, the business **MAY** use the user's contextual location hints passed in the
-> request `context` object to implicitly apply a `serves` filter, returning only locations
-> that can service the user. If `context` is omitted or business is unable to resolve the
-> provided address hint, unlike the treatment above for `distance`, business **SHOULD**
-> interpret this unqualified filter predicate as "serves any location target".
-
 ## Pagination
 
-Cursor-based pagination for list operations. Cursors are opaque strings
-that implementations **MAY** encode as stateless keyset tokens.
+Cursor-based pagination for list operations. Cursors are opaque strings. A
+Business **MAY** encode them as stateless keyset tokens.
 
 ### Page Size
 
-The `limit` parameter is a requested page size, not a guaranteed count.
-Implementations **SHOULD** accept a page size of at least 10. When the
-requested limit exceeds the implementation's maximum, implementations
-**MAY** clamp to their maximum silently — returning fewer results without
-error. Clients MUST NOT assume the response size equals the requested limit.
+The `limit` parameter is a requested page size, not a guaranteed count. A
+Business **SHOULD** accept a page size of at least 10 unless resource or
+policy constraints require a lower maximum. When the requested limit exceeds
+the Business's maximum, the Business **MAY** clamp to that maximum silently —
+returning fewer results without error. A Platform **MUST NOT** assume the
+response size equals the requested limit. An omitted `limit` defaults to 10;
+it never means all records, and a cursor is not an export guarantee. This
+clamping policy is specific to pagination; it never extends to
+`distance.max` (see [Distance](#distance)).
 
 ### Pagination Request
 
@@ -188,19 +298,17 @@ The following requests and responses are transport-neutral UCP payloads.
         "address_region": "CA",
         "postal_code": "94043"
       },
+      "serves": {
+        "point": {
+          "latitude": 37.422,
+          "longitude": -122.084
+        }
+      },
       "filters": {
         "hours": {
           "open_at": "2026-05-18T17:00:00Z"
         },
-        "amenities": ["dev.ucp.amenity.shopping.curbside_pickup"],
-        "geo": {
-          "serves": {
-            "point": {
-              "latitude": 37.422,
-              "longitude": -122.084
-            }
-          }
-        }
+        "amenities": ["dev.ucp.amenity.shopping.curbside_pickup"]
       }
     }
     ```
@@ -243,10 +351,11 @@ The following requests and responses are transport-neutral UCP payloads.
     }
     ```
 
-At the supplied instant, it is Monday at `10:00` in
-`America/Los_Angeles`, within the returned interval. See
-[Operating Hours](index.md#operating-hours) for complete schedule evaluation
-rules.
+The explicit `serves.point` is the authoritative service target; the coarse
+`context` hints only shape ranking and localization. At the supplied instant,
+it is Monday at `10:00` in `America/Los_Angeles`, within the returned
+interval. See [Operating Hours](index.md#operating-hours) for complete
+schedule evaluation rules.
 
 ### Locations with an inventory item within a distance
 
@@ -255,22 +364,20 @@ rules.
     <!-- ucp:example schema=common/location_search op=search direction=request -->
     ```json
     {
+      "distance": {
+        "center": {
+          "latitude": 40.707,
+          "longitude": -74.011
+        },
+        "max": 10000
+      },
       "filters": {
         "inventory": [
           {
             "id": "item_id_phone_15_pro",
             "availability_status": "in_stock"
           }
-        ],
-        "geo": {
-          "distance": {
-            "center": {
-              "latitude": 40.707,
-              "longitude": -74.011
-            },
-            "max_distance": 10000
-          }
-        }
+        ]
       }
     }
     ```
@@ -308,6 +415,9 @@ rules.
       ]
     }
     ```
+
+Each returned Location satisfies both the `distance` relation and the
+inventory predicate, and includes the `geo` used in the distance evaluation.
 
 ## Transport Bindings
 

--- a/docs/specification/location/search.md
+++ b/docs/specification/location/search.md
@@ -142,8 +142,6 @@ Matching semantics are closed:
     applies to `distance.max`.
 * A Location without a usable authoritative `geo` does not match; exclusion
     is a non-match, not an error.
-* A Business **MUST** return each matching Location with the `geo` value
-    used in the evaluation.
 
 The relation is a hard restriction; it neither requests nor implies distance
 ordering. Ranking remains separate Business behavior unless another
@@ -406,10 +404,6 @@ schedule evaluation rules.
             "address_country": "US",
             "postal_code": "10005"
           },
-          "geo": {
-            "latitude": 40.709,
-            "longitude": -74.008
-          },
           "amenities": ["dev.ucp.amenity.shopping.curbside_pickup", "dev.ucp.amenity.shopping.in_store_pickup"]
         }
       ]
@@ -417,7 +411,8 @@ schedule evaluation rules.
     ```
 
 Each returned Location satisfies both the `distance` relation and the
-inventory predicate, and includes the `geo` used in the distance evaluation.
+inventory predicate. The `distance` relation does not require the Business to
+disclose the Location coordinate used in the evaluation.
 
 ## Transport Bindings
 

--- a/docs/specification/location/search.md
+++ b/docs/specification/location/search.md
@@ -85,9 +85,8 @@ A request with no structured spatial constraint is valid. An empty body
 `{}`, a request carrying only `context` or `signals`, a request carrying
 only `pagination`, and a filters-only request are each a bounded browse over
 the Business's default, policy-controlled selection — never a spatial
-assertion and never an export. An omitted `pagination.limit` allows Business
-to enforce their desired arbitrarily threshold and **MUST NOT** be
-interpreted as "all records".
+assertion and never an export. Its page size follows the shared
+[Pagination](#pagination) contract.
 
 A Business **MAY** use `context`, `signals`, and IP-derived locality to
 influence ranking, localization, or selection of a bounded default browse
@@ -139,8 +138,8 @@ Matching semantics are closed:
 * A Business that cannot honor a supplied `distance.max` (for example, a
     radius cap below the requested value) **MUST** reject the request with an
     actionable error; it **MUST NOT** silently clamp the radius or substitute
-    its own. Requested-limit clamping in [Pagination](#pagination) never
-    applies to `distance.max`.
+    its own. The permission to return fewer results under
+    [Pagination](#pagination) never permits reducing `distance.max`.
 * A Location without a usable authoritative `geo` does not match; exclusion
     is a non-match, not an error.
 
@@ -262,15 +261,16 @@ Business **MAY** encode them as stateless keyset tokens.
 
 ### Page Size
 
-The `limit` parameter is a requested page size, not a guaranteed count. A
-Business **SHOULD** accept a page size of at least 10 unless resource or
-policy constraints require a lower maximum. When the requested limit exceeds
-the Business's maximum, the Business **MAY** clamp to that maximum silently —
-returning fewer results without error. A Platform **MUST NOT** assume the
-response size equals the requested limit. An omitted `limit` allows Business to
-apply their desired threshold; it never means all records, and a cursor is not
-an export guarantee. This clamping policy is specific to pagination; it never extends to
-`distance.max` (see [Distance](#distance)).
+The `limit` parameter is a requested page size, not a guaranteed result
+count. When `limit` is omitted, the Business **MUST** apply a default page
+size. A default of 10 is **RECOMMENDED**, but the Business **MAY** choose
+another value.
+
+The Business **MAY** return fewer results than the requested or default page
+size, including when enforcing its maximum page size. A Platform **MUST NOT**
+assume that the response count equals either value. This permission applies
+only to page size; it does not permit reducing `distance.max` (see
+[Distance](#distance)).
 
 ### Pagination Request
 

--- a/docs/specification/location/search.md
+++ b/docs/specification/location/search.md
@@ -85,8 +85,9 @@ A request with no structured spatial constraint is valid. An empty body
 `{}`, a request carrying only `context` or `signals`, a request carrying
 only `pagination`, and a filters-only request are each a bounded browse over
 the Business's default, policy-controlled selection — never a spatial
-assertion and never an export. An omitted `pagination.limit` defaults to 10,
-not all records.
+assertion and never an export. An omitted `pagination.limit` allows Business
+to enforce their desired arbitrarily threshold and **MUST NOT** be
+interpreted as "all records".
 
 A Business **MAY** use `context`, `signals`, and IP-derived locality to
 influence ranking, localization, or selection of a bounded default browse
@@ -266,9 +267,9 @@ Business **SHOULD** accept a page size of at least 10 unless resource or
 policy constraints require a lower maximum. When the requested limit exceeds
 the Business's maximum, the Business **MAY** clamp to that maximum silently —
 returning fewer results without error. A Platform **MUST NOT** assume the
-response size equals the requested limit. An omitted `limit` defaults to 10;
-it never means all records, and a cursor is not an export guarantee. This
-clamping policy is specific to pagination; it never extends to
+response size equals the requested limit. An omitted `limit` allows Business to
+apply their desired threshold; it never means all records, and a cursor is not
+an export guarantee. This clamping policy is specific to pagination; it never extends to
 `distance.max` (see [Distance](#distance)).
 
 ### Pagination Request

--- a/source/schemas/common/location_lookup.json
+++ b/source/schemas/common/location_lookup.json
@@ -8,7 +8,7 @@
   "$defs": {
     "lookup_request": {
       "type": "object",
-      "description": "Request body for batch location lookup.",
+      "description": "Request body for batch location lookup. The Business resolves and deduplicates `ids` before applying `distance`, `serves`, and every supplied `filters` predicate; all structured predicates combine with AND.",
       "required": ["ids"],
       "properties": {
         "ids": {
@@ -16,6 +16,16 @@
           "items": { "type": "string" },
           "minItems": 1,
           "description": "Identifiers of the locations to lookup. Implementations MUST support location ID."
+        },
+        "distance": {
+          "$ref": "types/location_distance.json",
+          "description": "Optional explicit-center radius predicate applied after ID resolution. It combines with `serves` and every supplied `filters` predicate using AND.",
+          "ucp_request": "optional"
+        },
+        "serves": {
+          "$ref": "types/location_serves.json",
+          "description": "Optional authoritative service-target predicate applied after ID resolution. It combines with `distance` and every supplied `filters` predicate using AND.",
+          "ucp_request": "optional"
         },
         "filters": {
           "$ref": "types/location_filter.json",

--- a/source/schemas/common/location_lookup.json
+++ b/source/schemas/common/location_lookup.json
@@ -6,6 +6,35 @@
   "description": "Location lookup by identifier. Supports batch retrieval (lookup_locations) and single-location detail (get_location).",
   "type": "object",
   "$defs": {
+    "lookup_location": {
+      "description": "Location with required correlation metadata for lookup responses.",
+      "allOf": [
+        { "$ref": "types/location.json" },
+        {
+          "type": "object",
+          "required": ["inputs"],
+          "properties": {
+            "inputs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "The identifier exactly as supplied in the lookup request.",
+                    "ucp_request": "omit"
+                  }
+                }
+              },
+              "minItems": 1,
+              "description": "Which request identifiers resolved to this Location. Each entry preserves one identifier exactly as supplied in the request.",
+              "ucp_request": "omit"
+            }
+          }
+        }
+      ]
+    },
     "lookup_request": {
       "type": "object",
       "description": "Request body for batch location lookup. The Business resolves and deduplicates `ids` before applying `distance`, `serves`, and every supplied `filters` predicate; all structured predicates combine with AND.",
@@ -15,7 +44,7 @@
           "type": "array",
           "items": { "type": "string" },
           "minItems": 1,
-          "description": "Identifiers of the locations to lookup. Implementations MUST support location ID."
+          "description": "Identifiers of the Locations to look up. The Business MUST support canonical `Location.id` values and MAY support secondary or alias identifiers."
         },
         "distance": {
           "$ref": "types/location_distance.json",
@@ -52,16 +81,16 @@
         "locations": {
           "type": "array",
           "items": {
-            "$ref": "types/location.json"
+            "$ref": "#/$defs/lookup_location"
           },
-          "description": "Locations matching the requested identifiers and filters. May contain fewer locations if some identifiers are not found."
+          "description": "Locations matching the requested identifiers and refinements. May contain fewer Locations if some identifiers do not resolve or their resolved Locations are filtered out, or more if one identifier resolves to multiple Locations. When multiple identifiers resolve to the same Location, one returned Location carries all corresponding `inputs` entries."
         },
         "messages": {
           "type": "array",
           "items": {
             "$ref": "types/message.json"
           },
-          "description": "Errors, warnings, or informational messages about the requested locations."
+          "description": "Errors, warnings, or informational messages about the requested Locations, including `batch_limit_applied` when the Business processes only its configured maximum number of identifiers."
         }
       }
     }

--- a/source/schemas/common/location_search.json
+++ b/source/schemas/common/location_search.json
@@ -8,6 +8,7 @@
   "$defs": {
     "search_request": {
       "type": "object",
+      "description": "Request body for location search. The `distance` and `serves` relations and every supplied `filters` predicate combine with AND; `query` does not relax them.",
       "properties": {
         "query": {
           "type": "string",
@@ -18,6 +19,16 @@
         },
         "signals": {
           "$ref": "types/signals.json"
+        },
+        "distance": {
+          "$ref": "types/location_distance.json",
+          "description": "Optional explicit-center radius predicate. When present, it combines with `serves` and every supplied `filters` predicate using AND.",
+          "ucp_request": "optional"
+        },
+        "serves": {
+          "$ref": "types/location_serves.json",
+          "description": "Optional authoritative service-target predicate. When present, it combines with `distance` and every supplied `filters` predicate using AND.",
+          "ucp_request": "optional"
         },
         "filters": {
           "$ref": "types/location_filter.json"

--- a/source/schemas/common/types/geo.json
+++ b/source/schemas/common/types/geo.json
@@ -10,15 +10,13 @@
       "type": "number",
       "minimum": -90,
       "maximum": 90,
-      "description": "WGS 84 latitude in decimal degrees.",
-      "ucp_request": "required"
+      "description": "WGS 84 latitude in decimal degrees."
     },
     "longitude": {
       "type": "number",
       "minimum": -180,
       "maximum": 180,
-      "description": "WGS 84 longitude in decimal degrees.",
-      "ucp_request": "required"
+      "description": "WGS 84 longitude in decimal degrees."
     }
   }
 }

--- a/source/schemas/common/types/geo.json
+++ b/source/schemas/common/types/geo.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/common/types/geo.json",
   "title": "Geo",
-  "description": "Geographic information.",
+  "description": "WGS 84 geographic coordinates in decimal degrees.",
   "type": "object",
   "required": ["latitude", "longitude"],
   "properties": {
@@ -10,13 +10,15 @@
       "type": "number",
       "minimum": -90,
       "maximum": 90,
-      "description": "Latitude in decimal degrees."
+      "description": "WGS 84 latitude in decimal degrees.",
+      "ucp_request": "required"
     },
     "longitude": {
       "type": "number",
       "minimum": -180,
       "maximum": 180,
-      "description": "Longitude in decimal degrees."
+      "description": "WGS 84 longitude in decimal degrees.",
+      "ucp_request": "required"
     }
   }
 }

--- a/source/schemas/common/types/location_distance.json
+++ b/source/schemas/common/types/location_distance.json
@@ -2,21 +2,19 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/common/types/location_distance.json",
   "title": "Location Distance",
-  "description": "An explicit-center inclusive-radius predicate. The Business compares the unrounded shortest WGS 84 ellipsoidal geodesic distance in meters from `center` to the Location's authoritative `geo`; a value less than or equal to `max` matches. Implementations MAY use any algorithm that produces the WGS 84 inverse-geodesic result at sufficient precision such that the match outcome agrees with this unrounded comparison. No context, signals, IP, or `serves` fallback, radius clamping, tolerance, or operand substitution is permitted.",
+  "description": "An explicit-center inclusive-radius predicate. The Business compares the unrounded shortest WGS 84 ellipsoidal geodesic distance in RFC 7035 distance unit (meters) from `center` to the Location's authoritative `geo`; a value less than or equal to `max` matches. Implementations MAY use any algorithm that produces the WGS 84 inverse-geodesic result at sufficient precision such that the match outcome agrees with this unrounded comparison. No context, signals, IP, or `serves` fallback, radius clamping, tolerance, or operand substitution is permitted.",
   "type": "object",
   "required": ["center", "max"],
   "additionalProperties": true,
   "properties": {
     "center": {
       "$ref": "geo.json",
-      "description": "Explicit center of the radius. The Platform MUST supply it; the Business MUST NOT derive it from context, signals, an IP address, or `serves`.",
-      "ucp_request": "required"
+      "description": "Explicit center of the radius. The Platform MUST supply it; the Business MUST NOT derive it from context, signals, an IP address, or `serves`."
     },
     "max": {
       "type": "number",
       "minimum": 0,
-      "description": "Inclusive maximum distance in meters; `max_distance` is not an alias. A Business unable to honor the supplied value MUST reject the request rather than clamp it or substitute another radius.",
-      "ucp_request": "required"
+      "description": "Inclusive maximum distance in RFC 7035 distance unit (meters); `max` is not an alias. A Business unable to honor the supplied value MUST reject the request rather than clamp it or substitute another radius."
     }
   }
 }

--- a/source/schemas/common/types/location_distance.json
+++ b/source/schemas/common/types/location_distance.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/common/types/location_distance.json",
   "title": "Location Distance",
-  "description": "An explicit-center inclusive-radius predicate. The Business compares the unrounded shortest WGS 84 ellipsoidal geodesic distance in meters from `center` to the Location's authoritative `geo`; a value less than or equal to `max` matches. Implementations MAY use any algorithm that produces the WGS 84 inverse-geodesic result at sufficient precision such that the match outcome agrees with this unrounded comparison. A matching Location includes the `geo` used for evaluation. No context, signals, IP, or `serves` fallback, radius clamping, tolerance, or operand substitution is permitted.",
+  "description": "An explicit-center inclusive-radius predicate. The Business compares the unrounded shortest WGS 84 ellipsoidal geodesic distance in meters from `center` to the Location's authoritative `geo`; a value less than or equal to `max` matches. Implementations MAY use any algorithm that produces the WGS 84 inverse-geodesic result at sufficient precision such that the match outcome agrees with this unrounded comparison. No context, signals, IP, or `serves` fallback, radius clamping, tolerance, or operand substitution is permitted.",
   "type": "object",
   "required": ["center", "max"],
   "additionalProperties": true,

--- a/source/schemas/common/types/location_distance.json
+++ b/source/schemas/common/types/location_distance.json
@@ -14,7 +14,7 @@
     "max": {
       "type": "number",
       "minimum": 0,
-      "description": "Inclusive maximum distance in RFC 7035 distance unit (meters); `max` is not an alias. A Business unable to honor the supplied value MUST reject the request rather than clamp it or substitute another radius."
+      "description": "Inclusive maximum distance in RFC 7035 distance unit (meters). A Business unable to honor the supplied value MUST reject the request rather than clamp it or substitute another radius."
     }
   }
 }

--- a/source/schemas/common/types/location_distance.json
+++ b/source/schemas/common/types/location_distance.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/types/location_distance.json",
+  "title": "Location Distance",
+  "description": "An explicit-center inclusive-radius predicate. The Business compares the unrounded shortest WGS 84 ellipsoidal geodesic distance in meters from `center` to the Location's authoritative `geo`; a value less than or equal to `max` matches. Implementations MAY use any algorithm that produces the WGS 84 inverse-geodesic result at sufficient precision such that the match outcome agrees with this unrounded comparison. A matching Location includes the `geo` used for evaluation. No context, signals, IP, or `serves` fallback, radius clamping, tolerance, or operand substitution is permitted.",
+  "type": "object",
+  "required": ["center", "max"],
+  "additionalProperties": true,
+  "properties": {
+    "center": {
+      "$ref": "geo.json",
+      "description": "Explicit center of the radius. The Platform MUST supply it; the Business MUST NOT derive it from context, signals, an IP address, or `serves`.",
+      "ucp_request": "required"
+    },
+    "max": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Inclusive maximum distance in meters; `max_distance` is not an alias. A Business unable to honor the supplied value MUST reject the request rather than clamp it or substitute another radius.",
+      "ucp_request": "required"
+    }
+  }
+}

--- a/source/schemas/common/types/location_filter.json
+++ b/source/schemas/common/types/location_filter.json
@@ -2,48 +2,9 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/common/types/location_filter.json",
   "title": "Location Filter",
-  "description": "Filter criteria to narrow location search/lookup results. All specified outermost filters combine with AND logic.",
+  "description": "Filter criteria to narrow location search and lookup results. All specified filters combine with AND logic.",
   "type": "object",
   "properties": {
-    "geo": {
-      "type": "object",
-      "description": "Filter locations by geographic proximity or geofence coverage.",
-      "properties": {
-        "distance": {
-          "type": "object",
-          "description": "Filter locations within a maximum distance from a center point (proximity search).",
-          "required": ["max_distance"],
-          "properties": {
-            "center": {
-              "$ref": "geo.json",
-              "description": "The center coordinates. If omitted, the user's coarse location hints in the request context MUST be used to derive the center via forward geocoding strategies."
-            },
-            "max_distance": {
-              "type": "number",
-              "minimum": 0,
-              "description": "Maximum distance in RFC 7035 distance unit (meters)."
-            }
-          },
-          "additionalProperties": false
-        },
-        "serves": {
-          "type": "object",
-          "description": "Filter locations that serve the target destination (e.g., delivery area geofence check).",
-          "properties": {
-            "point": {
-              "$ref": "geo.json",
-              "description": "Coordinates of the target destination."
-            },
-            "address": {
-              "$ref": "locality.json",
-              "description": "Coarse postal address reference of the target destination (e.g., for ZIP-code based routing)."
-            }
-          },
-          "additionalProperties": true
-        }
-      },
-      "additionalProperties": false
-    },
     "hours": {
       "type": "object",
       "description": "Filter by operating hours, evaluated at the one supplied instant.",

--- a/source/schemas/common/types/location_serves.json
+++ b/source/schemas/common/types/location_serves.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/common/types/location_serves.json",
+  "title": "Location Serves",
+  "description": "A one-entry map whose key names the authoritative service-target representation. The Platform MUST supply exactly one target form. A Business that cannot evaluate a well-formed target, or receives an extension form that was not negotiated, MUST reject the request rather than ignore it, fall back, or broaden results. This dictionary-like representation map cannot host an ambient `ucp` member.",
+  "type": "object",
+  "minProperties": 1,
+  "maxProperties": 1,
+  "propertyNames": {
+    "anyOf": [
+      { "const": "point" },
+      { "const": "address" },
+      { "$ref": "reverse_domain_name.json" }
+    ]
+  },
+  "properties": {
+    "point": {
+      "$ref": "geo.json",
+      "description": "WGS 84 coordinates of the service target.",
+      "ucp_request": "optional"
+    },
+    "address": {
+      "allOf": [
+        { "$ref": "locality.json" },
+        {
+          "type": "object",
+          "anyOf": [
+            {
+              "required": ["address_country"],
+              "properties": {
+                "address_country": {
+                  "type": "string",
+                  "minLength": 1,
+                  "ucp_request": "required"
+                }
+              }
+            },
+            {
+              "required": ["address_region"],
+              "properties": {
+                "address_region": {
+                  "type": "string",
+                  "minLength": 1,
+                  "ucp_request": "required"
+                }
+              }
+            },
+            {
+              "required": ["postal_code"],
+              "properties": {
+                "postal_code": {
+                  "type": "string",
+                  "minLength": 1,
+                  "ucp_request": "required"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Coarse locality of the service target.",
+      "ucp_request": "optional"
+    }
+  },
+  "additionalProperties": true
+}

--- a/source/schemas/common/types/pagination.json
+++ b/source/schemas/common/types/pagination.json
@@ -16,8 +16,7 @@
         "limit": {
           "type": "integer",
           "minimum": 1,
-          "default": 10,
-          "description": "Requested page size. Implementations MAY clamp to a lower maximum."
+          "description": "Requested page size, not a guaranteed result count. When omitted, the Business MUST apply a default page size. A default of 10 is RECOMMENDED, but the Business MAY choose another value. The Business MAY return fewer results than the requested or default page size, including when enforcing its maximum page size. A Platform MUST NOT assume that the response count equals either value."
         }
       }
     },

--- a/source/services/common/mcp.openrpc.json
+++ b/source/services/common/mcp.openrpc.json
@@ -50,7 +50,7 @@
     {
       "name": "search_locations",
       "summary": "Search for physical locations",
-      "description": "Search for physical locations (e.g., retail stores, restaurants) using query text, filters, and geo proximity.",
+      "description": "Search for physical locations (e.g., retail stores, restaurants) using query text, explicit `distance` and `serves` relations, and structured filters (e.g., hours, amenities, inventory).",
       "params": [
         {
           "name": "meta",

--- a/source/services/common/mcp.openrpc.json
+++ b/source/services/common/mcp.openrpc.json
@@ -71,7 +71,7 @@
     {
       "name": "lookup_locations",
       "summary": "Batch lookup locations by identifier",
-      "description": "Batch lookup of physical locations by their stable identifiers. Returns matching locations and warnings.",
+      "description": "Batch lookup of physical Locations by supported identifiers. Returns matching Locations and warnings.",
       "params": [
         {
           "name": "meta",

--- a/source/services/common/rest.openapi.json
+++ b/source/services/common/rest.openapi.json
@@ -65,7 +65,7 @@
       "post": {
         "operationId": "lookup_locations",
         "summary": "Batch Lookup Locations",
-        "description": "Lookup one or more physical locations by their stable identifiers.",
+        "description": "Lookup one or more physical Locations by supported identifiers.",
         "parameters": [
           { "$ref": "#/components/parameters/authorization" },
           { "$ref": "#/components/parameters/x_api_key" },

--- a/source/services/common/rest.openapi.json
+++ b/source/services/common/rest.openapi.json
@@ -21,7 +21,7 @@
       "post": {
         "operationId": "search_locations",
         "summary": "Search Locations",
-        "description": "Search for physical locations (e.g., retail stores, restaurants) using query text, geo proximity, and structured filters (e.g., hours, amenities, inventory).",
+        "description": "Search for physical locations (e.g., retail stores, restaurants) using query text, explicit `distance` and `serves` relations, and structured filters (e.g., hours, amenities, inventory).",
         "parameters": [
           { "$ref": "#/components/parameters/authorization" },
           { "$ref": "#/components/parameters/x_api_key" },


### PR DESCRIPTION
Addresses some of the outstanding feedback on #589:

- moves `distance` and `serves` out of `filters.geo` and makes them independent root-level relations in Search and Lookup;
- defines deterministic distance and serviceability semantics without contextual fallback;
- preserves `filters` for predicates over inherent or current Location facts;
- mirrors Catalog’s batch Lookup response shape with required `inputs[]` correlation on every returned Location;
- keeps empty, hint-only, pagination-only, and filters-only Search requests as bounded browse operations.

## Why spatial relations are not filters

The previous `filters.geo` shape mixed two different kinds of constraints:

| Input | Meaning |
| :--- | :--- |
| `distance` | A relation between a candidate Location and an explicit Platform-supplied center and radius |
| `serves` | A relation between a candidate Location and an explicit Platform-supplied service target |
| `filters` | Predicates over inherent or current Location facts such as hours, amenities, and inventory |
| `context` / `signals` | Provisional ranking and localization hints, never spatial proof |

`distance` and `serves` now sit at the request root because their operands are external to the Location. Every supplied spatial relation and filter predicate combines with AND. Keeping the relations independent also permits requests such as “within five miles of this point and able to serve that address.” If both relations use the same point, the request repeats it explicitly rather than relying on hidden cross-field inheritance.

```json
{
  "distance": {
    "center": {
      "latitude": 40.707,
      "longitude": -74.011
    },
    "max": 10000
  },
  "serves": {
    "address": {
      "address_country": "US",
      "postal_code": "11201"
    }
  },
  "filters": {
    "inventory": [
      {
        "id": "item_id_phone_15_pro",
        "availability_status": "in_stock"
      }
    ]
  }
}
```

A returned Location must satisfy all three conditions:

```text
within 10,000 meters of distance.center
AND can provisionally serve serves.address
AND satisfies the inventory predicate
```

### `distance`

- requires an explicit `center` and inclusive `max` in meters;
- compares the unrounded shortest distance;

### `serves`

- contains exactly one target: `point`, coarse `address`, or a negotiated reverse-domain extension target;
- treats the supplied target as authoritative and never derives one from contextual hints;
- means that at least one currently available method at the Location can provisionally serve the target;
- does not expose coverage geometry, identify the qualifying method, reserve capacity, or guarantee checkout success;
- rejects unsupported or unevaluable targets rather than ignoring them or broadening results.

## Bounded browse

Search remains valid without `query`, `distance`, or `serves`. Empty, context-only, signals-only, pagination-only, and filters-only requests are bounded browse operations over the Business’s policy-controlled selection. They never mean an unbounded export, and an omitted `pagination.limit` retains the existing default of 10.

## Lookup correlation

Location Lookup now mirrors Catalog’s response shape: every returned Location carries a non-empty `inputs[]` array identifying the request identifiers that resolved to it.

```json
{
  "ids": ["loc_downtown", "downtown-store"]
}
```

```json
{
  "locations": [
    {
      "id": "loc_downtown",
      "inputs": [
        {"id": "loc_downtown"},
        {"id": "downtown-store"}
      ],
      "name": "Downtown Store"
    }
  ]
}
```

This supports unordered batch responses, secondary identifiers, multiple identifiers resolving to one Location, and one identifier resolving to multiple Locations.

Requiring `inputs[]` for direct canonical-ID matches adds minor payload overhead, but preserves the same uniform, schema-enforceable correlation rule as Catalog. Location does not copy Catalog’s `match` classification because it has no equivalent of product-to-featured-variant resolution.

## Batch limits

Batch limits are applied after duplicate identifiers are removed. When a request exceeds the Business maximum, the Business processes the first maximum number of distinct identifiers in request order and returns a successful partial response.

The response includes an informational message:

```json
{
  "type": "info",
  "code": "batch_limit_applied",
  "content": "Processed the first 2 of 3 distinct identifiers; 1 identifier was not processed."
}
```

The omitted suffix was not evaluated and must not be interpreted as unresolved. The Platform may submit it in a subsequent request. REST returns HTTP 200 and MCP returns a successful JSON-RPC result for this business outcome.