### PR TITLE
docs(cart): define the continue_url destination and format

### DIFF
--- a/docs/specification/shopping/cart/index.md
+++ b/docs/specification/shopping/cart/index.md
@@ -89,6 +89,37 @@ SHOULD be linked for the duration of the checkout.
     on a cleared cart ID return `not_found`; the platform can start a new
     session with `create_cart`.
 
+## Continue URL
+
+The `continue_url` field hands a cart from the platform to the business UI, so
+a buyer can share, recover, or keep building the cart in a browser, or move on
+to purchase.
+
+### Destination
+
+The destination is the business's choice: its cart page, its checkout entry,
+an embedded flow, or any surface that fits its purchase path. Whatever the
+destination, it **MUST** present the cart's current `line_items`, with their
+quantities and selected variants, without requiring the buyer to add them
+again. Items that can no longer be offered at resolution time follow the
+[permalink redirect resolution rules](../../permalink.md#redirect-resolution).
+
+A cart session is served by the business's UCP endpoint, and that endpoint does
+not always share state with the storefront. A `continue_url` that points at the
+storefront's own cart page then lands the buyer on an empty basket.
+
+### Format
+
+The `continue_url` **MUST** be an absolute HTTPS URL and **MUST** carry or
+reference the cart contents. Businesses **MAY** use either approach described
+in the [checkout Continue URL format](../checkout/index.md#format):
+
+* an opaque URL backed by server-side cart state, for example
+    `https://business.example.com/carts/{cart_id}`;
+* a stateless URL that encodes the cart's items, such as a
+    [permalink](../../permalink.md), which the business resolves into a cart
+    or a checkout.
+
 ## Quantity and sale basis
 
 Cart line items apply the shared
@@ -147,8 +178,8 @@ custom scopes are defined in [Identity Linking — Scopes](../../common/identity
 
 ### Business
 
-* **SHOULD** provide `continue_url` for cart handoff and session recovery.
-* TODO: discuss `continue_url` destination - cart vs checkout.
+* **SHOULD** provide `continue_url` for cart handoff and session recovery. See
+    [Continue URL](#continue-url) for destination and format.
 * **SHOULD** provide estimated totals when calculable.
 * **MAY** omit fulfillment totals until checkout when address is unknown.
 * **SHOULD** return informational messages for validation warnings.

--- a/docs/specification/shopping/cart/index.md
+++ b/docs/specification/shopping/cart/index.md
@@ -120,6 +120,20 @@ in the [checkout Continue URL format](../checkout/index.md#format):
     [permalink](../../permalink.md), which the business resolves into a cart
     or a checkout.
 
+### When to surface the continue URL
+
+The platform **SHOULD** surface `continue_url` in the following situations:
+
+* the buyer asks to share, save, or continue the cart in a browser;
+* the buyer asks to complete the purchase and the platform cannot convert the
+    cart to a checkout, because the business does not expose the checkout
+    capability or the platform does not support it;
+* a cart response carries a message the platform cannot resolve, for example
+    a message of type `unrecoverable` or `requires_buyer_input` (see
+    [Message](#message)).
+
+The platform **MAY** surface it at other times.
+
 ## Quantity and sale basis
 
 Cart line items apply the shared
@@ -173,7 +187,8 @@ custom scopes are defined in [Identity Linking — Scopes](../../common/identity
 
 * **MAY** use carts for pre-purchase exploration and session persistence.
 * **SHOULD** convert cart to checkout when user expresses purchase intent.
-* **MAY** display `continue_url` for handoff to business UI.
+* **MAY** display `continue_url` for handoff to business UI. See
+    [When to surface the continue URL](#when-to-surface-the-continue-url).
 * **SHOULD** handle `not_found` gracefully when cart expires or is canceled.
 
 ### Business


### PR DESCRIPTION
## Motivation

The cart page says businesses SHOULD provide `continue_url`, and the schema describes it as "URL for cart handoff and session recovery", but nothing says where the URL should lead or what it has to preserve. The requirements list still carries `TODO: discuss continue_url destination - cart vs checkout` from #73, where two readings met: for some implementers the URL is the checkout URL, for others the business decides the intended use (convert to checkout, or keep building the cart).

The checkout page answers the same questions for checkout in its Continue URL section (availability, format, server-side state or permalink); the cart page has no equivalent. And the permalink specification already lets a business merge items into an existing cart, create a new cart, or stage a checkout, so the destination question has an answer elsewhere in the spec: the business chooses.

This came up while implementing the cart capability: a cart session is served by the business's UCP endpoint, which does not always share state with the storefront, and a `continue_url` pointing at the storefront's own cart page lands the buyer on an empty basket.

## What this PR changes

- **`shopping/cart/index.md`** - adds a `## Continue URL` section after Cart-to-Checkout Conversion. **Destination**: the business chooses (cart page, checkout entry, embedded flow); whatever it picks MUST present the cart's current `line_items`, quantities and selected variants included, without the buyer re-adding them; items no longer available follow the permalink redirect resolution rules. **Format**: absolute HTTPS URL that MUST carry or reference the cart contents, using either approach the checkout page already describes **by reference** (server-side cart state or a stateless permalink), rather than restating them.
- Removes the TODO bullet and appends a link to the new section to the existing SHOULD bullet; the requirement level is unchanged.

Normative addition, scoped to the field: two MUSTs on `continue_url` (absolute HTTPS, contents preserved). Both mirror what the checkout page already requires for its own `continue_url`. No schema change.

Overlaps with nothing open: #740 (cart terminal status) edits the same requirements list but leaves this bullet as is, and #486 (return after handoff) is checkout-side.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

