### PR TITLE
docs: remove stale example corpus counts

### DIFF
--- a/scripts/test_validate_examples.py
+++ b/scripts/test_validate_examples.py
@@ -10,8 +10,8 @@ broke.
 
 Two layers of testing exist for the validator:
 
-  - **The doc corpus is the integration test.** All 268 ```json blocks
-    across 39 spec docs are validated on every CI run. This proves
+  - **The doc corpus is the integration test.** All annotated ```json
+    blocks across the spec docs are validated on every CI run. This proves
     real-world examples conform to the contract.
 
   - **This file is the unit test layer.** It proves the contract is


### PR DESCRIPTION
## Description

`scripts/test_validate_examples.py` described the integration corpus as 268
`json` blocks across 39 spec documents. The current validator audit finds 393
annotated blocks across 53 documents, so those fixed counts had already become
stale as the documentation grew.

**Fix:** describe the CI contract as validating all annotated `json` blocks
across the spec docs, without encoding a corpus size that changes with normal
documentation additions.

## Category (Required)

- [ ] **Core Protocol**: Protocol specification changes. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Governance or contribution process changes. (Requires Governance Council approval)
- [ ] **Capability**: Capability specification changes. (Requires Maintainer approval)
- [x] **Documentation**: Documentation updates. (Requires Maintainer approval)
- [ ] **Infrastructure**: Build, CI, tooling, or release changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency, compatibility, or routine maintenance changes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Repository-wide health files and configuration. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under `python_sdk`.

## Screenshots / Logs (if applicable)

`uv run python scripts/test_validate_examples.py`: 52 passed, 0 failed  
`uv run python scripts/validate_examples.py --schema-base source/schemas/ --audit`: 393 annotated blocks across 53 files  
`uvx pre-commit run --all-files`: passed
