### PR TITLE
fix(docs): ignore root documentation links during spec-only verification

### DIFF
--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -92,6 +92,14 @@ def check_links():
     except Exception as e:
       print(f"Warning: Could not read .linkignore: {e}")
 
+  # When checking isolated specification builds (DOCS_MODE=spec), ignore links
+  # to documentation pages which only exist on the root site.
+  docs_mode = os.environ.get("DOCS_MODE", "root")
+  if docs_mode == "spec":
+    ignore_patterns.append(
+      re.compile(r"^(?:/|https?://[^/]+/|(?:\.\./)+)?documentation/.*")
+    )
+
   print(f"Scanning {ROOT_DIR} for broken links (Site URL: {SITE_URL})...")
 
   html_files = list(ROOT_DIR.rglob("*.html"))


### PR DESCRIPTION
# Description

When building and verifying isolated specification release builds (`DOCS_MODE=spec`), shared documentation pages located in `docs/documentation/` are excluded from the output directory because they are living pages published on the root site.

This change updates `scripts/check_links.py` to automatically ignore links pointing to `documentation/` when `DOCS_MODE` is set to `spec`, preventing false-positive broken link failures during release verification while maintaining strict validation on full site builds.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

Verified locally with:
```bash
DOCS_MODE=spec uv run mkdocs build --strict
DOCS_MODE=spec uv run python scripts/check_links.py site
```
Output:
```text
Scanning site for broken links (Site URL: https://ucp.dev/)...
All internal links validated successfully.
```
