### PR TITLE
Ig/anyof review suggestions

### DIFF
--- a/docs/documentation/schema-authoring.md
+++ b/docs/documentation/schema-authoring.md
@@ -541,7 +541,7 @@ registered member.
 
 | Position | Admitted members | Shape |
 | :-- | :-- | :-- |
-| Object Constraint | `required`, `properties`, `anyOf` | `required` contains unique field names; `properties` maps field names to Object or Value Constraints; `anyOf` is a non-empty array of Object Constraints; an empty object is a no-op. |
+| Object Constraint | `required`, `properties`, `anyOf` | `required` contains unique field names; `properties` maps field names to Object or Value Constraints; `anyOf` is a non-empty array of non-empty Object Constraints; an empty object is a no-op except as an `anyOf` branch. |
 | Value Constraint | `enum`, `const` | `enum` is non-empty and unique; at least one member is present; both apply when present together. |
 
 The listed members define the grammar. A `request_constraints` value may

--- a/docs/specification/overview/index.md
+++ b/docs/specification/overview/index.md
@@ -237,6 +237,13 @@ sibling member and at least one branch. Each branch is an ordinary Object
 Constraint and cannot carry `path`, so every branch is evaluated against the
 same selected object.
 
+Branches are alternatives, not a partition: an object satisfying more than one
+branch is valid. Within a branch, `properties` constrains a member only when
+that member is present, so a branch pinning a discriminator through
+`properties` alone is also satisfied by an object that omits it; naming the
+discriminator in the branch's `required` makes the branch match only the shape
+it describes.
+
 ### Path
 
 Every `request_constraints` value has exactly one effective path. When `path`
@@ -543,8 +550,8 @@ payment policy.
 #### Alternative verification requirements on a submitted credential
 
 A Business accepts more than one credential shape and requires different
