### PR TITLE
docs: fix garbled sentence in the JWT grant single-use requirement

### DIFF
--- a/docs/specification/common/identity-linking/index.md
+++ b/docs/specification/common/identity-linking/index.md
@@ -1018,10 +1018,10 @@ field conveys the business's value prompt to the platform (e.g.,
 * **JWT grant lifetime.** JWT authorization grants **MUST** be short-lived;
   the `exp` claim **SHOULD** be no more than 60 seconds after `iat`. Short
   lifetimes limit the window for grant theft and replay.
-* **JWT grant single-use.** Businesses **MUST** enforce single-use JWT;
-  a short exp narrows the replay window, but only jti tracking closes it.
+* **JWT grant single-use.** Businesses **MUST** enforce single-use JWT
   authorization grants by tracking the `jti` claim within the grant's
-  validity window.
+  validity window; a short `exp` narrows the replay window, but only
+  `jti` tracking closes it.
 * **Grant relay.** Businesses **MUST NOT** store or forward JWT
   authorization grants received from platforms. Grants are bearer
   credentials scoped to a single audience (`aud`) and a single use.


### PR DESCRIPTION
In the identity linking security considerations, the "JWT grant single-use" bullet reads:

> Businesses **MUST** enforce single-use JWT; a short exp narrows the replay window, but only jti tracking closes it. authorization grants by tracking the `jti` claim within the grant's validity window.

The exp clause was inserted mid-sentence, splitting "single-use JWT authorization grants" and leaving a dangling fragment. This rejoins the sentence and keeps both statements:

> Businesses **MUST** enforce single-use JWT authorization grants by tracking the `jti` claim within the grant's validity window; a short `exp` narrows the replay window, but only `jti` tracking closes it.

No normative change.