### PR TITLE
feat: add per-seller offer attribution to catalog variants

### DIFF
--- a/docs/documentation/core-concepts.md
+++ b/docs/documentation/core-concepts.md
@@ -93,6 +93,13 @@ typically acts as the **Merchant of Record (MoR)**, retaining financial
 liability and ownership of the transaction — though UCP's capability model
 is not limited to transactional use cases.
 
+By default a Business serving a catalog is the Merchant of Record for everything
+it returns, and its responses carry no per-offer seller attribution. A catalog
+**MAY** instead aggregate offers from other Businesses: only when a variant
+includes an `offers[]` array does each offer name its own Merchant of Record via
+`offers[].seller`, and the Platform then routes checkout to that Business. A
+response without `offers[]` describes a single seller: the serving Business.
+
 * **Responsibilities:** Publishing a UCP profile, declaring supported
     services, capabilities and extensions, processing capability invocations
     which may be stateful or stateless.

--- a/docs/specification/glossary.md
+++ b/docs/specification/glossary.md
@@ -43,7 +43,7 @@ acronym in each specification Markdown file spells out the full term (e.g.,
 
 | Term                         | Acronym | Definition                                                                                                                                                |
 | :--------------------------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Business**                 | -       | The entity selling goods or services. In UCP, they act as the **Merchant of Record (MoR)**, retaining financial liability and ownership of the order.     |
+| **Business**                 | -       | The entity exposing UCP capabilities; in transactional contexts typically the **Merchant of Record (MoR)**, retaining financial liability and ownership of the order.                                                     |
 | **Buyer**                    | -       | The transacting customer or end consumer completing a commerce action over UCP. Synonymous to vocabularies like `user` and `consumer`.                    |
 | **Location**                 | -       | A physical place (e.g., store, restaurant, property, pickup point) identified by a stable, opaque string in a Business's namespace.                       |
 | **Increment**                | -       | Optional [ordering granularity](overview/index.md#ordering-increment) of a sale basis, a count of steps; advisory for Platform-authored quantities.       |

--- a/docs/specification/shopping/catalog/index.md
+++ b/docs/specification/shopping/catalog/index.md
@@ -39,6 +39,11 @@ This enables product discovery before checkout, supporting use cases like:
   variants.
 * **Variant**: A purchasable item with specific option selections (e.g., "Blue /
   Large"), price, and availability.
+* **Offer** (optional): An offer for a variant from a specific seller. When a variant
+  carries `offers[]`, each offer names the Business acting as Merchant of Record
+  (`offers[].seller.domain`) and the item ID (`offers[].item_id`) that Business's
+  checkout recognizes. A variant with no `offers[]` is sold directly by the Business
+  serving the catalog.
 * **Price**: Price values include both amount (in minor currency units) and
   currency code, enabling multi-currency catalogs.
 * **Sale basis**: How quantity is denominated—as whole items (`each`, the
@@ -47,9 +52,13 @@ This enables product discovery before checkout, supporting use cases like:
 
 ### Relationship to Checkout
 
-Catalog operations return product and variant IDs that can be used directly in
-checkout `line_items[].item.id`. The variant ID from catalog retrieval should match
-the item ID expected by checkout.
+Catalog operations return product and variant IDs. When a variant is sold directly
+by the Business serving the catalog (no `offers[]`), its variant ID is the checkout
+token and is used directly in checkout `line_items[].item.id`. When a variant carries
+`offers[]`, each offer is attributed to a seller (`offers[].seller.domain`, the
+Merchant of Record) and the item ID at checkout is that offer's `offers[].item_id`. In
+that case the Platform **MUST** use the selected `offers[].item_id` as
+`line_items[].item.id` and **MUST NOT** use the variant ID.
 
 Catalog responses (pricing, availability, etc.) reflect the Business's current
 terms for the given request but are not transactional commitments — checkout
@@ -170,6 +179,50 @@ A `get_product` response for bananas sold by the pound. The variant advertises
 }
 ```
 
+The same variant may be offered by more than one seller. Each offer names its own
+Merchant of Record (`offers[].seller.domain`) and the item ID (`offers[].item_id`) the
+Platform uses for that seller; `variants[].price` is a display summary while each
+`offers[].price` is authoritative:
+
+<!-- ucp:example schema=shopping/catalog_lookup op=get_product -->
+```json
+{
+  "ucp": { "version": "{{ ucp_version }}" },
+  "product": {
+    "id": "prod_trail_runner",
+    "title": "Trail Runner",
+    "description": { "plain": "Lightweight trail running shoe." },
+    "price_range": {
+      "min": { "amount": 8900, "currency": "USD" },
+      "max": { "amount": 9500, "currency": "USD" }
+    },
+    "variants": [
+      {
+        "id": "var_trail_blue_10",
+        "title": "Blue / 10",
+        "description": { "plain": "Trail Runner, Blue, US 10." },
+        "price": { "amount": 8900, "currency": "USD" },
+        "availability": { "available": true },
+        "offers": [
+          {
+            "seller": { "domain": "shop-a.example", "name": "Shop A" },
+            "item_id": "SHOEA-TR-BLUE-10",
+            "price": { "amount": 8900, "currency": "USD" },
+            "availability": { "available": true }
+          },
+          {
+            "seller": { "domain": "shop-b.example", "name": "Shop B" },
+            "item_id": "blue-10",
+            "price": { "amount": 9500, "currency": "USD" },
+            "availability": { "available": true }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
 ## Shared Entities
 
 ### Context
@@ -238,6 +291,17 @@ was `exact` or `featured` (server-selected). See
 as the first element. Platforms SHOULD treat the first element as featured.
 
 {{ schema_fields('types/variant', 'shopping/catalog') }}
+
+### Offer
+
+An offer for a variant from a specific seller, present only when a catalog aggregates
+offers from more than one Merchant of Record. Each offer names its own seller
+(`offers[].seller.domain`, the Merchant of Record) and carries that seller's item ID
+(`item_id`) and authoritative `price`. See
+[Relationship to Checkout](#relationship-to-checkout) for how the checkout item ID is
+resolved.
+
+{{ schema_fields('types/offer', 'shopping/catalog') }}
 
 ### Price
 

--- a/source/schemas/shopping/types/offer.json
+++ b/source/schemas/shopping/types/offer.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ucp.dev/schemas/shopping/types/offer.json",
+  "title": "Offer",
+  "description": "A purchasable offer for a variant, attributed to a specific seller. Present when a catalog aggregates offers from more than one Merchant of Record: the offer's `seller.domain` identifies the seller acting as Merchant of Record, and `item_id` is the item ID recognized by that seller's own checkout. When a variant carries no `offers`, the Business serving the catalog is the single seller and Merchant of Record, `variant.price` is authoritative, and `variant.id` is the item ID used at checkout.",
+  "type": "object",
+  "required": [
+    "seller",
+    "item_id",
+    "price"
+  ],
+  "properties": {
+    "seller": {
+      "type": "object",
+      "description": "The seller making this offer and acting as its Merchant of Record.",
+      "required": [
+        "domain"
+      ],
+      "properties": {
+        "domain": {
+          "type": "string",
+          "description": "The seller's canonical host: a bare hostname without scheme, path, port, or trailing slash (for example, `shop.example.com`). Identifies the Merchant of Record for this offer and the host whose checkout resolves `item_id`. A Platform resolves this host to the seller's UCP profile at `/.well-known/ucp` and verifies its signing keys via authority binding."
+        },
+        "name": {
+          "type": "string",
+          "description": "Seller display name."
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "$ref": "../../common/types/link.json"
+          },
+          "description": "Seller policy and information links."
+        }
+      }
+    },
+    "item_id": {
+      "type": "string",
+      "description": "Item ID for this offer, recognized by the seller's own checkout. Used as `item.id` in checkout when `offers` is present, in place of `variant.id`."
+    },
+    "price": {
+      "$ref": "../../common/types/price.json",
+      "description": "Authoritative current selling price for this offer, on the variant's sale basis (`variant.quantity_unit`). When `offers` is present, this — not `variant.price` — is the price the seller will honor at checkout."
+    },
+    "list_price": {
+      "$ref": "../../common/types/price.json",
+      "description": "List price before discounts for this offer (for strikethrough display)."
+    },
+    "unit_price": {
+      "$ref": "unit_price.json",
+      "description": "Price per standard unit of measurement for this offer, for shelf-style comparison display. MAY be omitted when unit pricing does not apply."
+    },
+    "availability": {
+      "$ref": "availability.json",
+      "description": "Availability of this offer for purchase."
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Canonical page URL for this offer on the seller's site."
+    },
+    "sku": {
+      "type": "string",
+      "description": "Seller-assigned identifier for inventory and fulfillment."
+    }
+  }
+}

--- a/source/schemas/shopping/types/variant.json
+++ b/source/schemas/shopping/types/variant.json
@@ -13,7 +13,7 @@
   "properties": {
     "id": {
       "type": "string",
-      "description": "Global ID (GID) uniquely identifying this variant. Used as item.id in checkout."
+      "description": "Global ID (GID) uniquely identifying this variant. When `offers` is absent, this is also the item ID used as `item.id` in checkout. When `offers` is present, the item ID at checkout is the selected `offers[].item_id` instead, and this ID serves only to identify the variant."
     },
     "sku": {
       "type": "string",
@@ -112,7 +112,7 @@
     },
     "seller": {
       "type": "object",
-      "description": "Optional seller context for this variant.",
+      "description": "Optional display-only seller context for the variant as a whole. This does not assign a Merchant of Record. When a variant is sold by more than one seller, per-offer attribution and the Merchant of Record are carried by `offers[].seller`.",
       "properties": {
         "name": {
           "type": "string",
@@ -126,6 +126,14 @@
           "description": "Seller policy and information links."
         }
       }
+    },
+    "offers": {
+      "type": "array",
+      "items": {
+        "$ref": "offer.json"
+      },
+      "minItems": 1,
+      "description": "Offers for this variant from more than one seller. Optional and additive. When present, each entry attributes the offer to a specific seller — `offers[].seller.domain` is the Merchant of Record — and carries that seller's own item ID (`item_id`) and authoritative `price`. A Platform MUST resolve checkout from the selected offer's `item_id` and MUST NOT use `variant.id`, and MUST treat `offers[].price` as authoritative over the display-only `variant.price`. When absent, the Business serving the catalog is the single seller and Merchant of Record, `variant.price` is authoritative, and `variant.id` is the item ID used at checkout."
     }
   }
 }


### PR DESCRIPTION
Adds an optional `offers[]` array to the catalog `variant`, so one catalog can list a product sold by several different merchants and send each to the right seller's checkout.

# Description

Today the business serving a catalog is assumed to be the only seller and Merchant of Record (MoR): `variant.id` is the checkout item ID and `variant.price` is the price checkout honors. That doesn't fit a marketplace or shopping agent that lists the same product from many merchants, each with its own checkout. `offers[]` fixes that. A variant without `offers[]` is unchanged.

Each offer names the seller (`seller.domain`, the MoR), that seller's own checkout item ID (`item_id`), and the price. This affects the catalog capabilities `dev.ucp.shopping.catalog.search` and `dev.ucp.shopping.catalog.lookup`, which share the `variant` type.

**New type** `source/schemas/shopping/types/offer.json` — required: `seller` (with `seller.domain`), `item_id`, `price`. Optional: `list_price`, `unit_price`, `availability`, `url`, `sku`, `seller.name`, `seller.links`.

```json
{
  "id": "gid://shop/variant/123",
  "title": "Wireless Headphones",
  "price": { "amount": "19.99", "currency": "USD" },
  "offers": [
    { "seller": { "domain": "shop-a.example" }, "item_id": "A-item-1", "price": { "amount": "19.99", "currency": "USD" } },
    { "seller": { "domain": "shop-b.example" }, "item_id": "B-item-9", "price": { "amount": "21.50", "currency": "USD" } }
  ]
}
```

**When `offers` is present** (Business response → Platform), the Platform:
- checks out with the chosen `offers[].item_id` — **MUST NOT** use `variant.id`
- treats `offers[].price` as the real price — `variant.price` is display-only
- resolves `offers[].seller.domain` and checks out at that seller, after verifying it via authority binding

Also aligns the Business / MoR wording in `glossary.md` and `core-concepts.md` so a business need not be the MoR for everything it lists.

## Category (Required)

- [x] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [x] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

- #810 – Enhancement Proposal for this change.
- #682 – Bulk Product Discovery DWG — this fills the seller-attribution slice its charter defers)
- #530 – namespace authority bindingthis reuses for `seller.domain`
- #384 – this is an alternative to participant-actor approach

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

Not applicable.