### PR TITLE
docs: clarify local site build and serve steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ including spec versions:
 ./scripts/build_local.sh
 ```
 
-This will build the site and start a local server. You can use the
-`--draft-only` flag to skip release branches and only build the current draft:
+This will build the site; you can then start a local server with the command
+below. You can use the `--draft-only` flag to skip release branches and only
+build the current draft:
 
 ```bash
 ./scripts/build_local.sh --draft-only


### PR DESCRIPTION
## Description

The documentation says `./scripts/build_local.sh` "will build the site and
start a local server," but the script only builds `local_preview/` and prints
the command that the user must run next:

```bash
echo "To serve the fully built site (with versioning):"
echo "  python3 -m http.server 8000 -d $OUTPUT_DIR"
```

There is no executable `python3 -m http.server` or `mkdocs serve` invocation in
the script. The README already provides the manual server command immediately
below, so the current sentence incorrectly promises a running server when the
build finishes.

**Fix:** describe build and serve as two steps: the script builds the site, and
the command below starts the local server.

## Category (Required)

- [ ] **Core Protocol**: Protocol specification changes. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Governance or contribution process changes. (Requires Governance Council approval)
- [ ] **Capability**: Capability specification changes. (Requires Maintainer approval)
- [x] **Documentation**: Documentation updates. (Requires Maintainer approval)
- [ ] **Infrastructure**: Build, CI, tooling, or release changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency, compatibility, or routine maintenance changes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Repository-wide health files and configuration. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under `python_sdk`.

## Screenshots / Logs (if applicable)

Static script check confirms no executable server command; full example validators
and validator unit tests pass with `ucp-schema` on PATH. All remaining
pre-commit hooks (cspell, whitespace, YAML, shebang, Ruff, markdownlint,
stylelint, Prettier) and `git diff --check` pass.
