### PR TITLE
docs(location): document required REST headers

### DIFF
--- a/docs/specification/common/location/rest.md
+++ b/docs/specification/common/location/rest.md
@@ -167,6 +167,20 @@ Maps to the [Location Lookup](lookup.md) capability. See the
     }
     ```
 
+## HTTP Headers
+
+The following headers are defined for the HTTP binding and apply to all
+operations unless otherwise noted.
+
+{{ header_fields('search_locations', 'common/rest.openapi.json') }}
+
+### Specific Header Requirements
+
+* **UCP-Agent**: All requests **MUST** include the `UCP-Agent` header
+    containing the platform profile URI using Dictionary Structured Field syntax
+    ([RFC 8941](https://datatracker.ietf.org/doc/html/rfc8941){target="_blank"}).
+    Format: `profile="https://platform.example/profile"`.
+
 ## Error Handling
 
 UCP uses a two-layer error model separating transport-level errors from business outcomes.


### PR DESCRIPTION
## Summary

`docs/specification/common/location/rest.md` is the only one of the five REST bindings without an HTTP Headers section. Cart, catalog, checkout and order each render the header table through the `header_fields` macro and state the UCP-Agent requirement explicitly.

`source/services/common/rest.openapi.json` marks `Request-Id` and `UCP-Agent` as `required: true` for both `search_locations` and `lookup_locations`, but the binding never said so. Those two headers appear only inside the two envelope examples, so someone implementing from this page could reasonably read them as optional and ship a client that omits them.

## Change

Adds an HTTP Headers section ahead of Error Handling, using the same macro call and the same UCP-Agent wording as the catalog binding. The table is generated from the OpenAPI document, so it tracks the contract instead of drifting from it.

One file, 14 lines added.

## Verification

* `mkdocs build` is clean and the section renders 12 request headers and 3 response headers, with `Request-Id` and `UCP-Agent` both marked required.
* `scripts/validate_examples.py --schema-base source/schemas/`: 343 passed, 0 failed.
* `scripts/check_links.py`: all internal links validated.
* markdownlint and cspell are clean on the changed file.

## Notes

No backport looks necessary. None of the three release branches contains the Location binding, since the capability landed on main in #589.

Two adjacent things I left out on purpose:

* `## Message Signing` is present in the checkout and order bindings but missing from cart, catalog and location. That spans three bindings and is not specific to Location, so it seemed better as its own change.
* #716 moves `Authorization`, `Content-Type` and `Accept` out of header parameters and into `securitySchemes` for `shopping/rest.openapi.json`. `services/common/rest.openapi.json` has the same structure and is not covered by that PR. Because the table added here is generated from the OpenAPI document, it will pick up that change automatically whenever it is applied to the common service definition.
