### PR TITLE
fix(idempotency): define payload identity per operation class

### DIFF
--- a/docs/specification/shopping/cart/rest.md
+++ b/docs/specification/shopping/cart/rest.md
@@ -482,8 +482,8 @@ operations unless otherwise noted.
 * **Idempotency-Key**: Operations that modify state **SHOULD** support
     idempotency. When provided, the server **MUST**:
     1. Store the key with the operation result for at least 24 hours.
-    2. Return the cached result for duplicate keys whose request body matches the original.
-    3. Return `409 Conflict` if the key is reused with a mismatched body.
+    2. Return the cached result for duplicate keys whose payload matches the original.
+    3. Return `409 Conflict` if the key is reused with a mismatched payload.
     See [Message Signatures — Idempotency Key Requirements](../../signatures.md#replay-protection)
     for the full payload-matching contract.
 

--- a/docs/specification/shopping/checkout/mcp.md
+++ b/docs/specification/shopping/checkout/mcp.md
@@ -109,6 +109,14 @@ The `meta["ucp-agent"]` field is **required** on all requests to enable
 `meta["idempotency-key"]` for retry safety. Platforms **MAY** include
 additional metadata fields.
 
+When the request is signed, the covered `Idempotency-Key` header (see
+[Message Signing](#message-signing)) is authoritative for the idempotency
+key; `meta["idempotency-key"]` **MUST** equal it, and the Business
+**MUST** reject a mismatch without executing. On unsigned requests,
+`meta["idempotency-key"]` alone is authoritative. See
+[Message Signatures — Replay Protection](../../signatures.md#replay-protection)
+for the full payload-matching contract.
+
 ## Tools
 
 UCP Capabilities map 1:1 to MCP Tools.

--- a/docs/specification/shopping/checkout/rest.md
+++ b/docs/specification/shopping/checkout/rest.md
@@ -1308,8 +1308,8 @@ operations unless otherwise noted.
 * **Idempotency-Key**: Operations that modify state **SHOULD** support
     idempotency. When provided, the server **MUST**:
     1. Store the key with the operation result for at least 24 hours.
-    2. Return the cached result for duplicate keys whose request body matches the original.
-    3. Return `409 Conflict` if the key is reused with a mismatched body.
+    2. Return the cached result for duplicate keys whose payload matches the original.
+    3. Return `409 Conflict` if the key is reused with a mismatched payload.
     See [Message Signatures — Idempotency Key Requirements](../../signatures.md#replay-protection)
     for the full payload-matching contract.
 

--- a/docs/specification/signatures.md
+++ b/docs/specification/signatures.md
@@ -865,19 +865,28 @@ transport envelope:
   anything beyond `meta` and the target resource identifier —
   `complete_checkout` is in this class by schema. Businesses **MUST**
   detect a payload mismatch by comparing the SHA-256 hash of the
-  operation's arguments with the transport envelope excluded (the
-  request body for REST; the `params.arguments` object with `meta`
-  removed for MCP) — not the full JSON-RPC message bytes, whose
-  envelope fields (the JSON-RPC `id`, `meta`) are guaranteed to vary
-  per retry. The hash is compared within the key binding above, so a
-  reused key is rejected on an operation or target mismatch before any
-  hash comparison. Businesses persist this hash alongside the key; for REST
-  the hashed input remains the raw body bytes, the same digest RFC 9530
-  mandates as `Content-Digest`. The Business computes both the stored
-  and the compared hash itself, from each request as received, applying
-  the same deterministic procedure to exclude `meta`; no cross-party
-  canonical form is defined or needed, which preserves the spec's
-  no-canonicalization posture.
+  operation's arguments with the transport envelope excluded — not the
+  full JSON-RPC message bytes, whose envelope fields (the JSON-RPC
+  `id`, `meta`) are guaranteed to vary per retry. The hash is compared
+  within the key binding above, so a reused key is rejected on an
+  operation or target mismatch before any hash comparison, and
+  Businesses persist this hash alongside the key. The hashed input is
+  transport specific:
+
+    * For REST, the raw request body bytes as received, the same digest
+      RFC 9530 mandates as `Content-Digest`. No canonicalization: the
+      body is a single byte string on the wire and is hashed as such.
+    * For MCP, the `params.arguments` object with its top-level
+      `meta` member removed, serialized with the JSON
+      Canonicalization Scheme
+      ([RFC 8785](https://datatracker.ietf.org/doc/html/rfc8785)), the
+      canonicalization this specification already uses for durable
+      artifacts in
+      [AP2 Mandates](payment/extensions/ap2-mandates.md#canonicalization).
+      Removing a member is an operation on a parsed value, not on bytes,
+      so this class adopts canonicalization explicitly: logically
+      identical retries hash identically regardless of member order or
+      serializer, tolerating re-serialization across client stacks.
 
 Platforms **MUST** generate a fresh idempotency key whenever they modify
 a payload-carrying operation's arguments — including retries with

--- a/docs/specification/signatures.md
+++ b/docs/specification/signatures.md
@@ -823,6 +823,13 @@ Signature-Input: sig1=("@method" "@authority" "@path" "idempotency-key" ...);key
 Signature: sig1=:6G4i8TS6oUkGrx8KnCFUpsSPwd74...:
 ```
 
+Some bindings also carry the key inside the request payload (over MCP,
+`meta["idempotency-key"]` in the tool arguments). When the request is
+signed, the covered `Idempotency-Key` header is authoritative for the
+idempotency key; a payload copy of the key **MUST** equal it, and
+Businesses **MUST** reject a mismatch without executing. On unsigned
+requests, the payload copy alone is authoritative.
+
 **Idempotency Key Requirements:**
 
 | Requirement | Value |
@@ -834,18 +841,43 @@ Signature: sig1=:6G4i8TS6oUkGrx8KnCFUpsSPwd74...:
 | **On duplicate (mismatched payload)** | Reject with `409 Conflict` (REST) / `-32000` (MCP); do not execute |
 | **On storage failure** | Fail closed (reject request with 503) |
 
-**Payload Matching:** Businesses **MUST** detect whether the payload of
-a duplicate-key request matches the payload of the original by
-comparing the SHA-256 hash of the raw body bytes — the same digest
-RFC 9530 mandates as `Content-Digest`. When signing is in use, this
-value is supplied in the `Content-Digest` header and the Intermediary
-Warning above guarantees byte fidelity end-to-end; businesses persist
-it alongside the idempotency key. For unsigned requests, businesses
-compute the same digest from the received body bytes. Platforms
-therefore **MUST** generate a fresh idempotency key whenever they
-modify the request payload — including retries with modified payment
-instruments, updated shipping addresses, swapped line items, or any
-other change to the request body.
+**Payload Matching:** Payload identity is defined per operation, by
+whether the operation's arguments carry anything beyond `meta` and the
+target resource identifier — a class decidable from the operation's
+input schema alone, not from the transport envelope:
+
+* **Target-only operations.** The operation's arguments carry nothing
+  beyond `meta` and the target resource identifier (the path parameter
+  for REST, the top-level `id` argument for MCP) — `cancel_checkout` is
+  in this class by schema. Payload identity is the pair (idempotency
+  key, target resource identifier); Businesses persist the identifier
+  alongside the key. Businesses **MUST** treat a request as a replay,
+  and return the stored result, when its key matches a stored key and
+  its target resource identifier matches the identifier stored with
+  that key. Businesses **MUST** reject, without executing, a request
+  whose key matches a stored key but whose target resource identifier
+  differs from the identifier stored with that key. No hashing or
+  canonicalization applies to this class.
+* **Payload-carrying operations.** The operation's arguments carry
+  anything beyond `meta` and the target resource identifier —
+  `complete_checkout` is in this class by schema. Businesses **MUST**
+  detect a payload mismatch by comparing the SHA-256 hash of the
+  operation's arguments with the transport envelope excluded (the
+  request body for REST; the `params.arguments` object with `meta`
+  removed for MCP) — not the full JSON-RPC message bytes, whose
+  envelope fields (the JSON-RPC `id`, `meta`) are guaranteed to vary
+  per retry. Businesses persist this hash alongside the key; for REST
+  the hashed input remains the raw body bytes, the same digest RFC 9530
+  mandates as `Content-Digest`. The Business computes both the stored
+  and the compared hash itself, from each request as received, applying
+  the same deterministic procedure to exclude `meta`; no cross-party
+  canonical form is defined or needed, which preserves the spec's
+  no-canonicalization posture.
+
+Platforms **MUST** generate a fresh idempotency key whenever they modify
+a payload-carrying operation's arguments — including retries with
+modified payment instruments, updated shipping addresses, swapped line
+items, or any other change to the request payload.
 
 **Note:** For **default UCP** signatures, the RFC 9421 `created`
 parameter is **OPTIONAL** and replay protection is handled at the

--- a/docs/specification/signatures.md
+++ b/docs/specification/signatures.md
@@ -841,23 +841,26 @@ requests, the payload copy alone is authoritative.
 | **On duplicate (mismatched payload)** | Reject with `409 Conflict` (REST) / `-32000` (MCP); do not execute |
 | **On storage failure** | Fail closed (reject request with 503) |
 
-**Payload Matching:** Payload identity is defined per operation, by
-whether the operation's arguments carry anything beyond `meta` and the
-target resource identifier — a class decidable from the operation's
-input schema alone, not from the transport envelope:
+**Payload Matching:** A stored idempotency key binds the operation it
+was first used with and, where one exists, the target resource
+identifier (the path parameter for REST, the top-level `id` argument
+for MCP). Businesses **MUST** reject, without executing, any request
+that reuses a stored key with a different operation or a different
+target resource identifier. Within that binding, payload identity is
+defined per operation, by whether the operation's arguments carry
+anything beyond `meta` and the target resource identifier — a class
+decidable from the operation's input schema alone, not from the
+transport envelope:
 
 * **Target-only operations.** The operation's arguments carry nothing
   beyond `meta` and the target resource identifier (the path parameter
   for REST, the top-level `id` argument for MCP) — `cancel_checkout` is
-  in this class by schema. Payload identity is the pair (idempotency
-  key, target resource identifier); Businesses persist the identifier
-  alongside the key. Businesses **MUST** treat a request as a replay,
-  and return the stored result, when its key matches a stored key and
-  its target resource identifier matches the identifier stored with
-  that key. Businesses **MUST** reject, without executing, a request
-  whose key matches a stored key but whose target resource identifier
-  differs from the identifier stored with that key. No hashing or
-  canonicalization applies to this class.
+  in this class by schema. Payload identity is the key binding itself:
+  Businesses persist the operation and the target resource identifier
+  alongside the key, and **MUST** treat a request as a replay, and
+  return the stored result, when key, operation, and identifier all
+  match the stored record. No hashing or canonicalization applies to
+  this class.
 * **Payload-carrying operations.** The operation's arguments carry
   anything beyond `meta` and the target resource identifier —
   `complete_checkout` is in this class by schema. Businesses **MUST**
@@ -866,7 +869,9 @@ input schema alone, not from the transport envelope:
   request body for REST; the `params.arguments` object with `meta`
   removed for MCP) — not the full JSON-RPC message bytes, whose
   envelope fields (the JSON-RPC `id`, `meta`) are guaranteed to vary
-  per retry. Businesses persist this hash alongside the key; for REST
+  per retry. The hash is compared within the key binding above, so a
+  reused key is rejected on an operation or target mismatch before any
+  hash comparison. Businesses persist this hash alongside the key; for REST
   the hashed input remains the raw body bytes, the same digest RFC 9530
   mandates as `Content-Digest`. The Business computes both the stored
   and the compared hash itself, from each request as received, applying

--- a/docs/specification/signatures.md
+++ b/docs/specification/signatures.md
@@ -952,8 +952,10 @@ Signature: sig1=:6G4i8TS6oUkGrx8KnCFUpsSPwd74...:
 {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"complete_checkout","arguments":{"id":"chk_123","checkout":{...}}}}
 ```
 
-The JSON-RPC message is the HTTP body. `Content-Digest` binds it to the signature.
-No JSON canonicalization is required.
+The JSON-RPC message is the HTTP body. `Content-Digest` binds it to the signature;
+no JSON canonicalization is required for signing. For payload matching, the
+payload-carrying class canonicalizes `params.arguments` with JCS, as defined under
+[Replay Protection](#replay-protection).
 
 ## Error Handling
 


### PR DESCRIPTION
## Motivation

#664: idempotency payload matching is defined as a SHA-256 hash over the raw HTTP body bytes. Over MCP the signed body is the full JSON-RPC envelope, and the MCP base protocol requires the request `id` to not repeat within a session, so a compliant client retry can never be byte identical to the original request. Raw-body hashing therefore treats every legitimate retry of `complete_checkout` and `cancel_checkout` as a mismatched payload and rejects it without executing, on exactly the two operations idempotency exists to protect. This is not an edge case with a crafted client. It follows from the base MCP protocol as written, for any conforming client.

A second, related gap: the idempotency key can appear in two places on a signed MCP request, the covered `Idempotency-Key` header and `meta["idempotency-key"]` in the tool arguments, with no stated rule for which one governs when they disagree.

## The resolution

This PR implements the class split proposed by YanisMtcr in the #664 thread, building on the raw-arguments direction from westonale-facet (envelope excluded):

1. Operations whose arguments carry nothing beyond `meta` and the target resource id are decidable as a class from the operation's input schema alone. `cancel_checkout` is in this class: its OpenRPC params are exactly `meta` and `id`. For this class, payload identity is the pair (idempotency key, target resource id). A matching pair returns the stored result; a matching key with a different resource id is rejected without executing. No hashing, no canonicalization.
2. Operations whose arguments carry anything more are the payload-carrying class. `complete_checkout` is in this class: its OpenRPC params add a `checkout` object. For this class, payload matching stays a SHA-256 hash, now scoped to the operation's arguments with the transport envelope excluded (for MCP the `params.arguments` object with its top level `meta` member removed, serialized with JCS per RFC 8785; for REST the request body), not the JSON-RPC message bytes. For REST the hashed input remains the raw body bytes, so the existing `Content-Digest` linkage is unchanged.
3. When the request is signed, the covered `Idempotency-Key` header is authoritative and any payload copy of the key must equal it; a mismatch is rejected without executing. On unsigned requests, the payload copy alone is authoritative. This rule lives in signatures.md (Idempotency Key Placement), because a payload copy of the key exists wherever a signed MCP request carries `meta["idempotency-key"]` (`cancel_cart` requires it too, not just the checkout operations); the checkout MCP binding restates it where both locations are visible in the examples.

## Exact changes

- `docs/specification/signatures.md` (Idempotency Key Placement, under Replay Protection): adds the key location rule, binding general.
- `docs/specification/signatures.md` (Payload Matching, same section): replaces the single raw-body-hash rule with the two-class definition above; the fresh-key-on-payload-change guidance is retained, scoped to the payload-carrying class.
- `docs/specification/shopping/checkout/mcp.md` (Request Metadata): restates the key location rule for this binding.
- `docs/specification/shopping/checkout/rest.md` and `docs/specification/shopping/cart/rest.md` (Idempotency-Key header items): the duplicate-key items now say payload rather than request body. This is a consequence of the class split, not new scope: those items defer to signatures.md for the full payload-matching contract, and for cancel operations (no request body) the old body-matching summary would contradict the pair rule — a reused key with a different target previously counted as a matching payload because two empty bodies hash equal, and returned the cached response of a different resource; under the class split it is rejected without executing.

No schema files change. `cancel_cart` shares the same params shape as `cancel_checkout` (`meta`, `id`) in `source/services/shopping/mcp.openrpc.json`, so it falls under the target-only class through the same schema-general rule in signatures.md, with no separate edit needed in the cart docs.

## Related work

#679 documents the MCP server contract by reference to the REST binding and the overview error registry, at `docs/specification/checkout-mcp.md`, a path removed by the #723 specification reorg (current location is `docs/specification/shopping/checkout/mcp.md`). Because #679 documents by reference rather than restating the contract, it stays compatible with this PR once rebased onto the current paths: its reference to Replay Protection picks up the class split here.

## Testing

- `python3 scripts/validate_examples.py --schema-base source/schemas/`: 343 passed, 0 failed, 0 errors, 50 skipped on this branch, identical to a clean checkout of main at the base SHA.
- `ucp-schema lint source/`: 124 files checked, all passed. No schema files were touched by this PR.
- Relative links added in the diff checked by hand against the built anchors: `docs/specification/shopping/checkout/mcp.md#message-signing` and `docs/specification/signatures.md#replay-protection`, both existing headings, unchanged by this PR.
- Full-tree conflict marker sweep: none found.

## Amendment: the key binding

Probing both reference implementations against a literal reading of the class rules surfaced two gaps in the first commit, both closed by the second: the class 2 identity omitted the REST path identifier, which would have recreated for updates the cross resource replay the class 1 rule fixes for cancels, and cross operation key reuse was undefined while update_checkout and complete_checkout share identical argument shapes. The section now opens with a binding rule, a stored key binds the operation it was first used with and the target resource identifier where one exists, and any reuse across that binding is rejected without executing, before payload comparison. Both reference implementations already persist exactly this operation and resource scoping for checkout operations, so the binding codifies existing practice rather than adding new state.

## Amendment: JCS for the payload-carrying MCP hash

The review from westonale-facet is right that removing `meta` is an operation on a parsed value, so an unnamed per implementation re serialization was standing in for a canonical form, and member order variance across attempts would recreate the guaranteed retry mismatch on the MCP side. The payload carrying MCP hash input is now the `params.arguments` object with its top level `meta` member removed, serialized with JCS (RFC 8785), the canonicalization the specification already uses for AP2 mandate artifacts; the no canonicalization statement is scoped to the REST arm, where the hashed input really is the received byte string. Checked against an executable implementation of the full rule: member order permutations, whitespace variants, unicode escapes versus literals, and number forms (1 versus 1.0 versus 1e0) hash identically, while changed payloads, nested `meta` members inside `checkout`, cross operation reuse, and cross target reuse are all rejected.
