### PR TITLE
feat: Introduce anyOf constraint with payments example

### DIFF
--- a/docs/documentation/schema-authoring.md
+++ b/docs/documentation/schema-authoring.md
@@ -541,7 +541,7 @@ registered member.
 
 | Position | Admitted members | Shape |
 | :-- | :-- | :-- |
-| Object Constraint | `required`, `properties` | `required` contains unique field names; `properties` maps field names to Object or Value Constraints; an empty object is a no-op. |
+| Object Constraint | `required`, `properties`, `anyOf` | `required` contains unique field names; `properties` maps field names to Object or Value Constraints; `anyOf` is a non-empty array of Object Constraints; an empty object is a no-op. |
 | Value Constraint | `enum`, `const` | `enum` is non-empty and unique; at least one member is present; both apply when present together. |
 
 The listed members define the grammar. A `request_constraints` value may

--- a/docs/documentation/schema-authoring.md
+++ b/docs/documentation/schema-authoring.md
@@ -541,7 +541,7 @@ registered member.
 
 | Position | Admitted members | Shape |
 | :-- | :-- | :-- |
-| Object Constraint | `required`, `properties`, `anyOf` | `required` contains unique field names; `properties` maps field names to Object or Value Constraints; `anyOf` is a non-empty array of Object Constraints; an empty object is a no-op. |
+| Object Constraint | `required`, `properties`, `anyOf` | `required` contains unique field names; `properties` maps field names to Object or Value Constraints; `anyOf` is a non-empty array of non-empty Object Constraints; an empty object is a no-op except as an `anyOf` branch. |
 | Value Constraint | `enum`, `const` | `enum` is non-empty and unique; at least one member is present; both apply when present together. |
 
 The listed members define the grammar. A `request_constraints` value may

--- a/docs/specification/overview/index.md
+++ b/docs/specification/overview/index.md
@@ -226,7 +226,7 @@ Object Constraint's `properties` map.
 
 | Position | Admitted members | Shape and behavior |
 | :-- | :-- | :-- |
-| Object Constraint | `required`, `properties`, `anyOf` | `required` is an array of unique field names. `properties` maps field names to Object or Value Constraints. `anyOf` is a non-empty array of Object Constraints, at least one of which the object must satisfy. An empty Object Constraint is a valid no-op at any Object Constraint position. |
+| Object Constraint | `required`, `properties`, `anyOf` | `required` is an array of unique field names. `properties` maps field names to Object or Value Constraints. `anyOf` is a non-empty array of non-empty Object Constraints, at least one of which the object must satisfy. An empty Object Constraint is a valid no-op at every Object Constraint position except an `anyOf` branch. |
 | Value Constraint | `enum`, `const` | `enum` is a non-empty array of unique JSON values. `const` is any JSON value. At least one member is present; when both are present, both apply. |
 
 No other member is admitted at either grammar position.
@@ -236,6 +236,13 @@ narrow, override, or replace its siblings; the object must satisfy every
 sibling member and at least one branch. Each branch is an ordinary Object
 Constraint and cannot carry `path`, so every branch is evaluated against the
 same selected object.
+
+Branches are alternatives, not a partition: an object satisfying more than one
+branch is valid. Within a branch, `properties` constrains a member only when
+that member is present, so a branch pinning a discriminator through
+`properties` alone is also satisfied by an object that omits it; naming the
+discriminator in the branch's `required` makes the branch match only the shape
+it describes.
 
 ### Path
 
@@ -543,8 +550,8 @@ payment policy.
 #### Alternative verification requirements on a submitted credential
 
 A Business accepts more than one credential shape and requires different
