### PR TITLE
fix: separate resource binding from participant authorization 

### DIFF
--- a/docs/specification/payment/examples/platform-tokenizer-payment-handler.md
+++ b/docs/specification/payment/examples/platform-tokenizer-payment-handler.md
@@ -366,7 +366,7 @@ The platform application orchestrates the payment flow but
 
 1. The platform's **payment credential provider** securely stores payment credentials.
 2. When a payment is needed, the platform application requests a token from the credential provider.
-3. The credential provider generates a token bound to both the `binding` resource and the business's `identity` (from the handler declaration).
+3. The credential provider generates a token bound to the `binding` resource and issued to the business's `identity` (from the handler declaration).
 4. The credential provider returns the token to the platform application.
 5. The platform application includes this token in the checkout submission.
 
@@ -461,7 +461,7 @@ When the business forwards a token to the PSP:
 
 1. Extract the token from the payment instrument.
 2. Call the platform's **payment credential provider** `/detokenize` endpoint
-   with the business's identity in binding.
+   with the business's `identity` alongside the `binding`.
 3. Process the payment with the returned credential.
 
 #### Detokenize Request Example (PSP)
@@ -489,8 +489,9 @@ business, so they must specify which businesses' token they are retrieving.
 
 The platform's payment credential provider verifies that:
 
-* The PSP is authorized to detokenize for this business.
-* The `binding` and `identity` match the original tokenization.
+* The PSP is authorized to act for the business named by `identity`.
+* The `binding` matches the original tokenization, and `identity` resolves to
+  the participant the token was issued to.
 * The token has not expired or been used.
 
 ---
@@ -505,9 +506,9 @@ The platform's payment credential provider verifies that:
 | **No Platform App access** | Platform applications **MUST NOT** handle sensitive data—only the compliant payment credential provider does. |
 | **Endpoint isolation** | `/detokenize` endpoint **MUST** be exposed by the payment credential provider, not the platform application. |
 | **Participant authentication** | Platform's credential provider **MUST** authenticate businesses/PSPs before accepting `/detokenize` calls. |
-| **Identity binding** | Tokens **MUST** be bound to the business's `identity` from the handler declaration. |
+| **Identity binding** | Tokens **MUST** be issued to the business's `identity` from the handler declaration. |
 | **Resource-bound** | Tokens **MUST** be bound to the specific `binding` resource. |
-| **Caller verification** | Platform **MUST** verify authenticated caller matches the token's bound identity (or is an authorized PSP). |
+| **Caller verification** | Platform **MUST** verify the authenticated caller is the participant the token was issued to (or is an authorized PSP). |
 | **Single-use** | Tokens **SHOULD** be invalidated after detokenization. |
 | **Short TTL** | Tokens **SHOULD** expire shortly. |
 | **HTTPS required** | All `/detokenize` calls must use TLS. |

--- a/docs/specification/payment/template.md
+++ b/docs/specification/payment/template.md
@@ -370,8 +370,8 @@ Before participating in this handler's flow, {participants} **MUST** complete:
 
 | Requirement                  | Description                                                                                                                                                           |
 | :--------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Binding required**         | Credentials **MUST** be bound to the `binding` resource (`type` and `id`) and `identity` to prevent reuse.                                                            |
-| **Binding placement**        | Binding data (e.g., `binding`) **SHOULD** be included within the `credential` payload to ensure it is covered by the signature, rather than in transport headers.     |
+| **Binding required**         | Credentials **MUST** be bound to the `binding` resource (`type` and `id`) and issued to exactly one participant to prevent reuse.                                     |
+| **Binding placement**        | The `binding` object **SHOULD** be included within the `credential` payload to ensure it is covered by the signature, rather than in transport headers.               |
 | **Binding verified**         | The processing participant **MUST** verify binding matches before processing.                                                                                         |
 | **Token Expiry**             | {If using tokens: Tokens **MUST** expire after {duration} or single-use.}                                                                                             |
 | **Data Residency**           | {Specify if PII **MUST** be processed/stored in specific geographic regions (e.g., EU, US) to comply with local laws.}                                                |

--- a/docs/specification/payment/tokenization.md
+++ b/docs/specification/payment/tokenization.md
@@ -94,10 +94,10 @@ which lifecycle policy you use:
 All tokenization requests require a `binding` object that ties the token to a
 specific capability resource:
 
