### PR TITLE
docs: centralize shared REST header requirements via macro

### DIFF
--- a/docs/specification/shopping/cart/rest.md
+++ b/docs/specification/shopping/cart/rest.md
@@ -475,17 +475,7 @@ operations unless otherwise noted.
 
 ### Specific Header Requirements
 
-* **UCP-Agent**: All requests **MUST** include the `UCP-Agent` header
-    containing the platform profile URI using Dictionary Structured Field syntax
-    ([RFC 8941](https://datatracker.ietf.org/doc/html/rfc8941){target="_blank"}).
-    Format: `profile="https://platform.example/profile"`.
-* **Idempotency-Key**: Operations that modify state **SHOULD** support
-    idempotency. When provided, the server **MUST**:
-    1. Store the key with the operation result for at least 24 hours.
-    2. Return the cached result for duplicate keys whose request body matches the original.
-    3. Return `409 Conflict` if the key is reused with a mismatched body.
-    See [Message Signatures — Idempotency Key Requirements](../../signatures.md#replay-protection)
-    for the full payload-matching contract.
+{{ header_requirements('ucp_agent', 'idempotency_key') }}
 
 ## Protocol Mechanics
 

--- a/docs/specification/shopping/catalog/rest.md
+++ b/docs/specification/shopping/catalog/rest.md
@@ -518,10 +518,7 @@ operations unless otherwise noted.
 
 ### Specific Header Requirements
 
-* **UCP-Agent**: All requests **MUST** include the `UCP-Agent` header
-    containing the platform profile URI using Dictionary Structured Field syntax
-    ([RFC 8941](https://datatracker.ietf.org/doc/html/rfc8941){target="_blank"}).
-    Format: `profile="https://platform.example/profile"`.
+{{ header_requirements('ucp_agent') }}
 
 ## Error Handling
 

--- a/docs/specification/shopping/checkout/rest.md
+++ b/docs/specification/shopping/checkout/rest.md
@@ -1301,17 +1301,7 @@ operations unless otherwise noted.
 
 ### Specific Header Requirements
 
-* **UCP-Agent**: All requests **MUST** include the `UCP-Agent` header
-    containing the platform profile URI using Dictionary Structured Field syntax
-    ([RFC 8941](https://datatracker.ietf.org/doc/html/rfc8941){target="_blank"}).
-    Format: `profile="https://platform.example/profile"`.
-* **Idempotency-Key**: Operations that modify state **SHOULD** support
-    idempotency. When provided, the server **MUST**:
-    1. Store the key with the operation result for at least 24 hours.
-    2. Return the cached result for duplicate keys whose request body matches the original.
-    3. Return `409 Conflict` if the key is reused with a mismatched body.
-    See [Message Signatures — Idempotency Key Requirements](../../signatures.md#replay-protection)
-    for the full payload-matching contract.
+{{ header_requirements('ucp_agent', 'idempotency_key') }}
 
 ## Protocol Mechanics
 

--- a/docs/specification/shopping/order/rest.md
+++ b/docs/specification/shopping/order/rest.md
@@ -231,15 +231,7 @@ Returns the current-state snapshot of an order.
 
 ### Specific Header Requirements
 
-**UCP-Agent** (required on all requests):
-
-Platform identification using
-[RFC 8941 Dictionary](https://www.rfc-editor.org/rfc/rfc8941#name-dictionaries){ target="_blank" }
-syntax:
-
-```http
-UCP-Agent: profile="https://platform.example/.well-known/ucp"
-```
+{{ header_requirements('ucp_agent') }}
 
 ## Message Signing
 

--- a/main.py
+++ b/main.py
@@ -1590,6 +1590,35 @@ def define_env(env):
         f"Error processing OpenAPI: {e}{get_error_context()}"
       ) from e
 
+  # --- Shared "Specific Header Requirements" prose ---
+  HEADER_REQUIREMENTS = {
+    "ucp_agent": (
+      "* **UCP-Agent**: All requests **MUST** include the `UCP-Agent` header\n"
+      "    containing the platform profile URI using Dictionary Structured Field syntax\n"
+      '    ([RFC 8941](https://datatracker.ietf.org/doc/html/rfc8941){target="_blank"}).\n'
+      '    Format: `profile="https://platform.example/profile"`.'
+    ),
+    "idempotency_key": (
+      "* **Idempotency-Key**: Operations that modify state **SHOULD** support\n"
+      "    idempotency. When provided, the server **MUST**:\n"
+      "    1. Store the key with the operation result for at least 24 hours.\n"
+      "    2. Return the cached result for duplicate keys whose request body matches the original.\n"
+      "    3. Return `409 Conflict` if the key is reused with a mismatched body.\n"
+      "    See [Message Signatures — Idempotency Key Requirements](/specification/signatures/#replay-protection)\n"
+      "    for the full payload-matching contract."
+    ),
+  }
+
+  @env.macro
+  def header_requirements(*keys):
+    """Render shared 'Specific Header Requirements' bullets by key."""
+    try:
+      return "\n".join(HEADER_REQUIREMENTS[k] for k in keys)
+    except KeyError as exc:
+      raise ValueError(
+        f"Unknown header requirement {exc}{get_error_context()}."
+      )
+
   # --- MACRO 4: For HTTP Headers ---
   @env.macro
   def header_fields(operation_id, file_name):


### PR DESCRIPTION
# Description

The `UCP-Agent` (and `Idempotency-Key`) "Specific Header Requirements" was copy-pasted across REST bindings, and the order binding had already drifted to different wording. This PR adds a `header_requirements` macro as the single source for these bullets, and switches all five bindings to call it.

Docs-only change.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

Not applicable

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

Not applicable