### PR TITLE
fix: require whole-word skip and a non-empty reason in example annotations

### DIFF
--- a/scripts/test_validate_examples.py
+++ b/scripts/test_validate_examples.py
@@ -261,6 +261,26 @@ def test_annotation_parsing() -> None:
   )
 
   # Unknown attribute key rejected via reserved _error
+  # skip must be a whole word. Each typo below carries a valid reason=, so
+  # only a whole-word check can reject them — a reason-only guard cannot.
+  for typo in ('skiped reason="oops"', 'skip_the_check reason="oops"',
+               'skipping validation reason="oops"'):
+    ann = v.parse_annotation(typo)
+    _check(
+      f"annotation_skip_typo_with_reason_not_skipped[{typo}]",
+      ann.get("skip") is None,
+      f"got {ann!r}",
+    )
+
+  # A bare or empty reason= is not auditable and must not skip.
+  for bad in ("skip", 'skip reason=""'):
+    ann = v.parse_annotation(bad)
+    _check(
+      f"annotation_skip_missing_reason_rejected[{bad}]",
+      ann.get("_error") is not None and ann.get("skip") is None,
+      f"got {ann!r}",
+    )
+
   ann = v.parse_annotation("shema=foo")  # typo
   _check(
     "annotation_unknown_key_rejected",

--- a/scripts/test_validate_examples.py
+++ b/scripts/test_validate_examples.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# cspell:ignore shema directon
+# cspell:ignore shema directon skiped
 """Contract conformance tests for validate_examples.py.
 
 Each test asserts one claim from the contract documented in
@@ -263,8 +263,11 @@ def test_annotation_parsing() -> None:
   # Unknown attribute key rejected via reserved _error
   # skip must be a whole word. Each typo below carries a valid reason=, so
   # only a whole-word check can reject them — a reason-only guard cannot.
-  for typo in ('skiped reason="oops"', 'skip_the_check reason="oops"',
-               'skipping validation reason="oops"'):
+  for typo in (
+    'skiped reason="oops"',
+    'skip_the_check reason="oops"',
+    'skipping validation reason="oops"',
+  ):
     ann = v.parse_annotation(typo)
     _check(
       f"annotation_skip_typo_with_reason_not_skipped[{typo}]",

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# cspell:ignore shema directon
+# cspell:ignore shema directon skiped
 """Validate JSON examples in UCP specification documentation.
 
 UCP doc examples use a bespoke JSON capability set: strict JSON plus

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -136,6 +136,10 @@ _KNOWN_ATTRS = frozenset(
   {"schema", "op", "direction", "extract", "target", "def"}
 )
 
+# `skip` must appear as a whole word. A prefix match would let a typo such as
+# `skiped` or `skip_the_check` silently disable validation for that example.
+_SKIP_RE = re.compile(r"skip\b")
+
 # -----------------------------------------------------------
 # Annotation parsing
 # -----------------------------------------------------------
@@ -149,11 +153,18 @@ def parse_annotation(text: str) -> dict:
   reported via a reserved "_error" key (consumed by process_block).
   """
   text = text.strip()
-  if text.startswith("skip"):
-    reason_match = re.search(r'reason="([^"]*)"', text)
+  if _SKIP_RE.match(text):
+    reason_match = re.search(r'reason="([^"]+)"', text)
+    if reason_match is None:
+      return {
+        "_error": (
+          'skip annotation requires a non-empty reason="..." '
+          "so every skipped example stays auditable"
+        )
+      }
     return {
       "skip": True,
-      "reason": (reason_match.group(1) if reason_match else ""),
+      "reason": reason_match.group(1),
     }
   attrs: dict = {}
   unknown: list[str] = []


### PR DESCRIPTION
`parse_annotation()` treats any annotation text beginning with `skip` as a skip:

```python
if text.startswith("skip"):
```

So `skiped`, `skip_the_check` and `skipping validation for now` each disable validation for that block, silently. `_KNOWN_ATTRS` catches the same class of typo on the validating path (`shema=`, `directon=`), but the skipping path has no guard. A typo that accidentally validates is loud; one that accidentally skips is invisible.

The `reason` field looks like it's there so every skip stays auditable, but it's optional in the parse — a bare `skip` returns `{"skip": True, "reason": ""}`.

Nothing is broken today. All 51 skip annotations in the docs use the documented `skip reason="..."` form. This is a guard against a future silent loss of coverage, not a live bug.

The fix matches `skip` as a whole word and returns the existing `_error` when `reason` is missing or empty. `process_block` already handles `_error` ahead of the skip branch, so nothing else changes.

Tested: all 51 live skip annotations still parse as skips. `scripts/test_validate_examples.py` goes from 42 to 47 passing, with the same two pre-existing failures (`ucp-schema` not on PATH).