-verification data for each. In this example, a submitted credential must carry
-either a `cvc` or a `cryptogram` with its `eci_value`:
+verification data for each. In this example, a raw PAN must carry a `cvc`, and a
+network token must carry a `cryptogram` with its `eci_value`:
 
 <!-- ucp:example schema=shopping/types/available_payment_instrument op=read direction=response -->
 ```json
@@ -557,8 +564,14 @@ either a `cvc` or a `cryptogram` with its `eci_value`:
       "properties": {
         "credential": {
           "anyOf": [
-            {"required": ["cvc"]},
-            {"required": ["cryptogram", "eci_value"]}
+            {
+              "properties": {"card_number_type": {"const": "fpan"}},
+              "required": ["card_number_type", "cvc"]
+            },
+            {
+              "properties": {"card_number_type": {"const": "network_token"}},
+              "required": ["card_number_type", "cryptogram", "eci_value"]
+            }
           ]
         }
       }
@@ -570,9 +583,21 @@ either a `cvc` or a `cryptogram` with its `eci_value`:
 One path selects the submitted instrument, and one Object Constraint describes
 it. The sibling `required` applies to every matching instrument; the `anyOf`
 branches then apply to the nested `credential` object, which must satisfy at
-least one. A credential carrying neither field fails, as does one carrying
-`cryptogram` without `eci_value`. Expressing the same rule as two separately
-targeted constraints would restate the path and lose the single-object reading.
+least one. Each branch pins `card_number_type` and also names it in `required`,
+so a branch matches only the credential shape it describes. A raw PAN without a
+`cvc` fails, as does a network token missing its `eci_value`.
+
+Because every branch pins the discriminator, the branch set also closes the
+accepted values. A `dpan` credential is valid under
+[`card_credential.json`](site:schemas/shopping/types/card_credential.json) but
+satisfies neither branch, so this Business does not accept it at this path. A
+Business that later accepts a new variant adds a branch for it.
+
+Two separately targeted constraints cannot express this rule. Request
+Constraints conjoin, so one value requiring `cvc` and another requiring
+`cryptogram` would require both. Discriminating through the path filter instead
+— selecting `fpan` credentials in one value and `network_token` credentials in
+another — moves conditional logic into the selector, which paths do not carry.
 
 ## Actions
 
@@ -2714,9 +2739,10 @@ POST /checkout-sessions/{id}/complete
   "payment": {
     "instruments": [
       {
+        "id": "pi_tok_visa",
         "handler_id": "merchant_tokenizer",
-        // ... more instrument required field
-        "credential": { "token": "tok_visa_123" }
+        "type": "card",
+        "credential": { "type": "card", "token": "tok_visa_123" }
       }
     ]
   },
@@ -2793,8 +2819,9 @@ POST /checkout-sessions/{id}/complete
   "payment": {
     "instruments": [
       {
+        "id": "pi_ap2_card",
         "handler_id": "ap2_234352",
-        // other required instruments fields
+        "type": "card",
         "credential": {
           "type": "card",
           "token": "eyJhbGciOiJ..." // Token would contain payment_mandate, the signed proof of funds auth

--- a/docs/specification/overview/index.md
+++ b/docs/specification/overview/index.md
@@ -221,15 +221,21 @@ optional `path`; nested constraint objects may not. The grammar does not admit
 `ucp`. Keys in `properties` name fields on selected request objects.
 
 The constraint begins at an Object Constraint. Object Constraints may nest
-through `properties`; Value Constraints occur only as values in an Object
-Constraint's `properties` map.
+through `properties` and `anyOf`; Value Constraints occur only as values in an
+Object Constraint's `properties` map.
 
 | Position | Admitted members | Shape and behavior |
 | :-- | :-- | :-- |
-| Object Constraint | `required`, `properties` | `required` is an array of unique field names. `properties` maps field names to Object or Value Constraints. An empty Object Constraint is a valid no-op at any Object Constraint position. |
+| Object Constraint | `required`, `properties`, `anyOf` | `required` is an array of unique field names. `properties` maps field names to Object or Value Constraints. `anyOf` is a non-empty array of Object Constraints, at least one of which the object must satisfy. An empty Object Constraint is a valid no-op at any Object Constraint position. |
 | Value Constraint | `enum`, `const` | `enum` is a non-empty array of unique JSON values. `const` is any JSON value. At least one member is present; when both are present, both apply. |
 
 No other member is admitted at either grammar position.
+
+Members present at the same Object Constraint all apply. `anyOf` does not
+narrow, override, or replace its siblings; the object must satisfy every
+sibling member and at least one branch. Each branch is an ordinary Object
+Constraint and cannot carry `path`, so every branch is evaluated against the
+same selected object.
 
 ### Path
 
@@ -533,6 +539,40 @@ a match, the constraint requires `billing_address` on every matching instrument.
 The payment-handler or instrument contract defines any stronger association.
 This example does not define card brands, credentials, support, availability, or
 payment policy.
+
+#### Alternative verification requirements on a submitted credential
+
+A Business accepts more than one credential shape and requires different
+verification data for each. In this example, a submitted credential must carry
+either a `cvc` or a `cryptogram` with its `eci_value`:
+
+<!-- ucp:example schema=shopping/types/available_payment_instrument op=read direction=response -->
+```json
+{
+  "type": "card",
+  "ucp": {
+    "request_constraints": {
+      "path": "$['payment']['instruments'][?@['handler_id'] == 'processor_1' && @['type'] == 'card']",
+      "required": ["credential"],
+      "properties": {
+        "credential": {
+          "anyOf": [
+            {"required": ["cvc"]},
+            {"required": ["cryptogram", "eci_value"]}
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+One path selects the submitted instrument, and one Object Constraint describes
+it. The sibling `required` applies to every matching instrument; the `anyOf`
+branches then apply to the nested `credential` object, which must satisfy at
+least one. A credential carrying neither field fails, as does one carrying
+`cryptogram` without `eci_value`. Expressing the same rule as two separately
+targeted constraints would restate the path and lose the single-object reading.
 
 ## Actions
 

--- a/main.py
+++ b/main.py
@@ -795,6 +795,19 @@ def define_env(env):
         )
       )
     else:
+      # A bare "#" is a self-root reference naming the schema being rendered.
+      # It carries no filename, so create_link derives an empty anchor and emits
+      # a broken "<page>/##" link. Recursive refs are irreducible: ucp-schema
+      # preserves them even under --bundle, so the docs layer is the only place
+      # that can name them. Resolve against this schema's own $id.
+      self_id = schema_data.get("$id")
+      self_ref_name = self_id.rsplit("/", 1)[-1] if self_id else None
+
+      def _deref_self(ref_value):
+        if ref_value == "#" and self_ref_name:
+          return self_ref_name
+        return ref_value
+
       for field_name, details in properties.items():
         if field_name == "$ref":
           md.append(
@@ -811,7 +824,7 @@ def define_env(env):
         )
 
         f_type = details.get("type", "any")
-        ref = details.get("$ref")
+        ref = _deref_self(details.get("$ref"))
 
         # Resolve UCP $defs references inline so properties render as
         # expanded tables (with anchors) instead of opaque links.
@@ -837,7 +850,7 @@ def define_env(env):
 
         # Check for Array specific logic
         items = details.get("items", {})
-        items_ref = items.get("$ref")
+        items_ref = _deref_self(items.get("$ref"))
 
         # Special handling for UCP version
         version_data = None
@@ -859,7 +872,9 @@ def define_env(env):
           for one_of_type in details.get("oneOf", []):
             if "$ref" in one_of_type:
               parts.append(
-                create_link(one_of_type["$ref"], spec_file_name, context)
+                create_link(
+                  _deref_self(one_of_type["$ref"]), spec_file_name, context
+                )
               )
             elif one_of_type.get("type"):
               parts.append(f"`{one_of_type['type']}`")

--- a/main.py
+++ b/main.py
@@ -712,6 +712,19 @@ def define_env(env):
     if not schema_data:
       return "_No content fields defined._"
 
+    # A bare "#" is a self-root reference naming the schema being rendered.
+    # It carries no filename, so create_link derives an empty anchor and emits
+    # a broken "<page>/##" link. Recursive refs are irreducible: ucp-schema
+    # preserves them even under --bundle, so the docs layer is the only place
+    # that can name them. Resolve against this schema's own $id.
+    self_id = schema_data.get("$id")
+    self_ref_name = self_id.rsplit("/", 1)[-1] if self_id else None
+
+    def _deref_self(ref_value):
+      if ref_value == "#" and self_ref_name:
+        return self_ref_name
+      return ref_value
+
     # If schema is ONLY a oneOf, render as prose instead of table
     if (
       "oneOf" in schema_data
@@ -722,7 +735,9 @@ def define_env(env):
       links = []
       for item in schema_data["oneOf"]:
         if "$ref" in item:
-          links.append(create_link(item["$ref"], spec_file_name, context))
+          links.append(
+            create_link(_deref_self(item["$ref"]), spec_file_name, context)
+          )
         elif item.get("type"):
           links.append(f"`{item.get('type')}`")
       if links:
@@ -795,19 +810,6 @@ def define_env(env):
         )
       )
     else:
-      # A bare "#" is a self-root reference naming the schema being rendered.
-      # It carries no filename, so create_link derives an empty anchor and emits
-      # a broken "<page>/##" link. Recursive refs are irreducible: ucp-schema
-      # preserves them even under --bundle, so the docs layer is the only place
-      # that can name them. Resolve against this schema's own $id.
-      self_id = schema_data.get("$id")
-      self_ref_name = self_id.rsplit("/", 1)[-1] if self_id else None
-
-      def _deref_self(ref_value):
-        if ref_value == "#" and self_ref_name:
-          return self_ref_name
-        return ref_value
-
       for field_name, details in properties.items():
         if field_name == "$ref":
           md.append(
@@ -907,7 +909,7 @@ def define_env(env):
                 continue
               if branch.get("$ref"):
                 inner_type = create_link(
-                  branch["$ref"], spec_file_name, context
+                  _deref_self(branch["$ref"]), spec_file_name, context
                 )
                 break
               if branch.get("title"):

--- a/source/schemas/common/types/constraint_expression.json
+++ b/source/schemas/common/types/constraint_expression.json
@@ -7,7 +7,8 @@
   "properties": {
     "required": {
       "type": "array",
-      "description": "Property names required by the constrained object.",
+      "description": "Property names required by the constrained object. Must be non-empty: an empty array applies no constraint.",
+      "minItems": 1,
       "uniqueItems": true,
       "items": {
         "type": "string"
@@ -15,7 +16,8 @@
     },
     "properties": {
       "type": "object",
-      "description": "Constraints keyed by property name.",
+      "description": "Constraints keyed by property name. Must be non-empty: an empty object applies no constraint.",
+      "minProperties": 1,
       "additionalProperties": {
         "oneOf": [
           {"$ref": "#"},

--- a/source/schemas/common/types/constraint_expression.json
+++ b/source/schemas/common/types/constraint_expression.json
@@ -25,9 +25,9 @@
     },
     "anyOf": {
       "type": "array",
-      "description": "Alternative Object Constraints. The constrained object must satisfy at least one.",
+      "description": "Alternative Object Constraints. The constrained object must satisfy at least one. A branch must be non-empty: an empty branch is satisfied by every object and neutralizes the alternation.",
       "minItems": 1,
-      "items": {"$ref": "#"}
+      "items": {"$ref": "#", "minProperties": 1}
     }
   },
   "additionalProperties": false,

--- a/source/schemas/common/types/constraint_expression.json
+++ b/source/schemas/common/types/constraint_expression.json
@@ -22,6 +22,12 @@
           {"$ref": "#/$defs/value_constraint"}
         ]
       }
+    },
+    "anyOf": {
+      "type": "array",
+      "description": "Alternative Object Constraints. The constrained object must satisfy at least one.",
+      "minItems": 1,
+      "items": {"$ref": "#"}
     }
   },
   "additionalProperties": false,

--- a/source/schemas/common/types/request_constraints.json
+++ b/source/schemas/common/types/request_constraints.json
@@ -11,7 +11,8 @@
     },
     "required": {
       "type": "array",
-      "description": "Property names required by the constrained object.",
+      "description": "Property names required by the constrained object. Must be non-empty: an empty array applies no constraint.",
+      "minItems": 1,
       "uniqueItems": true,
       "items": {
         "type": "string"
@@ -19,7 +20,8 @@
     },
     "properties": {
       "type": "object",
-      "description": "Constraints keyed by property name.",
+      "description": "Constraints keyed by property name. Must be non-empty: an empty object applies no constraint.",
+      "minProperties": 1,
       "additionalProperties": {
         "oneOf": [
           {"$ref": "constraint_expression.json"},

--- a/source/schemas/common/types/request_constraints.json
+++ b/source/schemas/common/types/request_constraints.json
@@ -26,6 +26,12 @@
           {"$ref": "constraint_expression.json#/$defs/value_constraint"}
         ]
       }
+    },
+    "anyOf": {
+      "type": "array",
+      "description": "Alternative Object Constraints. The constrained object must satisfy at least one.",
+      "minItems": 1,
+      "items": {"$ref": "constraint_expression.json"}
     }
   },
   "additionalProperties": false

--- a/source/schemas/common/types/request_constraints.json
+++ b/source/schemas/common/types/request_constraints.json
@@ -29,9 +29,9 @@
     },
     "anyOf": {
       "type": "array",
-      "description": "Alternative Object Constraints. The constrained object must satisfy at least one.",
+      "description": "Alternative Object Constraints. The constrained object must satisfy at least one. A branch must be non-empty: an empty branch is satisfied by every object and neutralizes the alternation.",
       "minItems": 1,
-      "items": {"$ref": "constraint_expression.json"}
+      "items": {"$ref": "constraint_expression.json", "minProperties": 1}
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
# Description

Resolving our open follow-up to #655, introducing the anyOf constraint to the base UCP constraints grammar.
Added a simple example using it with payments, and #424 is stacked on top of this to extend the usage of constraints across payments normatively.

## Category (Required)

_Please select one or more categories that apply to this change._

- [x] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.
