### PR TITLE
docs: correct payment terms capability id

### DIFF
--- a/docs/documentation/core-concepts.md
+++ b/docs/documentation/core-concepts.md
@@ -194,7 +194,7 @@ up-to-date list.
 | `dev.ucp.common.payment.authentication` | checkout | Browser-surface device data collection and 3DS challenges |
 | `dev.ucp.common.payment.ap2_mandate` | checkout | Non-repudiable authorization for autonomous commerce |
 | `dev.ucp.common.payment.split_payments` | checkout | Multi-instrument allocation and split settlements |
-| `dev.ucp.common.payment.payment_terms` | checkout | Deposits, installments, and deferred payment schedules |
+| `dev.ucp.common.payment.terms` | checkout | Deposits, installments, and deferred payment schedules |
 
 ### Services
 


### PR DESCRIPTION
## Description

The extensions table in `docs/documentation/core-concepts.md` names the
payment-terms capability as:

```markdown
`dev.ucp.common.payment.payment_terms`
```

The schema is authoritative for this identifier and declares
`dev.ucp.common.payment.terms` instead. The payment-terms specification page
uses the same canonical name, so the table entry currently points readers to a
capability that does not exist.

**Fix:** replace the table entry with `dev.ucp.common.payment.terms`.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A — documentation-only capability identifier correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
