### PR TITLE
chore: block non-public registries in lockfiles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,11 @@ repos:
   - repo: local
     hooks:
       - id: block-corporate-registries
-        name: Block corporate registries in uv.lock
-        entry: '(?i)(pkgs\.shopify\.io|\.pkg\.dev)'
+        name: Block non-public registries in uv.lock
+        entry: '(?i)(registry\s*=\s*"https?://(?!pypi\.org)|pkgs\.shopify\.io|\.pkg\.dev|codeartifact|amazonaws\.com|visualstudio\.com|dev\.azure\.com)'
         language: pygrep
         files: ^uv\.lock$
-        description: "Avoid corporate URLs (PR #108, #368). Fix: 'uv lock --refresh'."
+        description: "Avoid corporate/private URLs in uv.lock. Packages must resolve from pypi.org. Fix: 'uv lock --refresh'."
       - id: block-corporate-registries-npm
         name: Block non-public registries in package-lock.json
         entry: '(?i)"resolved":\s*"https?://(?!registry\.npmjs\.org)'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,16 @@ repos:
     hooks:
       - id: block-corporate-registries
         name: Block corporate registries in uv.lock
-        entry: '(?i)(pkgs\.shopify\.io|us-npm\.pkg\.dev)'
+        entry: '(?i)(pkgs\.shopify\.io|\.pkg\.dev)'
         language: pygrep
         files: ^uv\.lock$
         description: "Avoid corporate URLs (PR #108, #368). Fix: 'uv lock --refresh'."
+      - id: block-corporate-registries-npm
+        name: Block non-public registries in package-lock.json
+        entry: '(?i)"resolved":\s*"https?://(?!registry\.npmjs\.org)'
+        language: pygrep
+        files: ^package-lock\.json$
+        description: "Avoid corporate/private registry URLs in package-lock.json. Fix: run 'npm install' pointing to registry.npmjs.org."
       # Docs-example validator. Requires the ucp-schema binary on PATH;
       # install with `cargo install ucp-schema`. CI runs the full-corpus
       # check on every PR as the mandatory backstop


### PR DESCRIPTION
# Description

Expands the local pre-commit hook suite to block non-public and corporate registry URLs across both lockfiles:

- **`package-lock.json`:** Added `block-corporate-registries-npm` enforcing that all packages resolve from `registry.npmjs.org`.
- **`uv.lock`:** Upgraded `block-corporate-registries` to enforce that package registries resolve from `pypi.org`, while explicitly blocking enterprise package feeds (AWS CodeArtifact, Azure Artifacts, Google Artifact Registry, and Shopify).

This prevents accidental commits of environment-specific or private registry URLs in pull requests (such as #803).

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [x] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

Follow-up to #108, #368, and #411. Helps safeguard PRs like #803.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

Tested locally with pre-commit across clean lockfiles and sample entries for AWS CodeArtifact, Azure Artifacts, Artifact Registry, and Shopify (fails with exit code 1 naming the offending line).
