### PR TITLE
docs(checkout-rest): cover ucp-agent in the example signed request

### DIFF
--- a/docs/specification/shopping/checkout/rest.md
+++ b/docs/specification/shopping/checkout/rest.md
@@ -1437,7 +1437,7 @@ Content-Type: application/json
 UCP-Agent: profile="https://platform.example/.well-known/ucp"
 Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000
 Content-Digest: sha-256=:X48E9q...:
-Signature-Input: sig1=("@method" "@authority" "@path" "idempotency-key" "content-digest" "content-type");keyid="platform-2025"
+Signature-Input: sig1=("@method" "@authority" "@path" "ucp-agent" "idempotency-key" "content-digest" "content-type");keyid="platform-2025"
 Signature: sig1=:6G4i8TS6oUkGrx8KnCFUpsSPwd74...:
 
 {"line_items":[{"item":{"id":"item_123"},"quantity":2}]}


### PR DESCRIPTION
Fixes #794

## What this changes

Adds `"ucp-agent"` to the covered components of the Example Signed Request in the checkout REST binding, `docs/specification/shopping/checkout/rest.md` line 1440.

Before:

```
("@method" "@authority" "@path" "idempotency-key" "content-digest" "content-type")
```

After:

```
("@method" "@authority" "@path" "ucp-agent" "idempotency-key" "content-digest" "content-type")
```

The example already prints a `UCP-Agent` header. The Identity Resolution Algorithm at `overview/index.md` line 2435 requires a signature to cover `ucp-agent` when that header is present and requires a verifier to skip a signature that does not, so the example as shipped models a request a conformant verifier will not authenticate.

The resulting covered set is identical to the canonical REST request example at `signatures.md` line 515, which is the document this section links to for the complete signing algorithm. The two examples still differ elsewhere, for instance in their `keyid`.

## Scope

One line. No normative text changes, no schema changes, no new prose.

The linked issue carries the sweep: of 13 fenced blocks under `docs/specification` containing a `Signature-Input`, 2 are excluded because their component list is elided with `...` and 3 because they are not requests, leaving 8 judged. Six of those cover every gate header they carry and 2 do not. The other violation is `shopping/order/index.md` line 751, already addressed by open PR #659, so that pair closes the class.

## Test plan

* `scripts/validate_examples.py --schema-base source/schemas/`: 343 passed, 0 failed, 50 skipped.
* `scripts/test_validate_examples.py`: 52 passed.
* `cspell` on the changed file: 0 issues.

All three measured on a test merge into main `1d39948` on 2026-09-01, and all three are unchanged by this commit. That is expected rather than reassuring: the example is an unannotated ` ```http ` fence, so `validate_examples.py` never inspects it and no CI job here checks a covered set. The mechanical check that does catch it compares, per fenced block, the headers the block carries against the components its own `Signature-Input` names, and it flags this block before the change and not after. Reverting the one line makes it flag again.
