### PR TITLE
docs: clarify Accelerated IdP Flow subject token

### DIFF
--- a/docs/specification/common/identity-linking/index.md
+++ b/docs/specification/common/identity-linking/index.md
@@ -524,6 +524,34 @@ UCP tightens the JWT authorization grant beyond what the base RFCs
 mandate: `aud` **MUST** be a single-valued URI plus a unique `jti` (see
 [JWT Authorization Grant](#jwt-authorization-grant)).
 
+### Subject Token
+
+The `subject_token` passed in [Step 2](#flow) is an access token the platform
+previously obtained from the IdP on behalf of the user. Platforms acquire this
+token by completing an OAuth 2.0 Authorization Code flow (with PKCE) directly
+against the IdP's authorization server — the same flow as
+[Account Linking Flow](#account-linking-flow), but targeting the IdP rather than
+a business.
+
+This initial IdP connection is a prerequisite for the Accelerated IdP Flow.
+Without it, platforms **MUST** fall back to direct OAuth on the business domain
+(see [Identity Providers](#identity-providers)).
+
+**Minimum token requirements.** The subject token **MUST** have been issued to
+the authenticated user whose identity is being chained. Platforms **MUST NOT**
+present subject tokens issued to a different user and **MUST NOT** reuse a
+subject token across users.
+
+The IdP defines which scopes a token must carry to be accepted in a token
+exchange request. At minimum, the token **SHOULD** have been issued with
+`openid` scope so that the IdP can resolve the user's `sub` and populate
+standard OIDC claims in the resulting JWT authorization grant. Platforms
+**SHOULD** also request scopes covering any claims listed in the target
+business's `required_claims` (see
+[Provider Configuration](#provider-configuration)) during the initial IdP
+connection — for example, including `email` scope so that `email` and
+`email_verified` are available in grants when businesses require them.
+
 ### Flow
 
 1. Platform discovers `config.providers` in the business's identity linking
@@ -692,6 +720,23 @@ IdP **MUST**:
 * Issue a JWT authorization grant conforming to the
     [JWT Authorization Grant](#jwt-authorization-grant) requirements.
 * Return `issued_token_type` as `urn:ietf:params:oauth:token-type:jwt`.
+
+**Consent models.** UCP does not prescribe how the IdP establishes that the
+user has authorized identity sharing with a given business. Two common
+approaches are:
+
+* **Platform-level consent:** Authorization to share identity is captured when
+    the user connects their account to the platform at the IdP (for example,
+    via `openid` or an IdP-specific scope during the initial
+    [Subject Token](#subject-token) acquisition). The IdP then issues grants
+    for any relying party in its ecosystem without per-business interaction.
+* **Per-business consent:** The IdP prompts the user interactively the first
+    time a grant is requested for a new business, records the authorization, and
+    issues subsequent grants silently.
+
+IdPs **SHOULD** document which model they implement. Platforms **SHOULD**
+communicate the applicable consent model to users before initiating identity
+chaining (see [General Guidelines for Platforms](#for-platforms)).
 
 IdPs **SHOULD** populate OIDC Core §5.1 standard claims in JWT
 authorization grants when the user has consented to share them — at
@@ -1266,3 +1311,145 @@ Business validates `code_verifier` against stored `code_challenge`, returns:
 
 Platform now includes `Authorization: Bearer <token>` on subsequent requests
 to user-authenticated capability endpoints.
+
+### End-to-End Walkthrough (Accelerated IdP Flow)
+
+**Setup:** Platform (AI shopping agent) + Business (B2C retailer). The business
+lists `app.example.login` as a trusted provider in `config.providers`:
+
+<!-- ucp:example skip reason="OAuth metadata, not UCP payload" -->
+```json
+{
+  "providers": {
+    "app.example.login": [
+      {
+        "type": "oauth2",
+        "auth_url": "https://accounts.example-login.app/",
+        "required_claims": ["email"]
+      }
+    ]
+  },
+  "scopes": {
+    "dev.ucp.shopping.order:read":   {},
+    "dev.ucp.shopping.order:manage": {}
+  }
+}
+```
+
+**Prerequisite — Subject token acquisition.** The platform previously linked
+the user's identity with `app.example.login` using the standard Authorization
+Code flow (see [Subject Token](#subject-token)):
+
+```text
+GET https://accounts.example-login.app/oauth2/authorize
+  ?response_type=code
+  &client_id=platform-client-id
+  &redirect_uri=https://agent.example.com/idp-callback
+  &scope=openid email
+  &code_challenge=<S256-hash>
+  &code_challenge_method=S256
+  &state=<random>
+```
+
+The user authenticated and consented at the IdP. The platform exchanged the
+authorization code for a subject token scoped to `openid email` and stores it
+for subsequent token exchange requests.
+
+**Step 1 — Discover providers.** Platform reads the business's `config.providers`,
+finds `app.example.login` with `required_claims: ["email"]`. The platform holds a
+subject token with `email` scope — the entry is a match.
+
+**Step 2 — Token exchange at the IdP.** Platform calls the IdP's token endpoint
+using the token exchange grant type
+([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693){ target="_blank" }):
+
+```http
+POST https://accounts.example-login.app/oauth2/token
+Authorization: Basic <base64(platform-client-id:platform-client-secret)>
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+&subject_token=<idp-access-token>
+&subject_token_type=urn:ietf:params:oauth:token-type:access_token
+&audience=https://merchant.example.com
+&requested_token_type=urn:ietf:params:oauth:token-type:jwt
+```
+
+The `:` characters in URN values and the `&` separators must be percent-encoded
+in the actual request; they are shown decoded here for readability.
+
+The IdP validates the subject token, confirms the user has authorized identity
+sharing with `https://merchant.example.com`, and returns a short-lived JWT
+authorization grant:
+
+<!-- ucp:example skip reason="OAuth metadata, not UCP payload" -->
+```json
+{
+  "access_token": "<jwt-authorization-grant>",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_type": "N_A",
+  "expires_in": 60
+}
+```
+
+The JWT authorization grant decodes to:
+
+<!-- ucp:example skip reason="OAuth metadata, not UCP payload" -->
+```json
+{
+  "iss": "https://accounts.example-login.app",
+  "sub": "user-12345",
+  "aud": "https://merchant.example.com",
+  "iat": 1700000000,
+  "exp": 1700000060,
+  "jti": "unique-grant-id-abc123",
+  "email": "user@example.com",
+  "email_verified": true
+}
+```
+
+`aud` is the business's AS issuer URI (single value per UCP requirements).
+`jti` is unique per grant for replay protection. `exp` is 60 seconds after `iat`.
+
+**Step 3 — JWT bearer assertion at Business.** Platform derives the scope set
+from the business's `config.scopes` and presents the grant:
+
+```http
+POST https://merchant.example.com/oauth2/token
+Authorization: Basic <base64(platform-client-id:platform-client-secret)>
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
+&assertion=<jwt-authorization-grant>
+&scope=dev.ucp.shopping.order:read dev.ucp.shopping.order:manage
+```
+
+Reserved characters in URN values and `:` in scope tokens must be
+percent-encoded in the actual request; they are shown decoded here for readability.
+
+The business validates the grant — `iss` against `config.providers`, `aud`
+against its own issuer URI, `exp`, `jti` for single-use replay protection, and
+signature via the IdP's `jwks_uri` — resolves or provisions the user account
+from `(iss, sub)`, and returns:
+
+<!-- ucp:example skip reason="OAuth metadata, not UCP payload" -->
+```json
+{
+  "access_token": "<merchant-access-token>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "dev.ucp.shopping.order:read dev.ucp.shopping.order:manage"
+}
+```
+
+**Step 4 — Authenticated requests.** Platform includes the business-issued
+token on subsequent requests to user-authenticated capability endpoints:
+
+```http
+Authorization: Bearer <merchant-access-token>
+```
+
+No browser redirect was required after the initial IdP linking — the platform
+obtained access to the business silently on the user's behalf. When the
+business-issued token expires, the platform repeats Steps 2–3 to obtain a
+new grant (see [Token Lifecycle](#token-lifecycle)).


### PR DESCRIPTION
# Description

### Motivation
The [Accelerated IdP Flow](https://github.com/Universal-Commerce-Protocol/ucp/blob/main/docs/specification/common/identity-linking/index.md#accelerated-idp-flow) currently describes Step 2 as:

> `subject_token`: the platform's existing IdP access token

However, the specification does not define:

1. **How the platform acquires this "existing" IdP access token** — the prerequisite Account Linking Flow against the IdP itself is implied but never described, leaving implementors to guess.
2. **What scopes the subject token must carry** — the token exchange (RFC 8693) will fail at the IdP if the subject token lacks required scopes, but no minimum scope requirement is stated.
3. **How the IdP establishes "the user has authorized identity sharing"** — the IdP Requirements section mandates this check (`The IdP MUST NOT issue grants for businesses the user has not authorized`) without describing the consent model that satisfies it.

These gaps create ambiguity for both Platform implementors (how do I get a subject token?) and IdP implementors (which consent model should I implement?).

This is distinct from [#667](https://github.com/Universal-Commerce-Protocol/ucp/issues/667), which addresses trust-chain security gaps _after_ a subject token is already in hand (client authentication for unregistered businesses and `auth_url` trust anchor).

### Proposed Changes

Three additive documentation-only changes to `docs/specification/common/identity-linking/index.md`:

#### 1. New `### Subject Token` subsection in `## Accelerated IdP Flow`

Inserted before `### Flow`. Clarifies that:

- The subject token is obtained by running the standard OAuth 2.0 Authorization Code flow (with PKCE) against the IdP — the same pattern as Account Linking Flow, but targeting the IdP instead of a business.
- This initial IdP connection is a **prerequisite**: without it, platforms MUST fall back to direct OAuth on the business domain.
- The subject token MUST have been issued to the authenticated user (MUST NOT be reused across users).
- The token SHOULD carry at minimum `openid` scope; platforms SHOULD also pre-request scopes for any claims listed in target businesses' `required_claims`.

#### 2. `**Consent models.**` paragraph in `## IdP Requirements`

Inserted after the existing MUST list. Describes the two common consent patterns the IdP MAY implement:

- **Platform-level consent**: authorization captured once when the user connects to the platform at the IdP (e.g., `openid` scope at sign-in); IdP issues grants for any relying party thereafter.
- **Per-business consent**: IdP prompts the user interactively on first access to a new business; subsequent grants are silent.

Adds SHOULD guidance that IdPs document their model and that platforms communicate it to users.

#### 3. New `### End-to-End Walkthrough (Accelerated IdP Flow)` in `## Examples`

Added after the existing Account Linking Flow walkthrough. Provides a complete step-by-step example covering:

- Prerequisite: subject token acquisition via Authorization Code flow at the IdP
- Step 1: platform discovers `config.providers` and selects a matching entry
- Step 2: token exchange request/response at the IdP (with decoded JWT authorization grant)
- Step 3: JWT bearer assertion request/response at the Business
- Step 4: authenticated requests using the business-issued access token

### Normative Impact

None. All proposed text is documentation and SHOULD-level guidance. No existing MUST requirements are changed. The changes clarify existing implied behavior without adding new constraints.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

- [#667](https://github.com/Universal-Commerce-Protocol/ucp/issues/667) — Security gaps in delegated-IdP accelerated flow (distinct: addresses post-subject-token trust-chain vulnerabilities)
- [#355](https://github.com/Universal-Commerce-Protocol/ucp/issues/355) — RFC: Identity Linking, Identity Management, and Loyalty (closed; Phase 2 introduced the Accelerated IdP Flow without specifying consent timing)
- [#330](https://github.com/Universal-Commerce-Protocol/ucp/issues/330) — PR that merged the Accelerated IdP Flow (closed; subject token prerequisites were not addressed)

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [x] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

```bash
$ pre-commit run --all-files
Block corporate registries in uv.lock....................................Passed
Validate JSON examples (changed docs)....................................Passed
Validate JSON examples (full corpus).....................................Passed
Validator unit tests.....................................................Passed
cspell...................................................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
check for added large files..............................................Passed
check that scripts with shebangs are executable..........................Passed
check that executables have shebangs.....................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
markdownlint.............................................................Passed
stylelint................................................................Passed
prettier-css.............................................................Passed
```