-| Field  | Required | Description                                                                          |
-| :----- | :------- | :----------------------------------------------------------------------------------- |
-| `type` | Yes      | The capability that owns the bound resource, for example `dev.ucp.shopping.checkout` |
-| `id`   | Yes      | Opaque identifier of the bound resource within that capability                       |
+| Field  | Required | Description                                                                                                 |
+| :----- | :------- | :---------------------------------------------------------------------------------------------------------- |
+| `type` | Yes      | The capability that owns the bound resource, for example `dev.ucp.shopping.checkout`                        |
+| `id`   | Yes      | Opaque identifier of the bound resource within that capability. The caller **MUST** send a non-empty string |
 
 See [Binding Schema](site:schemas/common/types/binding.json).
 
@@ -105,21 +105,33 @@ Resource scope and participant scope are separate. Requests carry `identity`
 alongside `binding` rather than inside it: `binding` says which resource the
 token is for, `identity` says which participant it is for. `identity` is
 required when the caller acts on behalf of another participant, and omitted
-when the authenticated caller is the binding target. See
+when the authenticated caller is that participant. See
 [Payment Identity Schema](site:schemas/common/types/payment_identity.json).
 
 Binding is a replay guard, not a resource reference. The following rules apply
 to every tokenizer:
 
-1. A Tokenizer **MUST** verify a binding by exact equality over the complete
-   `binding` object and over the `identity` presented with it. A Tokenizer
-   **MUST NOT** accept a partial match.
-2. A Tokenizer **MUST** treat `binding.id` as opaque. It **MUST NOT** parse the
-   value, resolve it, or verify that the identified resource exists.
+1. A Tokenizer **MUST** verify a binding by exact equality over `type` and
+   `id`. A Tokenizer **MUST NOT** accept a partial match, and **MUST** ignore
+   members of `binding` it does not recognize rather than rejecting the
+   request or including them in the comparison. Members other than `type` and
+   `id` are therefore not covered by the replay guard.
+2. A Tokenizer **MUST** treat `binding.id` as opaque: it **MUST NOT** require
+   the value to be resolvable, and **MUST NOT** reject a request because it
+   cannot confirm that the identified resource exists.
 3. A Tokenizer **MUST NOT** reject a request solely because it does not
    recognize `binding.type`. A tokenizer serving one capability today therefore
    remains usable by capabilities defined later without changing its
    implementation.
+4. Every token is issued to exactly one participant. A Tokenizer **MUST**
+   record that participant at `/tokenize` — from `identity` when present,
+   otherwise the authenticated caller. On `/detokenize` a Tokenizer **MUST**
+   resolve the requesting participant the same way, **MUST** verify it matches
+   the participant recorded at issuance, and **MUST** verify that the
+   authenticated caller is that participant or is authorized to act for it. A
+   Tokenizer **MUST NOT** return the credential when either check fails.
+   `identity` is a participant identifier, not a credential, and a Tokenizer
+   **MUST NOT** accept it as authentication.
 
 ---
 
@@ -131,7 +143,8 @@ payload example, which defines its own mechanism to encrypt.
 
 ### POST /tokenize
 
-Converts a raw credential into a token bound to a capability resource and identity.
+Converts a raw credential into a token bound to a capability resource and issued
+to a participant.
 
 **When to implement:** Always, unless you are an agent generating tokens
 internally.