-verification data for each. In this example, a submitted credential must carry
-either a `cvc` or a `cryptogram` with its `eci_value`:
+verification data for each. In this example, a raw PAN must carry a `cvc`, and a
+network token must carry a `cryptogram` with its `eci_value`:
 
 <!-- ucp:example schema=shopping/types/available_payment_instrument op=read direction=response -->
 ```json
@@ -557,8 +564,14 @@ either a `cvc` or a `cryptogram` with its `eci_value`:
       "properties": {
         "credential": {
           "anyOf": [
-            {"required": ["cvc"]},
-            {"required": ["cryptogram", "eci_value"]}
+            {
+              "properties": {"card_number_type": {"const": "fpan"}},
+              "required": ["card_number_type", "cvc"]
+            },
+            {
+              "properties": {"card_number_type": {"const": "network_token"}},
+              "required": ["card_number_type", "cryptogram", "eci_value"]
+            }
           ]
         }
       }
@@ -570,9 +583,21 @@ either a `cvc` or a `cryptogram` with its `eci_value`:
 One path selects the submitted instrument, and one Object Constraint describes
 it. The sibling `required` applies to every matching instrument; the `anyOf`
 branches then apply to the nested `credential` object, which must satisfy at
-least one. A credential carrying neither field fails, as does one carrying
-`cryptogram` without `eci_value`. Expressing the same rule as two separately
-targeted constraints would restate the path and lose the single-object reading.
+least one. Each branch pins `card_number_type` and also names it in `required`,
+so a branch matches only the credential shape it describes. A raw PAN without a
+`cvc` fails, as does a network token missing its `eci_value`.
+
+Because every branch pins the discriminator, the branch set also closes the
+accepted values. A `dpan` credential is valid under
+[`card_credential.json`](site:schemas/shopping/types/card_credential.json) but
+satisfies neither branch, so this Business does not accept it at this path. A
+Business that later accepts a new variant adds a branch for it.
+
+Two separately targeted constraints cannot express this rule. Request
+Constraints conjoin, so one value requiring `cvc` and another requiring
+`cryptogram` would require both. Discriminating through the path filter instead
+— selecting `fpan` credentials in one value and `network_token` credentials in
+another — moves conditional logic into the selector, which paths do not carry.
 
 ## Actions
 

--- a/docs/specification/overview/index.md
+++ b/docs/specification/overview/index.md
@@ -2714,9 +2714,10 @@ POST /checkout-sessions/{id}/complete
   "payment": {
     "instruments": [
       {
+        "id": "pi_tok_visa",
         "handler_id": "merchant_tokenizer",
-        // ... more instrument required field
-        "credential": { "token": "tok_visa_123" }
+        "type": "card",
+        "credential": { "type": "card", "token": "tok_visa_123" }
       }
     ]
   },
@@ -2793,8 +2794,9 @@ POST /checkout-sessions/{id}/complete
   "payment": {
     "instruments": [
       {
+        "id": "pi_ap2_card",
         "handler_id": "ap2_234352",
-        // other required instruments fields
+        "type": "card",
         "credential": {
           "type": "card",
           "token": "eyJhbGciOiJ..." // Token would contain payment_mandate, the signed proof of funds auth

--- a/docs/specification/overview/index.md
+++ b/docs/specification/overview/index.md
@@ -226,7 +226,7 @@ Object Constraint's `properties` map.
 
 | Position | Admitted members | Shape and behavior |
 | :-- | :-- | :-- |
-| Object Constraint | `required`, `properties`, `anyOf` | `required` is an array of unique field names. `properties` maps field names to Object or Value Constraints. `anyOf` is a non-empty array of Object Constraints, at least one of which the object must satisfy. An empty Object Constraint is a valid no-op at any Object Constraint position. |
+| Object Constraint | `required`, `properties`, `anyOf` | `required` is an array of unique field names. `properties` maps field names to Object or Value Constraints. `anyOf` is a non-empty array of non-empty Object Constraints, at least one of which the object must satisfy. An empty Object Constraint is a valid no-op at every Object Constraint position except an `anyOf` branch. |
 | Value Constraint | `enum`, `const` | `enum` is a non-empty array of unique JSON values. `const` is any JSON value. At least one member is present; when both are present, both apply. |
 
 No other member is admitted at either grammar position.

--- a/source/schemas/common/types/constraint_expression.json
+++ b/source/schemas/common/types/constraint_expression.json
@@ -25,9 +25,9 @@
     },
     "anyOf": {
       "type": "array",
-      "description": "Alternative Object Constraints. The constrained object must satisfy at least one.",
+      "description": "Alternative Object Constraints. The constrained object must satisfy at least one. A branch must be non-empty: an empty branch is satisfied by every object and neutralizes the alternation.",
       "minItems": 1,
-      "items": {"$ref": "#"}
+      "items": {"$ref": "#", "minProperties": 1}
     }
   },
   "additionalProperties": false,

--- a/source/schemas/common/types/request_constraints.json
+++ b/source/schemas/common/types/request_constraints.json
@@ -29,9 +29,9 @@
     },
     "anyOf": {
       "type": "array",
-      "description": "Alternative Object Constraints. The constrained object must satisfy at least one.",
+      "description": "Alternative Object Constraints. The constrained object must satisfy at least one. A branch must be non-empty: an empty branch is satisfied by every object and neutralizes the alternation.",
       "minItems": 1,
-      "items": {"$ref": "constraint_expression.json"}
+      "items": {"$ref": "constraint_expression.json", "minProperties": 1}
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
Nits/suggestions for #757.

**`docs: complete abridged payment instrument examples`** — Two `complete` examples elided `id`, `handler_id`, and `type` behind a `// ... more instrument required field` comment, and one also omitted `credential.type`. They only validate because shipped `ucp-schema` never applies the self-root `allOf` requirements in `selected_payment_instrument`, so `payment.instruments[]` is never checked against `payment_instrument`'s required members. [ucp-schema#44](https://github.com/Universal-Commerce-Protocol/ucp-schema/pull/44) fixes that; built against its head, this branch's base reports `316 passed, 2 failed` at exactly these two lines. Completing them costs one line each. 

**`feat: require non-empty anyOf branches in the constraint grammar`** — An empty Object Constraint is a valid no-op everywhere else, but an empty `anyOf` branch is satisfied by every object, so it neutralizes the alternation rather than doing nothing. Adds `minProperties: 1` as a sibling to the recursive `$ref` in both grammar schemas (legal 2020-12 sibling composition, applies at every nesting depth) and mirrors the constraint into both grammar tables.

**`docs: discriminate the anyOf credential example`** — The example's undiscriminated form does not enforce what the surrounding prose claims: `{"card_number_type": "anything", "cvc": "1"}` satisfies the `cvc` branch. Pins `card_number_type` with `const` in each branch and names it in that branch's `required`, matching the idiom #424 already uses in `payment/guide.md`. Uses the existing closed enum in `card_credential.json`, so it introduces no dependency on #424's new credential types.

Also documents the consequence that pinning creates — because every branch pins the discriminator, the branch set closes the accepted values, so a `dpan` credential valid under `card_credential.json` satisfies neither branch — and replaces the "would restate the path" justification. Request Constraints conjoin, so two separately targeted constraints would require *both* `cvc` and `cryptogram`; the real alternative is discriminating in the path filter, which puts conditional logic in the selector.