@@ -205,9 +218,9 @@ Authorization: Bearer {caller_access_token}
 }
 ```
 
-**Note:** `identity` is omitted when the authenticated caller is the binding
-target. Include it when acting on behalf of another participant (e.g., PSP
-detokenizing for business).
+**Note:** `identity` is omitted when the authenticated caller is the participant
+the token was issued to. Include it when acting on behalf of another participant
+(e.g., PSP detokenizing for business).
 
 See the full [OpenAPI specification](site:handlers/tokenization/openapi.json) for complete request/response schemas.
 
@@ -215,16 +228,16 @@ See the full [OpenAPI specification](site:handlers/tokenization/openapi.json) fo
 
 ## Security Requirements
 
-| Requirement                  | Description                                                                                |
-| :--------------------------- | :----------------------------------------------------------------------------------------- |
-| **Binding required**         | Credentials **MUST** be bound to a `binding` resource and an `identity` to prevent reuse   |
-| **Binding verified**         | Tokenizer **MUST** verify binding matches before returning credentials                     |
-| **Cryptographically random** | Use secure random generators; tokens must be unguessable                                   |
-| **Sufficient length**        | Minimum 128 bits of entropy                                                                |
-| **Non-reversible**           | Cannot derive the credential from the token                                                |
-| **Scoped**                   | Token should only work with your tokenizer                                                 |
-| **Time-limited**             | Enforce TTL appropriate to use case (typically 5-30 minutes)                               |
-| **Single-use preferred**     | Invalidate after first detokenization when possible                                        |
+| Requirement                  | Description                                                                                                                    |
+| :--------------------------- | :----------------------------------------------------------------------------------------------------------------------------- |
+| **Binding required**         | Credentials **MUST** be bound to a `binding` resource (`type` and `id`) and issued to exactly one participant to prevent reuse |
+| **Binding verified**         | Tokenizer **MUST** verify binding matches before returning credentials                                                         |
+| **Cryptographically random** | Use secure random generators; tokens must be unguessable                                                                       |
+| **Sufficient length**        | Minimum 128 bits of entropy                                                                                                    |
+| **Non-reversible**           | Cannot derive the credential from the token                                                                                    |
+| **Scoped**                   | Token should only work with your tokenizer                                                                                     |
+| **Time-limited**             | Enforce TTL appropriate to use case (typically 5-30 minutes)                                                                   |
+| **Single-use preferred**     | Invalidate after first detokenization when possible                                                                            |
 
 ---
 
@@ -281,6 +294,7 @@ A tokenizer handler conforms to this pattern if it:
 - [ ] Requires `binding` with `type` and `id` on tokenization requests
 - [ ] Uses `PaymentIdentity` for participant identification
 - [ ] Verifies `binding` matches by exact equality on detokenization requests
+- [ ] Records the participant each token is issued to, and on detokenization verifies both that participant and the caller's authority to act for it
 - [ ] Accepts binding types it does not recognize
 - [ ] Requires security acknowledgements from participants receiving raw credentials
 

--- a/source/handlers/tokenization/openapi.json
+++ b/source/handlers/tokenization/openapi.json
@@ -29,7 +29,7 @@
                   },
                   "identity": {
                     "$ref": "../../schemas/common/types/payment_identity.json",
-                    "description": "The participant this token is bound to. Required when acting on behalf of another participant, for example an agent tokenizing for a business. Omit when the authenticated caller is the binding target."
+                    "description": "The participant this token is issued to. Required when acting on behalf of another participant, for example an agent tokenizing for a business. Omit when the authenticated caller is that participant."
                   }
                 }
               },
@@ -151,7 +151,7 @@
                   },
                   "identity": {
                     "$ref": "../../schemas/common/types/payment_identity.json",
-                    "description": "Participant identity that must match the original tokenization request. Omit when it was omitted at tokenization."
+                    "description": "Participant whose token is being retrieved. Required when the caller acts on behalf of another participant; omit when the authenticated caller is that participant."
                   }
                 }
               },

--- a/source/schemas/common/types/binding.json
+++ b/source/schemas/common/types/binding.json
@@ -12,6 +12,7 @@
     },
     "id": {
       "type": "string",
+      "minLength": 1,
       "description": "Opaque identifier of the bound resource within the owning capability, for example a checkout identifier."
     }
   }

--- a/source/schemas/common/types/payment_identity.json
+++ b/source/schemas/common/types/payment_identity.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ucp.dev/schemas/common/types/payment_identity.json",
   "title": "Payment Identity",
-  "description": "Identity of a participant for token binding. The access_token uniquely identifies the participant who tokens should be bound to.",
+  "description": "Identity of a participant for token binding. The access_token uniquely identifies the participant whom tokens should be issued to.",
   "type": "object",
   "required": ["access_token"],
   "properties": {


### PR DESCRIPTION
   A token is bound to a resource and issued to a participant. Those need
   different checks — the resource is a replay guard compared for exact
   equality, the participant is an authorization question.

   #746 moves `identity` out of the `binding` object but rule 1 still
   compares it. That can't work, because `identity` depends on who is
   calling: a business omits it when detokenizing directly, its PSP
   includes it when acting on the business's behalf (platform-tokenizer
   L288 and L487). Same token, two legal shapes, so equality over it
   passes at most one of them.

   - Rule 1 compares `type` and `id` only, and ignores unrecognized
     members rather than rejecting or comparing them. `binding` is an
     open object now and nothing else defines this.
   - Rule 2: a tokenizer must not *depend* on `binding.id` resolving,
     but may check locally if it owns the resource.
   - Rule 4 (new): record the participant at mint, verify it at burn.
   - `/detokenize` told callers to omit `identity` "when it was omitted
     at tokenization"; the prose says omit it when you are the target.
     Those disagree — fixed to match the prose.
   - `minLength: 1` on `binding.id`.